### PR TITLE
Support for dividends in different currencies

### DIFF
--- a/src/__tests__/components/buttons/TransactionFormButton.test.tsx
+++ b/src/__tests__/components/buttons/TransactionFormButton.test.tsx
@@ -5,7 +5,6 @@ import {
   screen,
   fireEvent,
 } from '@testing-library/react';
-import * as swr from 'swr';
 
 import type { Commodity, Split } from '@/book/entities';
 import TransactionFormButton from '@/components/buttons/TransactionFormButton';
@@ -13,8 +12,6 @@ import TransactionForm from '@/components/forms/transaction/TransactionForm';
 import Modal from '@/components/Modal';
 import type { UseDataSourceReturn } from '@/hooks';
 import * as dataSourceHooks from '@/hooks/useDataSource';
-
-jest.mock('swr');
 
 jest.mock('@/components/Modal', () => jest.fn(
   (props: React.PropsWithChildren) => (
@@ -133,9 +130,6 @@ describe('TransactionFormButton', () => {
 
     const { onSave } = TransactionFormMock.mock.calls[0][0];
     act(() => onSave());
-    expect(swr.mutate).toBeCalledTimes(2);
-    expect(swr.mutate).toHaveBeenNthCalledWith(1, '/api/splits/1');
-    expect(swr.mutate).toHaveBeenNthCalledWith(2, '/api/splits/2');
     expect(mockSave).toBeCalledTimes(1);
 
     expect(Modal).toHaveBeenLastCalledWith(

--- a/src/components/buttons/TransactionFormButton.tsx
+++ b/src/components/buttons/TransactionFormButton.tsx
@@ -44,7 +44,6 @@ export default function TransactionFormButton(
           action={action}
           onSave={() => {
             save();
-            (defaultValues?.splits || []).forEach(split => mutate(`/api/splits/${split.account.guid}`));
             setIsModalOpen(false);
           }}
           defaultValues={defaultValues}

--- a/src/components/forms/transaction/TransactionForm.tsx
+++ b/src/components/forms/transaction/TransactionForm.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { DateTime } from 'luxon';
 import { useForm } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';
+import { mutate } from 'swr';
 
 import {
   Split,
   Transaction,
 } from '@/book/entities';
+import { isInvestment } from '@/book/helpers/accountType';
 import SplitsField from './SplitsField';
 import type { FormValues } from './types';
 
@@ -122,5 +124,11 @@ async function onSubmit(data: FormValues, action: 'add' | 'update' | 'delete', o
     await transaction.remove();
   }
 
+  transaction.splits.forEach(split => {
+    if (isInvestment(split.account)) {
+      mutate('/api/investments');
+    }
+    mutate(`/api/splits/${split.account.guid}`);
+  });
   onSave();
 }


### PR DESCRIPTION
In a change we introduced in https://github.com/maffin-io/maffin-app/commit/dca62c03ab2f67abd681772219b1a9f0a81a4f07#diff-28a1eddf39fdf2988e181547dae13df9391fab5a9623fa0df533fc11ef8ea214R75 we changed the way the transaction's currency is selected. Now, if one of the accounts has mainCurrency as currency, that's the transaction's currency. This created some issues with the previous code we had for storing dividends and this solves it.