### PR TITLE
Fix splits balance validator

### DIFF
--- a/src/__tests__/components/forms/transaction/__snapshots__/SplitField.test.tsx.snap
+++ b/src/__tests__/components/forms/transaction/__snapshots__/SplitField.test.tsx.snap
@@ -125,7 +125,6 @@ exports[`SplitField renders with empty data 1`] = `
         class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
         disabled=""
         name="splits.0.quantity"
-        placeholder="0"
         step="0.001"
         type="number"
       />
@@ -144,7 +143,6 @@ exports[`SplitField renders with empty data 1`] = `
         class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
         disabled=""
         name="splits.0.value"
-        placeholder="0"
         step="0.001"
         type="number"
       />
@@ -266,7 +264,6 @@ exports[`SplitField renders with empty data 1`] = `
         class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
         disabled=""
         name="splits.1.quantity"
-        placeholder="0"
         step="0.001"
         type="number"
       />
@@ -285,7 +282,6 @@ exports[`SplitField renders with empty data 1`] = `
         class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
         disabled=""
         name="splits.1.value"
-        placeholder="0"
         step="0.001"
         type="number"
       />

--- a/src/__tests__/components/forms/transaction/__snapshots__/SplitsField.test.tsx.snap
+++ b/src/__tests__/components/forms/transaction/__snapshots__/SplitsField.test.tsx.snap
@@ -132,7 +132,6 @@ exports[`SplitsField renders SplitField 1`] = `
               class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
               disabled=""
               name="splits.0.quantity"
-              placeholder="0"
               step="0.001"
               type="number"
             />
@@ -151,7 +150,6 @@ exports[`SplitsField renders SplitField 1`] = `
               class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
               disabled=""
               name="splits.0.value"
-              placeholder="0"
               step="0.001"
               type="number"
             />
@@ -302,7 +300,6 @@ exports[`SplitsField renders SplitField 1`] = `
               class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
               disabled=""
               name="splits.1.quantity"
-              placeholder="0"
               step="0.001"
               type="number"
             />
@@ -321,7 +318,6 @@ exports[`SplitsField renders SplitField 1`] = `
               class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
               disabled=""
               name="splits.1.value"
-              placeholder="0"
               step="0.001"
               type="number"
             />

--- a/src/__tests__/components/forms/transaction/__snapshots__/TransactionForm.test.tsx.snap
+++ b/src/__tests__/components/forms/transaction/__snapshots__/TransactionForm.test.tsx.snap
@@ -174,7 +174,6 @@ exports[`TransactionForm renders as expected with action add 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.0.quantity"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -193,7 +192,6 @@ exports[`TransactionForm renders as expected with action add 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.0.value"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -344,7 +342,6 @@ exports[`TransactionForm renders as expected with action add 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.1.quantity"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -363,7 +360,6 @@ exports[`TransactionForm renders as expected with action add 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.1.value"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -577,7 +573,6 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.0.quantity"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -596,7 +591,6 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.0.value"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -743,7 +737,6 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.1.quantity"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -762,7 +755,6 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.1.value"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -972,7 +964,6 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.0.quantity"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -991,7 +982,6 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.0.value"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -1142,7 +1132,6 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.1.quantity"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />
@@ -1161,7 +1150,6 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                 class="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
                 disabled=""
                 name="splits.1.value"
-                placeholder="0"
                 step="0.001"
                 type="number"
               />

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -201,6 +201,32 @@ describe('Transaction', () => {
       await expect(tx.save()).rejects.toThrow('splitsBalance');
     });
 
+    it('doesnt fail when floating point error', async () => {
+      const split1 = new Split();
+      split1.value = -86.56;
+      split1.fk_account = account;
+      const split2 = new Split();
+      split2.value = 55;
+      split2.fk_account = account2;
+      const split3 = new Split();
+      split3.value = 31.56;
+      split3.fk_account = Account.create({
+        name: 'Expenses2',
+        type: 'EXPENSE',
+        parent: root,
+        fk_commodity: eur,
+      });
+
+      const tx = Transaction.create({
+        description: 'description',
+        fk_currency: eur,
+        date: DateTime.fromISO('2023-01-01'),
+        splits: [split1, split2, split3],
+      });
+
+      await expect(tx.save()).rejects.not.toThrow('splitsBalance');
+    });
+
     it('fails if splits have duplicated accounts', async () => {
       const split1 = new Split();
       split1.fk_account = account;

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -96,7 +96,8 @@ function CheckSplitsBalance(validationOptions?: v.ValidationOptions) {
               0,
             );
 
-            return total === 0;
+            // Correct for floating point errors
+            return toFixed(total, 4) === 0;
           }
 
           return true;

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -33,9 +33,9 @@ export default function SplitField({
   const showValueField = account && account.commodity.guid !== txCurrency?.guid;
 
   async function onQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const q = e.target.value;
+    const q = Number(e.target.value);
     let rate = 1;
-    if (showValueField) {
+    if (showValueField && q !== 0) {
       rate = await getExchangeRate(
         account,
         txCurrency,
@@ -90,7 +90,7 @@ export default function SplitField({
         <span
           className="absolute px-1 py-2"
         >
-          {currencyToSymbol(account?.commodity?.mnemonic || '')}
+          {currencyToSymbol(account?.commodity?.mnemonic || '').slice(0, 3)}
         </span>
         <input
           {...form.register(
@@ -102,7 +102,6 @@ export default function SplitField({
           aria-label={`splits.${index}.quantity`}
           disabled={disableValueInputs}
           className="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
-          placeholder="0"
           type="number"
           step="0.001"
           onChange={(e) => {
@@ -134,7 +133,6 @@ export default function SplitField({
           aria-label={`splits.${index}.value`}
           disabled={disableValueInputs}
           className="w-full pl-4 text-right bg-gunmetal-800 border-none rounded-sm m-0"
-          placeholder="0"
           type="number"
           step="0.001"
         />


### PR DESCRIPTION
Fixes #101 

As an extra, it also fixes another bug where we would call `getExchangeRate` for values of 0 which would trigger errors and disallow us to add dividend splits