### PR TITLE
Add splits histogram to account detail page

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -15,8 +15,8 @@ const config = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}'],
   coverageThreshold: {
     global: {
-      lines: 86.5,
-      branches: 84.5,
+      lines: 87,
+      branches: 85.5,
     },
   },
   testEnvironment: 'jest-environment-jsdom',

--- a/src/__tests__/app/dashboard/accounts/[guid]/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/accounts/[guid]/__snapshots__/page.test.tsx.snap
@@ -14,17 +14,89 @@ exports[`AccountPage renders as expected with account 1`] = `
     class="grid grid-cols-12 items-center pb-4"
   >
     <span
-      class="col-span-10 text-xl font-medium"
+      class="col-span-10"
     >
-      path
-       
-      account
+      <span
+        class="text-xl font-medium badge"
+      >
+        path
+         
+        account
+      </span>
     </span>
     <div
       class="col-span-2 col-end-13 justify-self-end"
     >
       <div
         data-testid="AddTransactionButton"
+      />
+    </div>
+  </div>
+  <div
+    class="grid grid-cols-12"
+  >
+    <div
+      class="col-span-6"
+    >
+      <div
+        class="grid grid-cols-12"
+      >
+        <div
+          class="col-span-6"
+        >
+          <div
+            class="mr-6 bg-gunmetal-700 rounded-sm p-6"
+          >
+            <p>
+              You have a total of
+            </p>
+            <p
+              class=" text-2xl font-semibold my-3"
+            >
+              100.00 €
+            </p>
+            <span
+              class="text-sm"
+            >
+              with an average of 100.00 € per month
+            </span>
+          </div>
+        </div>
+        <div
+          class="col-span-6"
+        >
+          <div
+            class="mr-6 bg-gunmetal-700 rounded-sm p-6"
+          >
+            <p>
+              This year there's been a change of
+            </p>
+            <p
+              class=" text-2xl font-semibold my-3"
+            >
+              100.00 €
+            </p>
+            <span
+              class="text-sm"
+            >
+              for this account
+            </span>
+          </div>
+        </div>
+        <div
+          class="col-span-12"
+        >
+          <div
+            data-testid="TotalLineChart"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="col-span-6"
+    >
+      <div
+        data-testid="SplitsHistogram"
       />
     </div>
   </div>

--- a/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DateTime } from 'luxon';
 import {
   waitFor,
   render,
@@ -6,9 +7,12 @@ import {
 } from '@testing-library/react';
 import * as swr from 'swr';
 
+import Money from '@/book/Money';
 import AccountPage from '@/app/dashboard/accounts/[guid]/page';
 import TransactionsTable from '@/components/TransactionsTable';
 import AddTransactionButton from '@/components/buttons/AddTransactionButton';
+import SplitsHistogram from '@/components/pages/account/SplitsHistogram';
+import TotalLineChart from '@/components/pages/account/TotalLineChart';
 import { Account, Split } from '@/book/entities';
 import * as queries from '@/book/queries';
 import * as dataSourceHooks from '@/hooks/useDataSource';
@@ -33,6 +37,14 @@ const AddTransactionButtonMock = AddTransactionButton as jest.MockedFunction<
 
 jest.mock('@/components/TransactionsTable', () => jest.fn(
   () => <div data-testid="TransactionsTable" />,
+));
+
+jest.mock('@/components/pages/account/SplitsHistogram', () => jest.fn(
+  () => <div data-testid="SplitsHistogram" />,
+));
+
+jest.mock('@/components/pages/account/TotalLineChart', () => jest.fn(
+  () => <div data-testid="TotalLineChart" />,
 ));
 
 jest.mock('@/book/queries', () => ({
@@ -61,12 +73,23 @@ describe('AccountPage', () => {
         guid: 'guid',
         path: 'path',
         type: 'TYPE',
+        commodity: {
+          mnemonic: 'EUR',
+        },
+        get total() { return new Money(100, 'EUR'); },
       } as Account,
     ]);
     mockFindSplits = jest.spyOn(Split, 'find').mockResolvedValue(
       [
         {
           guid: 'split_guid',
+          transaction: {
+            date: DateTime.fromISO('2023-01-01'),
+          },
+          account: {
+            type: 'TYPE',
+          },
+          quantity: 100,
         } as Split,
       ],
     );
@@ -163,6 +186,11 @@ describe('AccountPage', () => {
           guid: 'guid',
           path: 'path',
           type: 'TYPE',
+          splits: [],
+          commodity: {
+            mnemonic: 'EUR',
+          },
+          total: expect.any(Money),
         },
         onSave: expect.any(Function),
       },
@@ -175,10 +203,58 @@ describe('AccountPage', () => {
             guid: 'guid',
             path: 'path',
             type: 'TYPE',
+            splits: [],
+            commodity: {
+              mnemonic: 'EUR',
+            },
+            total: expect.any(Money),
           },
         ],
         splits: [
-          { guid: 'split_guid' },
+          {
+            guid: 'split_guid',
+            transaction: {
+              date: DateTime.fromISO('2023-01-01'),
+            },
+            account: {
+              type: 'TYPE',
+            },
+            quantity: 100,
+          },
+        ],
+      },
+      {},
+    );
+    expect(SplitsHistogram).toHaveBeenLastCalledWith(
+      {
+        splits: [
+          {
+            guid: 'split_guid',
+            transaction: {
+              date: DateTime.fromISO('2023-01-01'),
+            },
+            account: {
+              type: 'TYPE',
+            },
+            quantity: 100,
+          },
+        ],
+      },
+      {},
+    );
+    expect(TotalLineChart).toHaveBeenLastCalledWith(
+      {
+        splits: [
+          {
+            guid: 'split_guid',
+            transaction: {
+              date: DateTime.fromISO('2023-01-01'),
+            },
+            account: {
+              type: 'TYPE',
+            },
+            quantity: 100,
+          },
         ],
       },
       {},

--- a/src/__tests__/app/dashboard/accounts/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/page.test.tsx
@@ -4,7 +4,6 @@ import {
   render,
 } from '@testing-library/react';
 import * as swr from 'swr';
-import crypto from 'crypto';
 
 import type { Account } from '@/book/entities';
 import AccountsPage from '@/app/dashboard/accounts/page';
@@ -14,12 +13,6 @@ import { PriceDB, PriceDBMap } from '@/book/prices';
 import * as queries from '@/book/queries';
 import * as dataSourceHooks from '@/hooks/useDataSource';
 import type { UseDataSourceReturn } from '@/hooks';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 jest.mock('swr', () => ({
   __esModule: true,

--- a/src/__tests__/app/dashboard/investments/page.test.tsx
+++ b/src/__tests__/app/dashboard/investments/page.test.tsx
@@ -57,6 +57,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       1,
       {
+        className: 'mx-6',
         title: 'Value/Cost',
         stats: '0.00 €',
         description: '0 total invested',
@@ -66,6 +67,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       2,
       {
+        className: 'mx-6',
         title: 'Unrealized Profit',
         stats: '0.00 € (NaN%)',
         description: '0 (NaN%) with dividends',
@@ -76,6 +78,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       3,
       {
+        className: 'mx-6',
         title: 'Realized',
         stats: '0.00 €',
         description: '0.00 € from dividends',
@@ -134,6 +137,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       7,
       {
+        className: 'mx-6',
         title: 'Value/Cost',
         stats: '5.00 €',
         description: '4 total invested',
@@ -143,6 +147,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       8,
       {
+        className: 'mx-6',
         title: 'Unrealized Profit',
         stats: '1.00 € (25%)',
         description: '6 (150%) with dividends',
@@ -153,6 +158,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       9,
       {
+        className: 'mx-6',
         title: 'Realized',
         stats: '15.00 €',
         description: '5.00 € from dividends',
@@ -211,6 +217,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       7,
       {
+        className: 'mx-6',
         title: 'Value/Cost',
         stats: '5.00 $',
         description: '4 total invested',
@@ -220,6 +227,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       8,
       {
+        className: 'mx-6',
         title: 'Unrealized Profit',
         stats: '1.00 $ (25%)',
         description: '6 (150%) with dividends',
@@ -230,6 +238,7 @@ describe('InvestmentsPage', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       9,
       {
+        className: 'mx-6',
         title: 'Realized',
         stats: '15.00 $',
         description: '5.00 $ from dividends',

--- a/src/__tests__/components/Modal.test.tsx
+++ b/src/__tests__/components/Modal.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Modal from '@/components/Modal';
+
+describe('Modal', () => {
+  it('returns span if not open', () => {
+    const { container } = render(
+      <Modal
+        open={false}
+        setOpen={() => {}}
+      >
+        <div />
+      </Modal>,
+    );
+
+    expect(container.innerHTML).toEqual('<span></span>');
+  });
+
+  it('renders as expected', () => {
+    const { container } = render(
+      <Modal
+        title="title"
+        open
+        setOpen={() => {}}
+      >
+        <div />
+      </Modal>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('calls setOpen on close', async () => {
+    const user = userEvent.setup();
+    const mockSetOpen = jest.fn();
+    render(
+      <Modal
+        title="title"
+        open
+        setOpen={mockSetOpen}
+      >
+        <div />
+      </Modal>,
+    );
+
+    screen.getByText('title');
+    await user.click(screen.getByText('X'));
+
+    expect(mockSetOpen).toBeCalledTimes(1);
+    expect(mockSetOpen).toBeCalledWith(false);
+  });
+});

--- a/src/__tests__/components/TransactionsTable.test.tsx
+++ b/src/__tests__/components/TransactionsTable.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@testing-library/react';
 import { DataSource } from 'typeorm';
 import type { LinkProps } from 'next/link';
-import crypto from 'crypto';
 
 import {
   Account,
@@ -16,12 +15,6 @@ import {
 } from '@/book/entities';
 import Table from '@/components/Table';
 import TransactionsTable from '@/components/TransactionsTable';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 jest.mock('@/components/Table', () => jest.fn(
   () => <div data-testid="Table" />,

--- a/src/__tests__/components/__snapshots__/Modal.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Modal.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal renders as expected 1`] = `
+<div>
+  <div
+    class="fixed inset-0 bg-white bg-opacity-30 overflow-y-auto h-full w-full z-50"
+    id="my-modal"
+  >
+    <div
+      class="relative top-20 mx-auto p-5 w-1/3 shadow-lg rounded-md bg-gunmetal-700"
+    >
+      <button
+        class="float-right"
+        type="button"
+      >
+        X
+      </button>
+      <div
+        class="w-full pb-4 border-b border-gunmetal-600"
+      >
+        <span
+          class="text-lg"
+        >
+          title
+        </span>
+      </div>
+      <div />
+    </div>
+  </div>
+</div>
+`;

--- a/src/__tests__/components/__snapshots__/Table.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/Table.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Table renders headers with empty data 1`] = `
 <div>
   <div
-    class="relative overflow-x-auto"
+    class="relative overflow-hidden"
   >
     <table
       class="w-full text-sm text-left"

--- a/src/__tests__/components/__snapshots__/TransactionsTable.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionsTable.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`TransactionsTable renders FromTo column as expected 1`] = `
   <ul>
     <li>
       <a
-        class="badge bg-red-500/20 text-red-300"
+        class="badge hover:text-slate-300 bg-red-500/20 text-red-300"
         href="/dashboard/accounts/account_guid_2"
       >
         Expenses:expense

--- a/src/__tests__/components/charts/Chart.test.tsx
+++ b/src/__tests__/components/charts/Chart.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ApexChart from 'react-apexcharts';
+import { ApexOptions } from 'apexcharts';
+
+import Chart from '@/components/charts/Chart';
+
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  // eslint-disable-next-line global-require
+  default: () => require('react-apexcharts'),
+}));
+
+jest.mock('react-apexcharts', () => jest.fn(
+  () => <div data-testid="Chart" />,
+));
+const ApexChartMock = ApexChart as jest.MockedFunction<typeof ApexChart>;
+
+describe('Chart', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns loading if no data', () => {
+    render(<Chart type="bar" />);
+
+    screen.getByText('Loading...');
+  });
+
+  it('creates chart with expected parameters', () => {
+    render(<Chart series={[1]} type="bar" />);
+
+    expect(ApexChartMock).toHaveBeenCalledWith(
+      {
+        className: 'apex-charts',
+        height: 400,
+        options: {
+          chart: {
+            foreColor: '#94A3B8',
+            id: '',
+            toolbar: {
+              show: false,
+            },
+            width: '100%',
+            zoom: {
+              autoScaleYaxis: true,
+              enabled: true,
+              type: 'x',
+            },
+            events: {
+              mounted: expect.any(Function),
+            },
+          },
+          dataLabels: {
+            enabled: false,
+          },
+          grid: {
+            borderColor: '#777f85',
+          },
+          labels: [],
+          legend: {
+            show: true,
+          },
+          plotOptions: {
+            bar: {
+              columnWidth: '55%',
+              horizontal: false,
+            },
+          },
+          stroke: {
+            curve: 'smooth',
+            dashArray: 0,
+            width: 0,
+          },
+          title: {
+            align: 'left',
+            text: '',
+          },
+          tooltip: {
+            fillSeriesColor: true,
+            intersect: true,
+            inverseOrder: true,
+            shared: false,
+            theme: 'dark',
+            x: {
+              show: false,
+            },
+            y: {
+              formatter: expect.any(Function),
+            },
+          },
+          xaxis: {
+            axisBorder: {
+              show: false,
+            },
+            categories: [],
+            type: undefined,
+          },
+          yaxis: {
+            labels: {
+              formatter: expect.any(Function),
+            },
+          },
+        },
+        series: [1],
+        type: 'bar',
+        width: '100%',
+      },
+      {},
+    );
+  });
+
+  it('hides series on mount', () => {
+    render(<Chart hideSeries={['a', 'b']} series={[1]} type="bar" />);
+
+    // @ts-ignore
+    const options = ApexChartMock.mock.calls[0][0].options as ApexOptions;
+
+    const mockHideSeries = jest.fn();
+    const mockChart = {
+      hideSeries: mockHideSeries,
+    };
+
+    // @ts-ignore
+    options.chart.events.mounted(mockChart);
+
+    expect(mockHideSeries).toBeCalledTimes(2);
+    expect(mockHideSeries).toHaveBeenNthCalledWith(1, 'a');
+    expect(mockHideSeries).toHaveBeenNthCalledWith(2, 'b');
+  });
+
+  it('sets optional params', () => {
+    render(
+      <Chart
+        series={[1]}
+        title="title"
+        showLegend={false}
+        xCategories={['a', 'b']}
+        xAxisType="datetime"
+        type="bar"
+        unit="unit"
+        height={200}
+      />,
+    );
+
+    // @ts-ignore
+    const options = ApexChartMock.mock.calls[0][0].options as ApexOptions;
+
+    expect(options?.title?.text).toEqual('title');
+    expect(options?.legend?.show).toEqual(false);
+    expect(options?.xaxis?.categories).toEqual(['a', 'b']);
+    // @ts-ignore
+    expect(options?.yaxis?.labels.formatter(1)).toEqual('1 unit');
+    // @ts-ignore
+    expect(options?.tooltip?.y?.formatter(1)).toEqual('1 unit');
+
+    // @ts-ignore
+    expect(ApexChartMock.mock.calls[0][0].height).toEqual(200);
+  });
+});

--- a/src/__tests__/components/equities/__snapshots__/StatisticsWidget.test.tsx.snap
+++ b/src/__tests__/components/equities/__snapshots__/StatisticsWidget.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StatisticsWidget renders as expected 1`] = `
 <div>
   <div
-    class="bg-gunmetal-700 rounded-sm mx-6 p-6"
+    class=" bg-gunmetal-700 rounded-sm p-6"
   >
     <p>
       Title
@@ -25,7 +25,7 @@ exports[`StatisticsWidget renders as expected 1`] = `
 exports[`StatisticsWidget renders as expected without optional params 1`] = `
 <div>
   <div
-    class="bg-gunmetal-700 rounded-sm mx-6 p-6"
+    class=" bg-gunmetal-700 rounded-sm p-6"
   >
     <p>
       Title

--- a/src/__tests__/components/forms/account/AccountForm.test.tsx
+++ b/src/__tests__/components/forms/account/AccountForm.test.tsx
@@ -6,7 +6,6 @@ import {
 import userEvent from '@testing-library/user-event';
 import { DataSource } from 'typeorm';
 import { SWRConfig } from 'swr';
-import crypto from 'crypto';
 
 import { getAllowedSubAccounts } from '@/book/helpers/accountType';
 import * as queries from '@/book/queries';
@@ -23,12 +22,6 @@ jest.mock('@/book/queries', () => ({
   __esModule: true,
   ...jest.requireActual('@/book/queries'),
 }));
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('AccountForm', () => {
   let datasource: DataSource;

--- a/src/__tests__/components/forms/transaction/SplitsField.test.tsx
+++ b/src/__tests__/components/forms/transaction/SplitsField.test.tsx
@@ -7,7 +7,6 @@ import {
   render,
   screen,
 } from '@testing-library/react';
-import crypto from 'crypto';
 
 import {
   Account,
@@ -17,12 +16,6 @@ import {
 } from '@/book/entities';
 import SplitsField from '@/components/forms/transaction/SplitsField';
 import type { FormValues } from '@/components/forms/transaction/types';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('SplitsField', () => {
   let datasource: DataSource;

--- a/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
+++ b/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
@@ -7,7 +7,6 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import Stocker from '@/apis/Stocker';
 import * as queries from '@/book/queries';
@@ -24,12 +23,6 @@ jest.mock('@/book/queries', () => ({
   __esModule: true,
   ...jest.requireActual('@/book/queries'),
 }));
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('TransactionForm', () => {
   let datasource: DataSource;

--- a/src/__tests__/components/pages/account/SplitsHistogram.test.tsx
+++ b/src/__tests__/components/pages/account/SplitsHistogram.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { DateTime } from 'luxon';
+import { render } from '@testing-library/react';
+
+import type { Split } from '@/book/entities';
+import Chart from '@/components/charts/Chart';
+import SplitsHistogram from '@/components/pages/account/SplitsHistogram';
+
+jest.mock('@/components/charts/Chart', () => jest.fn(
+  () => <div data-testid="Chart" />,
+));
+const ChartMock = Chart as jest.MockedFunction<typeof Chart>;
+
+describe('SplitsHistogram', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates Chart with expected params', () => {
+    const { container } = render(<SplitsHistogram splits={[]} />);
+
+    expect(ChartMock).toBeCalledWith(
+      {
+        series: [],
+        hideSeries: [],
+        title: 'Total per month',
+        type: 'bar',
+        unit: '',
+        xCategories: [
+          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+        ],
+      },
+      {},
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('builds series accumulating values', () => {
+    // note that splits are received ordered already. Without order, it will compute
+    // wrongly
+    render(
+      <SplitsHistogram
+        splits={[
+          {
+            account: {
+              type: 'ASSET',
+              commodity: {
+                mnemonic: 'EUR',
+              },
+            },
+            transaction: {
+              date: DateTime.fromISO('2023-01-02', { zone: 'utc' }),
+            },
+            quantity: 100,
+          } as Split,
+          {
+            account: {
+              // This is not very accurate as type is always the same but
+              // this way we test INCOME behavior in this same test
+              type: 'INCOME',
+              commodity: {
+                mnemonic: 'EUR',
+              },
+            },
+            transaction: {
+              date: DateTime.fromISO('2022-01-01', { zone: 'utc' }),
+            },
+            quantity: -200,
+          } as Split,
+        ]}
+      />,
+    );
+
+    expect(ChartMock).toBeCalledWith(
+      {
+        hideSeries: ['2022'],
+        series: [
+          {
+            data: [
+              {
+                x: 'Jan',
+                y: 200,
+              },
+              {
+                x: 'Feb',
+                y: 0,
+              },
+              {
+                x: 'Mar',
+                y: 0,
+              },
+              {
+                x: 'Apr',
+                y: 0,
+              },
+              {
+                x: 'May',
+                y: 0,
+              },
+              {
+                x: 'Jun',
+                y: 0,
+              },
+              {
+                x: 'Jul',
+                y: 0,
+              },
+              {
+                x: 'Aug',
+                y: 0,
+              },
+              {
+                x: 'Sep',
+                y: 0,
+              },
+              {
+                x: 'Oct',
+                y: 0,
+              },
+              {
+                x: 'Nov',
+                y: 0,
+              },
+              {
+                x: 'Dec',
+                y: 0,
+              },
+            ],
+            name: '2022',
+          },
+          {
+            data: [
+              {
+                x: 'Jan',
+                y: 100,
+              },
+              {
+                x: 'Feb',
+                y: 0,
+              },
+              {
+                x: 'Mar',
+                y: 0,
+              },
+              {
+                x: 'Apr',
+                y: 0,
+              },
+              {
+                x: 'May',
+                y: 0,
+              },
+              {
+                x: 'Jun',
+                y: 0,
+              },
+              {
+                x: 'Jul',
+                y: 0,
+              },
+              {
+                x: 'Aug',
+                y: 0,
+              },
+              {
+                x: 'Sep',
+                y: 0,
+              },
+              {
+                x: 'Oct',
+                y: 0,
+              },
+              {
+                x: 'Nov',
+                y: 0,
+              },
+              {
+                x: 'Dec',
+                y: 0,
+              },
+            ],
+            name: '2023',
+          },
+        ],
+        title: 'Total per month',
+        type: 'bar',
+        unit: '€',
+        xCategories: [
+          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+        ],
+      },
+      {},
+    );
+  });
+});

--- a/src/__tests__/components/pages/account/TotalLineChart.test.tsx
+++ b/src/__tests__/components/pages/account/TotalLineChart.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { DateTime } from 'luxon';
+import { render } from '@testing-library/react';
+
+import type { Split } from '@/book/entities';
+import Chart from '@/components/charts/Chart';
+import TotalLineChart from '@/components/pages/account/TotalLineChart';
+
+jest.mock('@/components/charts/Chart', () => jest.fn(
+  () => <div data-testid="Chart" />,
+));
+const ChartMock = Chart as jest.MockedFunction<typeof Chart>;
+
+describe('TotalLineChart', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates Chart with expected params', () => {
+    const { container } = render(<TotalLineChart splits={[]} />);
+
+    expect(ChartMock).toBeCalledWith(
+      {
+        height: 255,
+        series: [{ data: [] }],
+        type: 'line',
+        unit: '',
+        xAxisType: 'datetime',
+      },
+      {},
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('builds series accumulating values', () => {
+    // note that splits are received ordered already. Without order, it will compute
+    // wrongly
+    render(
+      <TotalLineChart
+        splits={[
+          {
+            account: {
+              type: 'ASSET',
+              commodity: {
+                mnemonic: 'EUR',
+              },
+            },
+            transaction: {
+              date: DateTime.fromISO('2023-01-02', { zone: 'utc' }),
+            },
+            quantity: 100,
+          } as Split,
+          {
+            account: {
+              // This is not very accurate as type is always the same but
+              // this way we test INCOME behavior in this same test
+              type: 'INCOME',
+              commodity: {
+                mnemonic: 'EUR',
+              },
+            },
+            transaction: {
+              date: DateTime.fromISO('2023-01-01', { zone: 'utc' }),
+            },
+            quantity: -200,
+          } as Split,
+        ]}
+      />,
+    );
+
+    expect(ChartMock).toBeCalledWith(
+      {
+        height: 255,
+        series: [
+          {
+            data: [
+              {
+                x: 1672531200000,
+                y: 200,
+              },
+              {
+                x: 1672617600000,
+                y: 300,
+              },
+            ],
+          },
+        ],
+        type: 'line',
+        unit: '€',
+        xAxisType: 'datetime',
+      },
+      {},
+    );
+  });
+});

--- a/src/__tests__/components/pages/account/__snapshots__/SplitsHistogram.test.tsx.snap
+++ b/src/__tests__/components/pages/account/__snapshots__/SplitsHistogram.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplitsHistogram creates Chart with expected params 1`] = `
+<div>
+  <div
+    class="bg-gunmetal-700 rounded-sm mb-6 p-4"
+  >
+    <div
+      data-testid="Chart"
+    />
+  </div>
+</div>
+`;

--- a/src/__tests__/components/pages/account/__snapshots__/TotalLineChart.test.tsx.snap
+++ b/src/__tests__/components/pages/account/__snapshots__/TotalLineChart.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TotalLineChart creates Chart with expected params 1`] = `
+<div>
+  <div
+    class="bg-gunmetal-700 rounded-sm my-6 mr-6"
+  >
+    <div
+      data-testid="Chart"
+    />
+  </div>
+</div>
+`;

--- a/src/app/dashboard/accounts/[guid]/page.tsx
+++ b/src/app/dashboard/accounts/[guid]/page.tsx
@@ -4,7 +4,13 @@ import React from 'react';
 import { useRouter } from 'next/navigation';
 import { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
+import classNames from 'classnames';
+import { DateTime } from 'luxon';
 
+import Money from '@/book/Money';
+import SplitsHistogram from '@/components/pages/account/SplitsHistogram';
+import TotalLineChart from '@/components/pages/account/TotalLineChart';
+import StatisticsWidget from '@/components/equities/StatisticsWidget';
 import { Split } from '@/book/entities';
 import TransactionsTable from '@/components/TransactionsTable';
 import AddTransactionButton from '@/components/buttons/AddTransactionButton';
@@ -23,7 +29,7 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
     '/api/accounts',
     getAccountsWithPath,
   );
-  const { data: splits } = useSWRImmutable(
+  let { data: splits } = useSWRImmutable(
     `/api/splits/${params.guid}`,
     () => {
       const start = performance.now();
@@ -62,6 +68,7 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
   // fallback data as stale data which means with immutable we will
   // never refresh the data.
   accounts = accounts || [];
+  splits = splits || [];
 
   if (!accounts.length) {
     return (
@@ -80,14 +87,60 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
       </div>
     );
   }
+  account.splits = splits;
+  const { total } = account;
+  const average = new Money(total.toNumber() / (splits.length && (splits[0].transaction.date.diff(
+    splits[splits.length - 1].transaction.date,
+    ['months', 'days'],
+  ).months || 1)) || 0, account.commodity.mnemonic);
+  // Setting to empty as this creates errors when rendering
+  // transaction form and couldnt find why.
+  account.splits = [];
+
+  let totalKeyword = 'have';
+  if (account.type === 'EXPENSE') {
+    totalKeyword = 'have spent';
+  }
+  if (account.type === 'INCOME') {
+    totalKeyword = 'have earned';
+  }
+  if (account.type === 'LIABILITY') {
+    totalKeyword = 'owe';
+  }
+
+  const currentYear = DateTime.now().year;
+  let totalThisYear = 0;
+  splits.every(split => {
+    if (split.transaction.date.year !== currentYear) {
+      return false;
+    }
+
+    let { quantity } = split;
+    if (split.account.type === 'INCOME') {
+      quantity = -quantity;
+    }
+
+    totalThisYear += quantity;
+    return true;
+  });
 
   return (
     <>
       <div className="grid grid-cols-12 items-center pb-4">
-        <span className="col-span-10 text-xl font-medium">
-          {account.path}
-          {' '}
-          account
+        <span className="col-span-10">
+          <span
+            className={classNames('text-xl font-medium badge', {
+              'bg-green-500/20 text-green-300': account.type === 'INCOME',
+              'bg-red-500/20 text-red-300': account.type === 'EXPENSE',
+              'bg-cyan-500/20 text-cyan-300': ['ASSET', 'BANK'].includes(account.type),
+              'bg-orange-500/20 text-orange-300': account.type === 'LIABILITY',
+              'bg-violet-500/20 text-violet-300': ['STOCK', 'MUTUAL'].includes(account.type),
+            })}
+          >
+            {account.path}
+            {' '}
+            account
+          </span>
         </span>
         <div className="col-span-2 col-end-13 justify-self-end">
           <AddTransactionButton
@@ -99,8 +152,37 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
           />
         </div>
       </div>
+      <div className="grid grid-cols-12">
+        <div className="col-span-6">
+
+          <div className="grid grid-cols-12">
+            <div className="col-span-6">
+              <StatisticsWidget
+                className="mr-6"
+                title={`You ${totalKeyword} a total of`}
+                stats={total.format()}
+                description={`with an average of ${average.format()} per month`}
+              />
+            </div>
+            <div className="col-span-6">
+              <StatisticsWidget
+                className="mr-6"
+                title="This year there's been a change of"
+                stats={new Money(totalThisYear, account.commodity.mnemonic).format()}
+                description="for this account"
+              />
+            </div>
+            <div className="col-span-12">
+              <TotalLineChart splits={splits} />
+            </div>
+          </div>
+        </div>
+        <div className="col-span-6">
+          <SplitsHistogram splits={splits.filter(split => split.quantity !== 0)} />
+        </div>
+      </div>
       <TransactionsTable
-        splits={splits || []}
+        splits={splits}
         accounts={accounts}
       />
     </>

--- a/src/app/dashboard/investments/page.tsx
+++ b/src/app/dashboard/investments/page.tsx
@@ -69,6 +69,7 @@ export default function InvestmentsPage(): JSX.Element {
           <div className="grid grid-cols-12">
             <div className="col-span-4">
               <StatisticsWidget
+                className="mx-6"
                 title="Value/Cost"
                 stats={`${totalValue.format()}`}
                 description={
@@ -79,6 +80,7 @@ export default function InvestmentsPage(): JSX.Element {
 
             <div className="col-span-4">
               <StatisticsWidget
+                className="mx-6"
                 statsTextClass={classNames({
                   'text-green-500': profitPct >= 0,
                   'text-red-400': profitPct < 0,
@@ -93,6 +95,7 @@ export default function InvestmentsPage(): JSX.Element {
 
             <div className="col-span-4">
               <StatisticsWidget
+                className="mx-6"
                 statsTextClass={classNames({
                   'text-green-500': totalRealized.add(totalDividends).toNumber() >= 0,
                   'text-red-400': totalRealized.add(totalDividends).toNumber() < 0,

--- a/src/book/__tests__/entities/Account.test.ts
+++ b/src/book/__tests__/entities/Account.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { DataSource, BaseEntity } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   Account,
@@ -8,12 +7,6 @@ import {
   Split,
   Transaction,
 } from '../../entities';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('Account', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/entities/BaseEntity.test.ts
+++ b/src/book/__tests__/entities/BaseEntity.test.ts
@@ -1,14 +1,7 @@
-import crypto from 'crypto';
 import * as v from 'class-validator';
 import { BaseEntity as BE } from 'typeorm';
 
 import { BaseEntity } from '../../entities';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('BaseEntity', () => {
   let instance: BaseEntity;

--- a/src/book/__tests__/entities/Book.test.ts
+++ b/src/book/__tests__/entities/Book.test.ts
@@ -1,5 +1,4 @@
 import { DataSource, BaseEntity } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   Book,
@@ -8,12 +7,6 @@ import {
   Split,
   Account,
 } from '../../entities';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('Book', () => {
   let instance: Book;

--- a/src/book/__tests__/entities/Commodity.test.ts
+++ b/src/book/__tests__/entities/Commodity.test.ts
@@ -1,13 +1,6 @@
 import { DataSource, BaseEntity } from 'typeorm';
-import crypto from 'crypto';
 
 import { Commodity } from '../../entities';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('Commodity', () => {
   let instance: Commodity;

--- a/src/book/__tests__/entities/Price.test.ts
+++ b/src/book/__tests__/entities/Price.test.ts
@@ -1,17 +1,10 @@
 import { DateTime } from 'luxon';
 import { DataSource, BaseEntity } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   Commodity,
   Price,
 } from '../../entities';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('Price', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/entities/Split.test.ts
+++ b/src/book/__tests__/entities/Split.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   BaseEntity,
@@ -9,12 +8,6 @@ import {
   Split,
   Account,
 } from '../../entities';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('Split', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   BaseEntity,
@@ -9,12 +8,6 @@ import {
   Split,
   Account,
 } from '../../entities';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('Transaction', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/models/InvestmentAccount.test.ts
+++ b/src/book/__tests__/models/InvestmentAccount.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import { InvestmentAccount } from '../../models';
 import {
@@ -12,12 +11,6 @@ import {
 } from '../../entities';
 import { PriceDB, PriceDBMap } from '../../prices';
 import Money from '../../Money';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('InvestmentAccount', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/prices/PriceDB.test.ts
+++ b/src/book/__tests__/prices/PriceDB.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import { PriceDB } from '../../prices';
 import {
@@ -12,12 +11,6 @@ import {
 } from '../../entities';
 import Stocker from '../../../apis/Stocker';
 import { toFixed } from '../../../helpers/number';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('PriceDB', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/prices/PriceDBMap.test.ts
+++ b/src/book/__tests__/prices/PriceDBMap.test.ts
@@ -1,15 +1,8 @@
 import { DateTime } from 'luxon';
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import { Commodity, Price } from '../../entities';
 import PriceDBMap from '../../prices/PriceDBMap';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('PriceDBMap', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/queries/getAccountsWithPath.test.ts
+++ b/src/book/__tests__/queries/getAccountsWithPath.test.ts
@@ -1,5 +1,4 @@
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   Account,
@@ -9,12 +8,6 @@ import {
   Transaction,
 } from '../../entities';
 import { getAccountsWithPath } from '../../queries';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('getAbsolutePaths', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/queries/getInvestments.test.ts
+++ b/src/book/__tests__/queries/getInvestments.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   Account,
@@ -16,12 +15,6 @@ import { InvestmentAccount } from '../../models';
 jest.mock('../../models', () => ({
   InvestmentAccount: jest.fn(),
 }));
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('getInvestments', () => {
   let datasource: DataSource;

--- a/src/book/__tests__/queries/getMainCurrency.test.ts
+++ b/src/book/__tests__/queries/getMainCurrency.test.ts
@@ -1,5 +1,4 @@
 import { DataSource } from 'typeorm';
-import crypto from 'crypto';
 
 import {
   Account,
@@ -8,12 +7,6 @@ import {
   Transaction,
 } from '../../entities';
 import { getMainCurrency } from '../../queries';
-
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    randomUUID: () => crypto.randomUUID(),
-  },
-});
 
 describe('getMainCurrency', () => {
   let eur: Commodity;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -10,9 +10,13 @@ export type ModalProps = {
 export default function Modal({
   open, setOpen, title, children,
 }: ModalProps): JSX.Element {
+  if (!open) {
+    return <span />;
+  }
+
   return (
     <div
-      className={`fixed ${open ? 'visible' : 'hidden'} inset-0 bg-white bg-opacity-30 overflow-y-auto h-full w-full z-50`}
+      className="fixed inset-0 bg-white bg-opacity-30 overflow-y-auto h-full w-full z-50"
       id="my-modal"
     >
       <div

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -54,7 +54,7 @@ export default function Table<T extends object = {}>(
 
   return (
     <>
-      <div className="relative overflow-x-auto">
+      <div className="relative overflow-hidden">
         <table className="w-full text-sm text-left">
           {
             showHeader

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -130,7 +130,7 @@ function FromToAccountPartial(
             <li key={split.guid}>
               <Link
                 href={`/dashboard/accounts/${split.account.guid}`}
-                className={classNames('badge', {
+                className={classNames('badge hover:text-slate-300', {
                   'bg-green-500/20 text-green-300': split.account.type === 'INCOME',
                   'bg-red-500/20 text-red-300': split.account.type === 'EXPENSE',
                   'bg-cyan-500/20 text-cyan-300': ['ASSET', 'BANK'].includes(split.account.type),

--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React from 'react';
+import dynamic from 'next/dynamic';
+import { ApexOptions } from 'apexcharts';
+
+import { toFixed } from '@/helpers/number';
+
+export type ChartProps = {
+  type: 'line' | 'bar' | 'pie' | 'donut',
+  series?: ApexOptions['series'],
+  labels?: string[],
+  title?: string,
+  showLegend?: boolean,
+  xCategories?: string[],
+  hideSeries?: string[],
+  unit?: string,
+  height?: number,
+  xAxisType?: 'datetime' | 'category' | 'numeric' | undefined,
+};
+
+// apexcharts import references window so we need this
+// https://stackoverflow.com/questions/68596778
+// However, I haven't found a neat way to fix types that's why
+// we need the ts-ignore in the return.
+const ApexChart = dynamic(
+  () => import('react-apexcharts').then((module) => module.default),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  },
+);
+
+export default function Chart({
+  type,
+  title = '',
+  series = [],
+  labels = [],
+  showLegend = true,
+  xCategories = [],
+  hideSeries = [],
+  unit = '',
+  height = 400,
+  xAxisType = undefined,
+}: ChartProps): JSX.Element {
+  if (!series?.length) {
+    return (
+      <span>Loading...</span>
+    );
+  }
+
+  let options = OPTIONS;
+  options = {
+    ...options,
+    labels,
+    chart: {
+      ...options.chart,
+      id: title,
+      events: {
+        mounted: (chart) => hideSeries.forEach(name => {
+          try {
+            chart.hideSeries(name);
+          } catch {
+            // this fails sometimes for some reason but still renders
+            // as expected. Adding the catch to protect against that.
+          }
+        }),
+      },
+    },
+    legend: {
+      show: showLegend,
+    },
+    title: {
+      text: title,
+      align: 'left',
+    },
+    xaxis: {
+      ...options.xaxis,
+      categories: xCategories,
+      type: xAxisType,
+    },
+    yaxis: {
+      labels: {
+        formatter: (val: number) => `${toFixed(val)} ${unit}`,
+      },
+    },
+    tooltip: {
+      ...options.tooltip,
+      y: {
+        formatter: (val: number) => `${toFixed(val)} ${unit}`,
+      },
+    },
+    stroke: {
+      ...options.stroke,
+      width: type === 'line' ? 1 : 0,
+      dashArray: type === 'line' ? 5 : 0,
+    },
+  };
+
+  return (
+    // @ts-ignore
+    <ApexChart
+      options={options}
+      series={series}
+      type={type}
+      className="apex-charts"
+      // https://stackoverflow.com/questions/75103994
+      width="100%"
+      height={height}
+    />
+  );
+}
+
+const OPTIONS: ApexOptions = {
+  grid: {
+    borderColor: '#777f85',
+  },
+  chart: {
+    id: 'line',
+    width: '100%',
+    foreColor: '#94A3B8',
+    toolbar: {
+      show: false,
+    },
+    zoom: {
+      type: 'x',
+      enabled: true,
+      autoScaleYaxis: true,
+    },
+  },
+  stroke: {
+    dashArray: 5,
+    curve: 'smooth',
+  },
+  xaxis: {
+    axisBorder: {
+      show: false,
+    },
+  },
+  plotOptions: {
+    bar: {
+      horizontal: false,
+      columnWidth: '55%',
+    },
+  },
+  dataLabels: {
+    enabled: false,
+  },
+  tooltip: {
+    fillSeriesColor: true,
+    x: {
+      show: false,
+    },
+    theme: 'dark',
+    intersect: true,
+    inverseOrder: true,
+    shared: false,
+  },
+};

--- a/src/components/equities/StatisticsWidget.tsx
+++ b/src/components/equities/StatisticsWidget.tsx
@@ -4,6 +4,7 @@ export type StatisticsWidgetProps = {
   title: string,
   stats: string,
   description: string,
+  className?: string,
   statsTextClass?: string,
 };
 
@@ -11,10 +12,11 @@ export default function StatisticsWidget({
   title,
   stats,
   description,
+  className = '',
   statsTextClass = '',
 }: StatisticsWidgetProps): JSX.Element {
   return (
-    <div className="bg-gunmetal-700 rounded-sm mx-6 p-6">
+    <div className={`${className} bg-gunmetal-700 rounded-sm p-6`}>
       <p>
         {title}
       </p>

--- a/src/components/pages/account/SplitsHistogram.tsx
+++ b/src/components/pages/account/SplitsHistogram.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { ApexOptions } from 'apexcharts';
+
+import Chart from '@/components/charts/Chart';
+import { Split } from '@/book/entities';
+import { currencyToSymbol } from '@/book/helpers';
+
+const MONTHS: { [key:number]:string; } = {
+  1: 'Jan',
+  2: 'Feb',
+  3: 'Mar',
+  4: 'Apr',
+  5: 'May',
+  6: 'Jun',
+  7: 'Jul',
+  8: 'Aug',
+  9: 'Sep',
+  10: 'Oct',
+  11: 'Nov',
+  12: 'Dec',
+};
+
+export type SplitsHistogramProps = {
+  splits: Split[],
+};
+
+export default function SplitsHistogram({
+  splits,
+}: SplitsHistogramProps): JSX.Element {
+  const yearlyAggregate: { [year: string]: { [month: string]: number } } = {};
+
+  splits.forEach(split => {
+    const { year, month } = split.transaction.date;
+    const yearData = yearlyAggregate[year] || {};
+    let { quantity } = split;
+    if (split.account.type === 'INCOME') {
+      quantity = -quantity;
+    }
+    yearData[month] = (yearData[month] || 0) + quantity;
+    yearlyAggregate[year] = yearData;
+  });
+
+  const series: ApexOptions['series'] = [];
+  const hiddenSeries: string[] = [];
+
+  Object.keys(yearlyAggregate).forEach((year, index) => {
+    Object.keys(MONTHS).forEach(month => {
+      if (!series[index]) {
+        series[index] = {
+          name: year,
+          data: [],
+        };
+      }
+
+      // @ts-ignore not sure why data type is wrong here...
+      series[index].data.push({
+        x: `${MONTHS[Number(month)]}`,
+        y: yearlyAggregate[year][month] || 0,
+      });
+    });
+
+    hiddenSeries.push(year);
+  });
+
+  hiddenSeries.pop();
+
+  return (
+    <div className="bg-gunmetal-700 rounded-sm mb-6 p-4">
+      <Chart
+        type="bar"
+        series={series}
+        title="Total per month"
+        xCategories={Object.values(MONTHS)}
+        hideSeries={hiddenSeries}
+        unit={currencyToSymbol(splits[0]?.account.commodity.mnemonic || '')}
+      />
+    </div>
+  );
+}

--- a/src/components/pages/account/TotalLineChart.tsx
+++ b/src/components/pages/account/TotalLineChart.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ApexOptions } from 'apexcharts';
+
+import Chart from '@/components/charts/Chart';
+import { Split } from '@/book/entities';
+import { currencyToSymbol } from '@/book/helpers';
+
+export type TotalLineChartProps = {
+  splits: Split[],
+};
+
+export default function TotalLineChart({
+  splits,
+}: TotalLineChartProps): JSX.Element {
+  const series: ApexOptions['series'] = [{ data: [] }];
+
+  let totalAggregate = 0;
+  splits.slice().reverse().forEach(split => {
+    let { quantity } = split;
+    if (split.account.type === 'INCOME') {
+      quantity = -quantity;
+    }
+    totalAggregate += quantity;
+
+    (series[0].data as { x: number, y: number }[]).push({
+      x: split.transaction.date.toMillis(),
+      y: totalAggregate,
+    });
+  });
+
+  return (
+    <div className="bg-gunmetal-700 rounded-sm my-6 mr-6">
+      <Chart
+        type="line"
+        series={series}
+        unit={currencyToSymbol(splits[0]?.account.commodity.mnemonic || '')}
+        height={255}
+        xAxisType="datetime"
+      />
+    </div>
+  );
+}

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -33,7 +33,7 @@
   }
 
   .badge {
-    @apply bg-slate-500/20 text-slate-300 inline-block my-1 px-1 py-1 text-xs text-center rounded-md hover:text-slate-300
+    @apply bg-slate-500/20 text-slate-300 inline-block my-1 px-1 py-1 text-xs text-center rounded-md
   }
 
   button.link {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,10 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import crypto from 'crypto';
+
+Object.defineProperty(global.self, 'crypto', {
+  value: {
+    randomUUID: () => crypto.randomUUID(),
+  },
+});


### PR DESCRIPTION
Adds some graphs and widgets to the Account detail page showing total per month, progression of the account over years and others.