### PR TITLE
Fix login

### DIFF
--- a/src/__tests__/app/user/login/page.test.tsx
+++ b/src/__tests__/app/user/login/page.test.tsx
@@ -81,6 +81,6 @@ describe('LoginPage', () => {
     );
     expect(mockRouterPush).toHaveBeenCalledWith('/dashboard/accounts');
     expect(swr.mutate).toBeCalledTimes(1);
-    expect(swr.mutate).toBeCalledWith('/api/user');
+    expect(swr.mutate).toBeCalledWith('/api/user', null, { revalidate: true });
   });
 });

--- a/src/app/user/login/page.tsx
+++ b/src/app/user/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage(): JSX.Element {
       scope: 'email profile https://www.googleapis.com/auth/drive.file',
       callback: async (tokenResponse) => {
         localStorage.setItem('accessToken', tokenResponse.access_token);
-        mutate('/api/user');
+        mutate('/api/user', null, { revalidate: true });
         router.push('/dashboard/accounts');
       },
     }));


### PR DESCRIPTION
Seems the bug where we keep the user in the login page even after logging in is back. This seems to fix it.

For future reference, to reproduce do the following:

- change the refresh period for `/api/user` to 5 seconds
- in the browser, type `window.gapi.client.setToken({ access_token: 'fake' })`

This will reproduce the token being invalid so you can test properly.