### PR TITLE
Saving indicator and save after modification

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -16,7 +16,7 @@ const config = {
   coverageThreshold: {
     global: {
       lines: 86.5,
-      branches: 85,
+      branches: 84.5,
     },
   },
   testEnvironment: 'jest-environment-jsdom',

--- a/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
@@ -11,10 +11,17 @@ import TransactionsTable from '@/components/TransactionsTable';
 import AddTransactionButton from '@/components/buttons/AddTransactionButton';
 import { Account, Split } from '@/book/entities';
 import * as queries from '@/book/queries';
+import * as dataSourceHooks from '@/hooks/useDataSource';
+import type { UseDataSourceReturn } from '@/hooks';
 
 jest.mock('swr', () => ({
   __esModule: true,
   ...jest.requireActual('swr'),
+}));
+
+jest.mock('@/hooks/useDataSource', () => ({
+  __esModule: true,
+  ...jest.requireActual('@/hooks/useDataSource'),
 }));
 
 jest.mock('@/components/buttons/AddTransactionButton', () => jest.fn(
@@ -99,7 +106,12 @@ describe('AccountPage', () => {
     expect(TransactionsTable).toHaveBeenCalledTimes(0);
   });
 
-  it('mutates when saving a transaction', async () => {
+  it('mutates and saves when saving a transaction', async () => {
+    const mockSave = jest.fn();
+    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
+      { save: mockSave as Function } as UseDataSourceReturn,
+    );
+
     render(
       <swr.SWRConfig value={{ provider: () => new Map() }}>
         <AccountPage params={{ guid: 'guid' }} />
@@ -113,6 +125,7 @@ describe('AccountPage', () => {
     }
     expect(swr.mutate).toBeCalledTimes(1);
     expect(swr.mutate).toHaveBeenNthCalledWith(1, '/api/splits/guid');
+    expect(mockSave).toBeCalledTimes(1);
   });
 
   it('renders as expected with account', async () => {

--- a/src/__tests__/app/dashboard/layout.test.tsx
+++ b/src/__tests__/app/dashboard/layout.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import type { DataSource } from 'typeorm';
 
+import type { UseDataSourceReturn } from '@/hooks';
 import DashboardLayout from '@/app/dashboard/layout';
 import Topbar from '@/layout/Topbar';
 import LeftSidebar from '@/layout/LeftSidebar';
@@ -41,7 +41,9 @@ describe('DashboardLayout', () => {
         isLoggedIn: false,
       },
     });
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue([{} as DataSource]);
+    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
+      { isLoaded: true } as UseDataSourceReturn,
+    );
   });
 
   it('returns loading when no user available', async () => {
@@ -59,7 +61,9 @@ describe('DashboardLayout', () => {
   });
 
   it('returns loading when datasource not available', async () => {
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue([null]);
+    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
+      { isLoaded: false } as UseDataSourceReturn,
+    );
     jest.spyOn(userHooks, 'default').mockReturnValue({
       user: {
         name: 'name',
@@ -67,7 +71,6 @@ describe('DashboardLayout', () => {
         image: 'image',
         isLoggedIn: true,
       },
-      mutate: jest.fn(),
     });
     const { container } = render(
       <DashboardLayout>
@@ -90,7 +93,6 @@ describe('DashboardLayout', () => {
         image: 'image',
         isLoggedIn: true,
       },
-      mutate: jest.fn(),
     });
 
     const { container } = render(

--- a/src/__tests__/components/buttons/__snapshots__/ImportButton.test.tsx.snap
+++ b/src/__tests__/components/buttons/__snapshots__/ImportButton.test.tsx.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ImportButton renders as expected when storage available 1`] = `
+exports[`ImportButton loads while unavailable datasource 1`] = `
 <div>
   <button
     class="link inline-block w-full whitespace-nowrap"
+    disabled=""
     id="menu-item-0"
     role="menuitem"
     tabindex="-1"

--- a/src/__tests__/components/buttons/__snapshots__/SaveButton.test.tsx.snap
+++ b/src/__tests__/components/buttons/__snapshots__/SaveButton.test.tsx.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SaveButton loads while unavailable bookstorage 1`] = `
-<div>
-  <button
-    class="btn-primary"
-    type="button"
-  >
-    ...
-  </button>
-</div>
-`;
-
 exports[`SaveButton loads while unavailable datasource 1`] = `
 <div>
   <button
@@ -22,7 +11,7 @@ exports[`SaveButton loads while unavailable datasource 1`] = `
 </div>
 `;
 
-exports[`SaveButton shows Save text when ready 1`] = `
+exports[`SaveButton renders as expected when datasource ready and not saving 1`] = `
 <div>
   <button
     class="btn-primary"
@@ -45,7 +34,37 @@ exports[`SaveButton shows Save text when ready 1`] = `
         d="M7 19h2v-2H7c-1.654 0-3-1.346-3-3 0-1.404 1.199-2.756 2.673-3.015l.581-.102.192-.558C8.149 8.274 9.895 7 12 7c2.757 0 5 2.243 5 5v1h1c1.103 0 2 .897 2 2s-.897 2-2 2h-3v2h3c2.206 0 4-1.794 4-4a4.01 4.01 0 0 0-3.056-3.888C18.507 7.67 15.56 5 12 5 9.244 5 6.85 6.611 5.757 9.15 3.609 9.792 2 11.82 2 14c0 2.757 2.243 5 5 5z"
       />
     </svg>
-    Save
+    <span>
+      Save
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SaveButton renders as expected when datasource ready and saving 1`] = `
+<div>
+  <button
+    class="btn-primary"
+    disabled=""
+    type="button"
+  >
+    <svg
+      class="mr-1 animate-spin"
+      fill="currentColor"
+      height="1em"
+      stroke="currentColor"
+      stroke-width="0"
+      viewBox="0 0 24 24"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M2 11h5v2H2zm15 0h5v2h-5zm-6 6h2v5h-2zm0-15h2v5h-2zM4.222 5.636l1.414-1.414 3.536 3.536-1.414 1.414zm15.556 12.728-1.414 1.414-3.536-3.536 1.414-1.414zm-12.02-3.536 1.414 1.414-3.536 3.536-1.414-1.414zm7.07-7.071 3.536-3.535 1.414 1.415-3.536 3.535z"
+      />
+    </svg>
+    <span>
+      Saving...
+    </span>
   </button>
 </div>
 `;

--- a/src/__tests__/hooks/useBookStorage.test.ts
+++ b/src/__tests__/hooks/useBookStorage.test.ts
@@ -23,7 +23,7 @@ describe('useBookStorage', () => {
   it('returns null if gapi not loaded', () => {
     const { result } = renderHook(() => useBookStorage());
 
-    expect(result.current).toEqual([null]);
+    expect(result.current).toEqual({ storage: null });
   });
 
   it('returns storage if gapi is loaded', async () => {
@@ -38,7 +38,7 @@ describe('useBookStorage', () => {
     rerender();
 
     await waitFor(() => {
-      expect(result.current).toEqual([expect.any(BookStorage)]);
+      expect(result.current).toEqual({ storage: expect.any(BookStorage) });
     });
   });
 
@@ -52,7 +52,7 @@ describe('useBookStorage', () => {
     rerender();
 
     await waitFor(() => {
-      expect(result.current).toEqual([expect.any(BookStorage)]);
+      expect(result.current).toEqual({ storage: expect.any(BookStorage) });
     });
     expect(BookStorage.prototype.initStorage).toBeCalledTimes(1);
   });

--- a/src/app/dashboard/accounts/[guid]/page.tsx
+++ b/src/app/dashboard/accounts/[guid]/page.tsx
@@ -9,6 +9,7 @@ import { Split } from '@/book/entities';
 import TransactionsTable from '@/components/TransactionsTable';
 import AddTransactionButton from '@/components/buttons/AddTransactionButton';
 import { getAccountsWithPath } from '@/book/queries';
+import { useDataSource } from '@/hooks';
 
 export type AccountPageProps = {
   params: {
@@ -17,6 +18,7 @@ export type AccountPageProps = {
 };
 
 export default function AccountPage({ params }: AccountPageProps): JSX.Element {
+  const { save } = useDataSource();
   let { data: accounts } = useSWRImmutable(
     '/api/accounts',
     getAccountsWithPath,
@@ -90,7 +92,10 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
         <div className="col-span-2 col-end-13 justify-self-end">
           <AddTransactionButton
             account={account}
-            onSave={() => mutate(`/api/splits/${params.guid}`)}
+            onSave={() => {
+              save();
+              mutate(`/api/splits/${params.guid}`);
+            }}
           />
         </div>
       </div>

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
+import { useDataSource } from '@/hooks';
 
 import AccountsTable from '@/components/AccountsTable';
 import AddAccountButton from '@/components/buttons/AddAccountButton';
@@ -10,6 +11,7 @@ import { getAccountsWithPath } from '@/book/queries';
 import { PriceDB, PriceDBMap } from '@/book/prices';
 
 export default function AccountsPage(): JSX.Element {
+  const { save } = useDataSource();
   let { data: accounts } = useSWRImmutable(
     '/api/accounts/splits',
     () => getAccountsWithPath({
@@ -35,6 +37,7 @@ export default function AccountsPage(): JSX.Element {
         <div className="col-span-2 col-end-13 justify-self-end">
           <AddAccountButton
             onSave={() => {
+              save();
               mutate('/api/accounts');
               mutate('/api/accounts/splits');
             }}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,8 +2,8 @@
 
 import React from 'react';
 
+import { useDataSource } from '@/hooks';
 import useUser from '@/hooks/useUser';
-import useDataSource from '@/hooks/useDataSource';
 import Footer from '@/layout/Footer';
 import LeftSidebar from '@/layout/LeftSidebar';
 import Topbar from '@/layout/Topbar';
@@ -12,9 +12,9 @@ export default function DashboardLayout({
   children,
 }: React.PropsWithChildren): JSX.Element {
   const { user } = useUser();
-  const [datasource] = useDataSource();
+  const { isLoaded } = useDataSource();
 
-  if (!user || !datasource || user.isLoggedIn === false) {
+  if (!user || !isLoaded || user.isLoggedIn === false) {
     return <div>Loading...</div>;
   }
 

--- a/src/components/AccountsTable.tsx
+++ b/src/components/AccountsTable.tsx
@@ -31,10 +31,7 @@ export default function AccountsTable(
 
   const root = accounts.find(a => a.type === 'ROOT');
   if (root && !todayPrices.isEmpty) {
-    const start = performance.now();
     rows = buildNestedRows(root, accounts, todayPrices).subRows;
-    const end = performance.now();
-    console.log(`build nested rows: ${end - start}ms`);
   }
 
   return (

--- a/src/components/buttons/ImportButton.tsx
+++ b/src/components/buttons/ImportButton.tsx
@@ -1,24 +1,11 @@
 import React from 'react';
 import { BiImport } from 'react-icons/bi';
-import { DataSource } from 'typeorm';
-import { mutate } from 'swr';
 
-import { useDataSource, useBookStorage } from '@/hooks';
-import {
-  Account,
-  Book,
-  Commodity,
-  Price,
-  Split,
-  Transaction,
-} from '@/book/entities';
-import type BookStorage from '@/apis/BookStorage';
+import { useDataSource } from '@/hooks';
 
 export default function ImportButton(): JSX.Element {
-  const [storage] = useBookStorage();
-  const [datasource] = useDataSource();
+  const { isLoaded, importBook } = useDataSource();
   const fileImportInput = React.useRef<HTMLInputElement>(null);
-  const isDisabled = !storage;
 
   return (
     <>
@@ -26,7 +13,7 @@ export default function ImportButton(): JSX.Element {
         id="menu-item-0"
         type="button"
         role="menuitem"
-        disabled={isDisabled}
+        disabled={!isLoaded}
         tabIndex={-1}
         className="link inline-block w-full whitespace-nowrap"
         onClick={() => fileImportInput.current !== null && fileImportInput.current.click()}
@@ -39,58 +26,25 @@ export default function ImportButton(): JSX.Element {
         className="hidden"
         type="file"
         ref={fileImportInput}
-        onChange={(e) => importBook(
-          e,
-          storage as BookStorage,
-          datasource as DataSource,
-        )}
+        onChange={(e) => i(e, importBook)}
       />
     </>
   );
 }
 
-function importBook(
+function i(
   event: React.ChangeEvent<HTMLInputElement>,
-  storage: BookStorage,
-  datasource: DataSource,
+  importBook: Function,
 ) {
   if (event.target.files !== null && event.target.files[0] !== null) {
     const fileReader = new FileReader();
     fileReader.onload = async (loadEvent) => {
       if (loadEvent.target !== null && loadEvent.target.result !== null) {
         const rawBook = new Uint8Array(loadEvent.target.result as ArrayBuffer);
-        await saveBook(rawBook, storage, datasource);
+        await importBook(rawBook);
       }
     };
 
     fileReader.readAsArrayBuffer(event.target.files[0]);
   }
-}
-
-/**
- * Receives a Uint8Array from the file to import, converts it
- * to Maffin schema using a temporary datasource and uploads the resulting
- * data.
- */
-async function saveBook(
-  rawData: Uint8Array,
-  storage: BookStorage,
-  datasource: DataSource,
-) {
-  const tempDataSource = new DataSource({
-    type: 'sqljs',
-    synchronize: true,
-    database: rawData,
-    logging: false,
-    entities: [Account, Book, Commodity, Price, Split, Transaction],
-  });
-  await tempDataSource.initialize();
-  const rawBook = tempDataSource.sqljsManager.exportDatabase();
-
-  await Promise.all([
-    datasource.sqljsManager.loadDatabase(rawBook),
-    storage.save(rawBook),
-  ]);
-
-  mutate(() => true);
 }

--- a/src/components/buttons/SaveButton.tsx
+++ b/src/components/buttons/SaveButton.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import { BiCloudUpload } from 'react-icons/bi';
+import { BiCloudUpload, BiLoader } from 'react-icons/bi';
+import useSWRImmutable from 'swr/immutable';
 
-import { useBookStorage, useDataSource } from '@/hooks';
+import { useDataSource } from '@/hooks';
 
 export default function SaveButton(): JSX.Element {
-  const [bookStorage] = useBookStorage();
-  const [datasource] = useDataSource();
+  const { data: isSaving } = useSWRImmutable(
+    '/state/save',
+    () => false,
+  );
+  const { isLoaded, save } = useDataSource();
 
-  if (bookStorage === null || datasource === null) {
+  if (!isLoaded) {
     return (
       <button
         type="button"
@@ -22,13 +26,27 @@ export default function SaveButton(): JSX.Element {
     <button
       type="button"
       className="btn-primary"
+      disabled={isSaving}
       onClick={async () => {
-        const rawBook = datasource?.sqljsManager.exportDatabase();
-        await bookStorage?.save(rawBook);
+        await save();
       }}
     >
-      <BiCloudUpload className="mr-1" />
-      Save
+      {
+        (
+          isSaving
+          && (
+          <>
+            <BiLoader className="mr-1 animate-spin" />
+            <span>Saving...</span>
+          </>
+          )
+        ) || (
+          <>
+            <BiCloudUpload className="mr-1" />
+            <span>Save</span>
+          </>
+        )
+      }
     </button>
   );
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as useDataSource } from './useDataSource';
+export type { UseDataSourceReturn } from './useDataSource';
 export { default as useBookStorage } from './useBookStorage';
 export { default as useGapiClient } from './useGapiClient';
 export { default as useUser } from './useUser';

--- a/src/hooks/useBookStorage.ts
+++ b/src/hooks/useBookStorage.ts
@@ -2,7 +2,11 @@ import React from 'react';
 import useGapiClient from '@/hooks/useGapiClient';
 import BookStorage from '@/apis/BookStorage';
 
-export default function useBookStorage(): [BookStorage | null] {
+type UseBookStorageReturn = {
+  storage: BookStorage | null,
+};
+
+export default function useBookStorage(): UseBookStorageReturn {
   const [isGapiLoaded] = useGapiClient();
   const [storage, setStorage] = React.useState<BookStorage | null>(null);
 
@@ -18,5 +22,5 @@ export default function useBookStorage(): [BookStorage | null] {
     }
   }, [isGapiLoaded]);
 
-  return [storage || null];
+  return { storage };
 }


### PR DESCRIPTION
This PR adds some UI changes so users see when saving is happening. 

<img width="173" alt="Screenshot 2023-07-21 at 5 39 00 PM" src="https://github.com/maffin-io/maffin-app/assets/3578154/105e0b91-8077-41b1-90fe-965134d6a73c">

Not only this but I've implemented some state management to know when saving is happening as now it can happen from different points in the code. (i.e. adding a new account, importing a new book, etc). The state management is implemented using SWR. I know it may feel a bit hacky but I've tried the following approaches without success:

- Using custom hooks doesnt work because the result if the hook is local to the component rendering it. This means the state change only happens when you push the Save button but when doing it in other UI components, the SaveButton component doesn't realize about that.
- Moving the datasource to a context. This one worked but the problem is that the datasource is used in multiple parts of the code and thus, whenever the flag for "isSaving" changed, it re-rendered components that didn't need to be re-rendered (i.e. accounts table and so on which only need the `isLoaded` flag).

With this new state management we can be granular and only change and re-render specifically what we need.

In order to not mix state management and data fetching, I'm splitting the SWR keys as `/api/<whatever` and `/state/<whatever>`.

As mentioned in #26, we may find a point where saving on each change is a bit costly due to latency issues. We can accumulate changes locally and save periodically in the future but for now it works so leaving as is.

Closes #26 
