### PR TITLE
Fix split order in transactions table

### DIFF
--- a/src/__tests__/app/user/logout/page.test.tsx
+++ b/src/__tests__/app/user/logout/page.test.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import type { LinkProps } from 'next/link';
 
 import LogoutPage from '@/app/user/logout/page';
+
+jest.mock('next/link', () => jest.fn(
+  (
+    props: LinkProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLAnchorElement>,
+  ) => (
+    <a className={props.className} href={props.href.toString()}>{props.children}</a>
+  ),
+));
 
 describe('LogoutPage', () => {
   it('matches snapshot', () => {

--- a/src/__tests__/components/__snapshots__/TransactionsTable.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionsTable.test.tsx.snap
@@ -1,263 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TransactionsTable displays splits as expected 1`] = `
+exports[`TransactionsTable renders Amount column as expected 1`] = `
+<div>
+  <span
+    class="text-green-300 flex items-center"
+  >
+    <svg
+      class="text-xs mr-1"
+      fill="currentColor"
+      height="1em"
+      stroke="currentColor"
+      stroke-width="0"
+      viewBox="0 0 448 512"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"
+      />
+    </svg>
+    100.00 €
+  </span>
+</div>
+`;
+
+exports[`TransactionsTable renders Date column as expected 1`] = `
 <div>
   <div
-    class="relative overflow-x-auto"
+    class="group flex relative"
   >
-    <table
-      class="w-full text-sm text-left"
-    >
-      <thead
-        class="bg-gunmetal-700 text-slate-300"
-      >
-        <tr>
-          <th
-            class="px-6 py-3"
-            scope="col"
-          >
-            <div
-              class="flex"
-            >
-              Date
-              <div
-                class="flex items-center cursor-pointer"
-              >
-                <svg
-                  class="opacity-50 absolute"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M279 224H41c-21.4 0-32.1-25.9-17-41L143 64c9.4-9.4 24.6-9.4 33.9 0l119 119c15.2 15.1 4.5 41-16.9 41z"
-                  />
-                </svg>
-                <svg
-                  class="opacity-100 absolute"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41z"
-                  />
-                </svg>
-              </div>
-            </div>
-          </th>
-          <th
-            class="px-6 py-3"
-            scope="col"
-          >
-            <div
-              class="flex"
-            >
-              Description
-            </div>
-          </th>
-          <th
-            class="px-6 py-3"
-            scope="col"
-          >
-            <div
-              class="flex"
-            >
-              From/To
-            </div>
-          </th>
-          <th
-            class="px-6 py-3"
-            scope="col"
-          >
-            <div
-              class="flex"
-            >
-              Amount
-            </div>
-          </th>
-          <th
-            class="px-6 py-3"
-            scope="col"
-          >
-            <div
-              class="flex"
-            >
-              Total
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          class="border-b border-gunmetal-700"
-        >
-          <td
-            class="px-6 py-4"
-          >
-            <div
-              class="group flex relative"
-            >
-              <span>
-                2023-01-01
-              </span>
-              <span
-                class="opacity-0 absolute rounded-md bg-black text-center z-50 -translate-x-1/2 left-1/2 mt-2 top-full text-xs p-2 transition-opacity group-hover:opacity-40"
-              >
-                tx_guid
-              </span>
-            </div>
-          </td>
-          <td
-            class="px-6 py-4"
-          >
-            random expense
-          </td>
-          <td
-            class="px-6 py-4"
-          >
-            <ul>
-              <li>
-                <a
-                  class="badge bg-red-500/20 text-red-300"
-                  href="/dashboard/accounts/account_guid_2"
-                >
-                  Expenses:expense
-                </a>
-              </li>
-            </ul>
-          </td>
-          <td
-            class="px-6 py-4"
-          >
-            <span
-              class="text-green-300 flex items-center"
-            >
-              <svg
-                class="text-xs mr-1"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 448 512"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"
-                />
-              </svg>
-              0.15 €
-            </span>
-          </td>
-          <td
-            class="px-6 py-4"
-          >
-            <span>
-              0.15 €
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <div
-    class="flex text-center text-sm items-center px-2 pb-1"
-  >
-    <label
-      class="mr-1"
-    >
-      Display:
-    </label>
-    <select>
-      <option
-        value="5"
-      >
-        5
-      </option>
-      <option
-        value="10"
-      >
-        10
-      </option>
-      <option
-        value="50"
-      >
-        50
-      </option>
-    </select>
-    <span
-      class="mx-5"
-    >
-      Page
-       
-      <strong>
-        1
-         
-        of
-         
-        1
-      </strong>
-       
+    <span>
+      2023-01-01
     </span>
     <span
-      class="flex justify-start items-center"
+      class="opacity-0 absolute rounded-md bg-black text-center z-50 -translate-x-1/2 left-1/2 mt-2 top-full text-xs p-2 transition-opacity group-hover:opacity-40"
     >
-      <label
-        class="mr-1"
-      >
-        Go to page:
-      </label>
-      <input
-        class="w-1/4"
-        type="number"
-        value="1"
-      />
+      tx_guid
     </span>
-    <div
-      class="ms-auto"
-    >
-      <button
-        class="bg-gunmetal-700 rounded-full disabled:opacity-50 px-3 py-1"
-        disabled=""
-        type="button"
-      >
-        &lt;&lt;
-      </button>
-       
-      <button
-        class="bg-gunmetal-700 rounded-full disabled:opacity-50 px-3 py-1"
-        disabled=""
-        type="button"
-      >
-        &lt;
-      </button>
-       
-      <button
-        class="bg-gunmetal-700 rounded-full disabled:opacity-50 px-3 py-1"
-        disabled=""
-        type="button"
-      >
-        &gt;
-      </button>
-       
-      <button
-        class="bg-gunmetal-700 rounded-full disabled:opacity-50 px-3 py-1"
-        disabled=""
-        type="button"
-      >
-        &gt;&gt;
-      </button>
-       
-    </div>
   </div>
+</div>
+`;
+
+exports[`TransactionsTable renders FromTo column as expected 1`] = `
+<div>
+  <ul>
+    <li>
+      <a
+        class="badge bg-red-500/20 text-red-300"
+        href="/dashboard/accounts/account_guid_2"
+      >
+        Expenses:expense
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TransactionsTable renders Total column as expected 1`] = `
+<div>
+  <span>
+    250.00 €
+  </span>
 </div>
 `;

--- a/src/__tests__/layout/LeftSideBar.test.tsx
+++ b/src/__tests__/layout/LeftSideBar.test.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import type { LinkProps } from 'next/link';
 
 import LeftSidebar from '@/layout/LeftSidebar';
+
+jest.mock('next/link', () => jest.fn(
+  (
+    props: LinkProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLAnchorElement>,
+  ) => (
+    <a className={props.className} href={props.href.toString()}>{props.children}</a>
+  ),
+));
 
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),

--- a/src/__tests__/layout/__snapshots__/LeftSideBar.test.tsx.snap
+++ b/src/__tests__/layout/__snapshots__/LeftSideBar.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`LeftSidebar renders as expected 1`] = `
                   >
                     <a
                       class="block pt-3 pb-3"
-                      data-menu-key="home"
                       href="/dashboard/accounts"
                     >
                       <span
@@ -89,7 +88,6 @@ exports[`LeftSidebar renders as expected 1`] = `
                   >
                     <a
                       class="block pt-3 pb-3"
-                      data-menu-key="investments"
                       href="/dashboard/investments"
                     >
                       <span

--- a/src/app/dashboard/accounts/[guid]/page.tsx
+++ b/src/app/dashboard/accounts/[guid]/page.tsx
@@ -48,6 +48,7 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
     if (datasource) {
       load();
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasource, params.guid, accounts]);
 
   if (account === null) {

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -43,8 +43,12 @@ export default function TransactionsTable({
         },
         order: {
           fk_transaction: {
-            date: 'ASC',
+            date: 'DESC',
           },
+          // This is so debit is always before credit
+          // so we avoid negative amounts when display
+          // partial totals
+          quantityNum: 'ASC',
         },
       });
       setSplits(newSplits);
@@ -67,7 +71,6 @@ export default function TransactionsTable({
     <Table<Split>
       columns={columns}
       data={splits}
-      initialSort={{ id: 'date', desc: true }}
     />
   );
 }
@@ -76,6 +79,7 @@ const columns: ColumnDef<Split>[] = [
   {
     header: 'Date',
     id: 'date',
+    enableSorting: false,
     accessorFn: (row: Split) => row.transaction.date.toMillis(),
     cell: ({ row }) => (
       <Tooltip
@@ -130,8 +134,8 @@ const columns: ColumnDef<Split>[] = [
       const currentRow = rows.findIndex(
         (otherRow: Row<Split>) => otherRow.original.guid === row.original.guid,
       );
-      const previousRows = rows.slice(0, currentRow + 1);
-      const totalPreviousSplits = previousRows.reduce(
+      const nextRows = rows.slice(currentRow, rows.length + 1);
+      const totalPreviousSplits = nextRows.reverse().reduce(
         (total: Money, otherRow: Row<Split>) => {
           if (otherRow.original.account.type === 'INCOME') {
             return total.add(

--- a/src/layout/Menu.tsx
+++ b/src/layout/Menu.tsx
@@ -8,13 +8,11 @@ import { usePathname } from 'next/navigation';
 
 const MENU_ITEMS = [
   {
-    key: 'home',
     label: 'Home',
     icon: <BiHomeAlt size="1.125em" />,
     url: '/dashboard/accounts',
   },
   {
-    key: 'investments',
     label: 'Investments',
     icon: <BiCoinStack size="1.125em" />,
     url: '/dashboard/investments',
@@ -23,7 +21,6 @@ const MENU_ITEMS = [
 
 type MenuItemProps = {
   item: {
-    key: string;
     url: string;
     target?: string;
     icon: JSX.Element;
@@ -39,7 +36,6 @@ function MenuItem({ item, className }: MenuItemProps): JSX.Element {
         href={item.url}
         target={item.target}
         className="block pt-3 pb-3"
-        data-menu-key={item.key}
       >
         <span className={`flex justify-center items-center w-20 ${className} text-slate-400 hover:text-white`}>
           {item.icon}


### PR DESCRIPTION
Apparently react-table re-ordering was messing with the order of the items which came already ordered from typeorm query. What I've done is to disable the sorting from the table component and just rely on the ordering that comes from typeorm. Note that this means we can't order by date in the table anymore

Fixes #5