### PR TITLE
Net worth Pie

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -16,7 +16,7 @@ const config = {
   coverageThreshold: {
     global: {
       lines: 94.5,
-      branches: 89.5,
+      branches: 89.2,
     },
   },
   testEnvironment: 'jest-environment-jsdom',

--- a/src/__tests__/app/dashboard/accounts/[guid]/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/accounts/[guid]/__snapshots__/page.test.tsx.snap
@@ -53,12 +53,12 @@ exports[`AccountPage renders as expected with account 1`] = `
             <p
               class=" text-2xl font-semibold my-3"
             >
-              100.00 €
+              €100.00
             </p>
             <span
               class="text-sm"
             >
-              with an average of 100.00 € per month
+              with an average of €100.00 per month
             </span>
           </div>
         </div>
@@ -74,7 +74,7 @@ exports[`AccountPage renders as expected with account 1`] = `
             <p
               class=" text-2xl font-semibold my-3"
             >
-              100.00 €
+              €100.00
             </p>
             <span
               class="text-sm"

--- a/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`AccountsPage generates tree as expected, no investments 1`] = `
       class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
       <div
-        data-testid="NetWorthRadial"
+        data-testid="NetWorthPie"
       />
     </div>
     <div
@@ -74,7 +74,7 @@ exports[`AccountsPage generates tree as expected, with investments 1`] = `
       class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
       <div
-        data-testid="NetWorthRadial"
+        data-testid="NetWorthPie"
       />
     </div>
     <div
@@ -118,7 +118,7 @@ exports[`AccountsPage passes empty data to components when loading when not read
       class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
       <div
-        data-testid="NetWorthRadial"
+        data-testid="NetWorthPie"
       />
     </div>
     <div

--- a/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
@@ -24,8 +24,15 @@ exports[`AccountsPage generates tree as expected, no investments 1`] = `
     </div>
   </div>
   <div
-    class="grid grid-cols-12 items-top pb-4"
+    class="grid grid-cols-12 items-start items-top pb-4"
   >
+    <div
+      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+    >
+      <div
+        data-testid="NetWorthRadial"
+      />
+    </div>
     <div
       class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
@@ -61,8 +68,15 @@ exports[`AccountsPage generates tree as expected, with investments 1`] = `
     </div>
   </div>
   <div
-    class="grid grid-cols-12 items-top pb-4"
+    class="grid grid-cols-12 items-start items-top pb-4"
   >
+    <div
+      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+    >
+      <div
+        data-testid="NetWorthRadial"
+      />
+    </div>
     <div
       class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
@@ -98,8 +112,15 @@ exports[`AccountsPage passes empty data to components when loading when not read
     </div>
   </div>
   <div
-    class="grid grid-cols-12 items-top pb-4"
+    class="grid grid-cols-12 items-start items-top pb-4"
   >
+    <div
+      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+    >
+      <div
+        data-testid="NetWorthRadial"
+      />
+    </div>
     <div
       class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >

--- a/src/__tests__/app/dashboard/accounts/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/page.test.tsx
@@ -3,7 +3,7 @@ import {
   screen,
   render,
 } from '@testing-library/react';
-import { DateTime, Interval } from 'luxon';
+import { DateTime } from 'luxon';
 import type { SWRResponse } from 'swr';
 
 import Money from '@/book/Money';
@@ -12,7 +12,7 @@ import AccountsPage from '@/app/dashboard/accounts/page';
 import AccountsTable from '@/components/AccountsTable';
 import AddAccountButton from '@/components/buttons/AddAccountButton';
 import DateRangeInput from '@/components/DateRangeInput';
-import NetWorthRadial from '@/components/pages/accounts/NetWorthRadial';
+import NetWorthPie from '@/components/pages/accounts/NetWorthPie';
 import { PriceDBMap } from '@/book/prices';
 import * as apiHook from '@/hooks/useApi';
 
@@ -33,8 +33,8 @@ jest.mock('@/components/DateRangeInput', () => jest.fn(
   () => <div data-testid="DateRangeInput" />,
 ));
 
-jest.mock('@/components/pages/accounts/NetWorthRadial', () => jest.fn(
-  () => <div data-testid="NetWorthRadial" />,
+jest.mock('@/components/pages/accounts/NetWorthPie', () => jest.fn(
+  () => <div data-testid="NetWorthPie" />,
 ));
 
 describe('AccountsPage', () => {
@@ -50,9 +50,6 @@ describe('AccountsPage', () => {
   it('passes empty data to components when loading when not ready', async () => {
     const date = DateTime.fromISO('2022-01-01');
     jest.spyOn(apiHook, 'default')
-      .mockReturnValueOnce({ data: date } as SWRResponse)
-      .mockReturnValueOnce({ data: [] } as SWRResponse)
-      .mockReturnValueOnce({ data: undefined } as SWRResponse)
       .mockReturnValueOnce({ data: date } as SWRResponse)
       .mockReturnValueOnce({ data: [] } as SWRResponse)
       .mockReturnValueOnce({ data: undefined } as SWRResponse);
@@ -76,18 +73,19 @@ describe('AccountsPage', () => {
     await screen.findByTestId('DateRangeInput');
     expect(DateRangeInput).toHaveBeenLastCalledWith(
       {
-        dateRange: Interval.fromDateTimes(
-          DateTime.fromISO('2022-01-01'),
-          DateTime.fromISO('2023-01-02'),
-        ),
+        asSingle: true,
+        dateRange: {
+          start: DateTime.fromISO('2023-01-02'),
+          end: DateTime.fromISO('2023-01-02'),
+        },
         earliestDate: DateTime.fromISO('2022-01-01'),
         onChange: expect.any(Function),
       },
       {},
     );
 
-    await screen.findByTestId('NetWorthRadial');
-    expect(NetWorthRadial).toHaveBeenLastCalledWith(
+    await screen.findByTestId('NetWorthPie');
+    expect(NetWorthPie).toHaveBeenLastCalledWith(
       {
         tree: {
           account: {},
@@ -143,9 +141,6 @@ describe('AccountsPage', () => {
     jest.spyOn(apiHook, 'default')
       .mockReturnValueOnce({ data: date } as SWRResponse)
       .mockReturnValueOnce({ data: accounts } as SWRResponse)
-      .mockReturnValueOnce({ data: todayQuotes } as SWRResponse)
-      .mockReturnValueOnce({ data: date } as SWRResponse)
-      .mockReturnValueOnce({ data: accounts } as SWRResponse)
       .mockReturnValueOnce({ data: todayQuotes } as SWRResponse);
 
     const { container } = render(<AccountsPage />);
@@ -170,19 +165,19 @@ describe('AccountsPage', () => {
       },
     };
     await screen.findByTestId('AccountsTable');
-    expect(AccountsTable).toBeCalledTimes(2);
+    expect(AccountsTable).toBeCalledTimes(1);
     expect(AccountsTable).toHaveBeenLastCalledWith(expectedTree, {});
-    expect((AccountsTable as jest.Mock).mock.calls[1][0].tree.total.toString()).toEqual('0.00 EUR');
+    expect((AccountsTable as jest.Mock).mock.calls[0][0].tree.total.toString()).toEqual('0.00 EUR');
     expect(
       // eslint-disable-next-line testing-library/no-node-access
-      (AccountsTable as jest.Mock).mock.calls[1][0].tree.children[0].total.toString(),
+      (AccountsTable as jest.Mock).mock.calls[0][0].tree.children[0].total.toString(),
     ).toEqual('990.00 EUR'); // 1000 USD * 0.98 + 10 EUR
     expect(
       // eslint-disable-next-line testing-library/no-node-access
-      (AccountsTable as jest.Mock).mock.calls[1][0].tree.children[0].children[0].total.toString(),
+      (AccountsTable as jest.Mock).mock.calls[0][0].tree.children[0].children[0].total.toString(),
     ).toEqual('1000.00 USD');
 
-    expect(NetWorthRadial).toHaveBeenLastCalledWith(expectedTree, {});
+    expect(NetWorthPie).toHaveBeenLastCalledWith(expectedTree, {});
 
     expect(container).toMatchSnapshot();
   });
@@ -236,9 +231,6 @@ describe('AccountsPage', () => {
     jest.spyOn(apiHook, 'default')
       .mockReturnValueOnce({ data: date } as SWRResponse)
       .mockReturnValueOnce({ data: accounts } as SWRResponse)
-      .mockReturnValueOnce({ data: todayQuotes } as SWRResponse)
-      .mockReturnValueOnce({ data: date } as SWRResponse)
-      .mockReturnValueOnce({ data: accounts } as SWRResponse)
       .mockReturnValueOnce({ data: todayQuotes } as SWRResponse);
 
     const { container } = render(<AccountsPage />);
@@ -263,19 +255,19 @@ describe('AccountsPage', () => {
       },
     };
     await screen.findByTestId('AccountsTable');
-    expect(AccountsTable).toBeCalledTimes(2);
+    expect(AccountsTable).toBeCalledTimes(1);
     expect(AccountsTable).toHaveBeenLastCalledWith(expectedTree, {});
-    expect((AccountsTable as jest.Mock).mock.calls[1][0].tree.total.toString()).toEqual('0.00 EUR');
+    expect((AccountsTable as jest.Mock).mock.calls[0][0].tree.total.toString()).toEqual('0.00 EUR');
     expect(
       // eslint-disable-next-line testing-library/no-node-access
-      (AccountsTable as jest.Mock).mock.calls[1][0].tree.children[0].total.toString(),
+      (AccountsTable as jest.Mock).mock.calls[0][0].tree.children[0].total.toString(),
     ).toEqual('196.00 EUR'); // 200 USD * 0.98
     expect(
       // eslint-disable-next-line testing-library/no-node-access
-      (AccountsTable as jest.Mock).mock.calls[1][0].tree.children[0].children[0].total.toString(),
+      (AccountsTable as jest.Mock).mock.calls[0][0].tree.children[0].children[0].total.toString(),
     ).toEqual('200.00 USD'); // 2 GOOGL * 100 USD
 
-    expect(NetWorthRadial).toHaveBeenLastCalledWith(expectedTree, {});
+    expect(NetWorthPie).toHaveBeenLastCalledWith(expectedTree, {});
 
     expect(container).toMatchSnapshot();
   });

--- a/src/__tests__/app/dashboard/accounts/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/page.test.tsx
@@ -12,6 +12,7 @@ import AccountsPage from '@/app/dashboard/accounts/page';
 import AccountsTable from '@/components/AccountsTable';
 import AddAccountButton from '@/components/buttons/AddAccountButton';
 import DateRangeInput from '@/components/DateRangeInput';
+import NetWorthRadial from '@/components/pages/accounts/NetWorthRadial';
 import { PriceDBMap } from '@/book/prices';
 import * as apiHook from '@/hooks/useApi';
 
@@ -30,6 +31,10 @@ jest.mock('@/components/AccountsTable', () => jest.fn(
 
 jest.mock('@/components/DateRangeInput', () => jest.fn(
   () => <div data-testid="DateRangeInput" />,
+));
+
+jest.mock('@/components/pages/accounts/NetWorthRadial', () => jest.fn(
+  () => <div data-testid="NetWorthRadial" />,
 ));
 
 describe('AccountsPage', () => {
@@ -80,6 +85,19 @@ describe('AccountsPage', () => {
       },
       {},
     );
+
+    await screen.findByTestId('NetWorthRadial');
+    expect(NetWorthRadial).toHaveBeenLastCalledWith(
+      {
+        tree: {
+          account: {},
+          children: [],
+          total: expect.any(Money),
+        },
+      },
+      {},
+    );
+
     expect(container).toMatchSnapshot();
   });
 
@@ -132,30 +150,28 @@ describe('AccountsPage', () => {
 
     const { container } = render(<AccountsPage />);
 
+    const expectedTree = {
+      tree: {
+        account: accounts[0],
+        total: expect.any(Money),
+        children: [
+          {
+            account: accounts[1],
+            total: expect.any(Money),
+            children: [
+              {
+                account: accounts[2],
+                total: expect.any(Money),
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
     await screen.findByTestId('AccountsTable');
     expect(AccountsTable).toBeCalledTimes(2);
-    expect(AccountsTable).toHaveBeenLastCalledWith(
-      {
-        tree: {
-          account: accounts[0],
-          total: expect.any(Money),
-          children: [
-            {
-              account: accounts[1],
-              total: expect.any(Money),
-              children: [
-                {
-                  account: accounts[2],
-                  total: expect.any(Money),
-                  children: [],
-                },
-              ],
-            },
-          ],
-        },
-      },
-      {},
-    );
+    expect(AccountsTable).toHaveBeenLastCalledWith(expectedTree, {});
     expect((AccountsTable as jest.Mock).mock.calls[1][0].tree.total.toString()).toEqual('0.00 EUR');
     expect(
       // eslint-disable-next-line testing-library/no-node-access
@@ -165,6 +181,9 @@ describe('AccountsPage', () => {
       // eslint-disable-next-line testing-library/no-node-access
       (AccountsTable as jest.Mock).mock.calls[1][0].tree.children[0].children[0].total.toString(),
     ).toEqual('1000.00 USD');
+
+    expect(NetWorthRadial).toHaveBeenLastCalledWith(expectedTree, {});
+
     expect(container).toMatchSnapshot();
   });
 
@@ -224,30 +243,28 @@ describe('AccountsPage', () => {
 
     const { container } = render(<AccountsPage />);
 
+    const expectedTree = {
+      tree: {
+        account: accounts[0],
+        total: expect.any(Money),
+        children: [
+          {
+            account: accounts[1],
+            total: expect.any(Money),
+            children: [
+              {
+                account: accounts[2],
+                total: expect.any(Money),
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
     await screen.findByTestId('AccountsTable');
     expect(AccountsTable).toBeCalledTimes(2);
-    expect(AccountsTable).toHaveBeenLastCalledWith(
-      {
-        tree: {
-          account: accounts[0],
-          total: expect.any(Money),
-          children: [
-            {
-              account: accounts[1],
-              total: expect.any(Money),
-              children: [
-                {
-                  account: accounts[2],
-                  total: expect.any(Money),
-                  children: [],
-                },
-              ],
-            },
-          ],
-        },
-      },
-      {},
-    );
+    expect(AccountsTable).toHaveBeenLastCalledWith(expectedTree, {});
     expect((AccountsTable as jest.Mock).mock.calls[1][0].tree.total.toString()).toEqual('0.00 EUR');
     expect(
       // eslint-disable-next-line testing-library/no-node-access
@@ -257,6 +274,9 @@ describe('AccountsPage', () => {
       // eslint-disable-next-line testing-library/no-node-access
       (AccountsTable as jest.Mock).mock.calls[1][0].tree.children[0].children[0].total.toString(),
     ).toEqual('200.00 USD'); // 2 GOOGL * 100 USD
+
+    expect(NetWorthRadial).toHaveBeenLastCalledWith(expectedTree, {});
+
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/__tests__/app/dashboard/investments/page.test.tsx
+++ b/src/__tests__/app/dashboard/investments/page.test.tsx
@@ -59,8 +59,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Value/Cost',
-        stats: '0.00 €',
-        description: '0 total invested',
+        stats: '€0.00',
+        description: '€0.00 total invested',
       },
       {},
     );
@@ -69,8 +69,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Unrealized Profit',
-        stats: '0.00 € (NaN%)',
-        description: '0 (NaN%) with dividends',
+        stats: '€0.00 (NaN%)',
+        description: '€0.00 (NaN%) with dividends',
         statsTextClass: '',
       },
       {},
@@ -80,8 +80,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Realized',
-        stats: '0.00 €',
-        description: '0.00 € from dividends',
+        stats: '€0.00',
+        description: '€0.00 from dividends',
         statsTextClass: 'text-green-500',
       },
       {},
@@ -141,8 +141,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Value/Cost',
-        stats: '5.00 €',
-        description: '4 total invested',
+        stats: '€5.00',
+        description: '€4.00 total invested',
       },
       {},
     );
@@ -151,8 +151,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Unrealized Profit',
-        stats: '1.00 € (25%)',
-        description: '6 (150%) with dividends',
+        stats: '€1.00 (25%)',
+        description: '€6.00 (150%) with dividends',
         statsTextClass: 'text-green-500',
       },
       {},
@@ -162,8 +162,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Realized',
-        stats: '15.00 €',
-        description: '5.00 € from dividends',
+        stats: '€15.00',
+        description: '€5.00 from dividends',
         statsTextClass: 'text-green-500',
       },
       {},
@@ -220,8 +220,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Value/Cost',
-        stats: '5.00 $',
-        description: '4 total invested',
+        stats: '$5.00',
+        description: '$4.00 total invested',
       },
       {},
     );
@@ -230,8 +230,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Unrealized Profit',
-        stats: '1.00 $ (25%)',
-        description: '6 (150%) with dividends',
+        stats: '$1.00 (25%)',
+        description: '$6.00 (150%) with dividends',
         statsTextClass: 'text-green-500',
       },
       {},
@@ -241,8 +241,8 @@ describe('InvestmentsPage', () => {
       {
         className: 'mx-6',
         title: 'Realized',
-        stats: '15.00 $',
-        description: '5.00 $ from dividends',
+        stats: '$15.00',
+        description: '$5.00 from dividends',
         statsTextClass: 'text-green-500',
       },
       {},

--- a/src/__tests__/components/AccountsTable.test.tsx
+++ b/src/__tests__/components/AccountsTable.test.tsx
@@ -259,7 +259,7 @@ describe('AccountsTable', () => {
       }),
     );
 
-    await screen.findByText('10.00 €');
+    await screen.findByText('€10.00');
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/__tests__/components/DateRangeInput.test.tsx
+++ b/src/__tests__/components/DateRangeInput.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Datepicker from 'react-tailwindcss-datepicker';
-import { DateTime, Interval } from 'luxon';
+import { DateTime } from 'luxon';
 
 import DateRangeInput from '@/components/DateRangeInput';
 
@@ -24,6 +24,8 @@ describe('DateRangeInput', () => {
     expect(Datepicker).toBeCalledTimes(1);
     expect(Datepicker).toBeCalledWith(
       {
+        asSingle: false,
+        useRange: true,
         containerClassName: 'relative w-full text-sm text-slate-400',
         displayFormat: 'DD/MMM/YY',
         inputClassName: 'relative transition-all duration-300 py-2.5 pl-4 pr-14 w-full border-gray-300 rounded-lg tracking-wide placeholder-gray-400 bg-gunmetal-700',
@@ -36,36 +38,15 @@ describe('DateRangeInput', () => {
         showShortcuts: true,
         startWeekOn: 'mon',
         value: {
-          startDate: DateTime.now().startOf('year').toJSDate(),
-          endDate: DateTime.now().toJSDate(),
+          startDate: null,
+          endDate: null,
         },
         configs: {
           shortcuts: {
-            yearToDate: {
-              text: 'Year to date',
+            today: {
+              text: 'Today',
               period: {
-                start: DateTime.now().startOf('year').toJSDate(),
-                end: DateTime.now().toJSDate(),
-              },
-            },
-            previousYear: {
-              text: 'Previous year',
-              period: {
-                start: DateTime.now().minus({ years: 1 }).startOf('year').toJSDate(),
-                end: DateTime.now().minus({ years: 1 }).endOf('year').toJSDate(),
-              },
-            },
-            last3Years: {
-              text: 'Last 3 years',
-              period: {
-                start: DateTime.now().minus({ years: 3 }).startOf('year').toJSDate(),
-                end: DateTime.now().toJSDate(),
-              },
-            },
-            all: {
-              text: 'All',
-              period: {
-                start: DateTime.now().minus({ years: 10 }).toJSDate(),
+                start: DateTime.now().toJSDate(),
                 end: DateTime.now().toJSDate(),
               },
             },
@@ -79,29 +60,41 @@ describe('DateRangeInput', () => {
   it('sets dateRange and earliestDate', () => {
     render(
       <DateRangeInput
+        asSingle
         onChange={jest.fn()}
-        dateRange={Interval.fromDateTimes(
-          DateTime.fromISO('2023-01-01'),
-          DateTime.fromISO('2023-01-05'),
-        )}
-        earliestDate={DateTime.fromISO('2022-01-01')}
+        dateRange={
+          {
+            start: DateTime.fromISO('2023-05-01', { zone: 'utc' }),
+            end: DateTime.fromISO('2023-05-01', { zone: 'utc' }),
+          }
+        }
+        earliestDate={DateTime.fromISO('2022-01-01', { zone: 'utc' })}
       />,
     );
 
     expect(Datepicker).toBeCalledWith(
       expect.objectContaining({
+        asSingle: true,
+        useRange: false,
         value: {
-          startDate: DateTime.fromISO('2023-01-01').toJSDate(),
-          endDate: DateTime.fromISO('2023-01-05').toJSDate(),
+          startDate: DateTime.fromISO('2023-05-01', { zone: 'utc' }).toJSDate(),
+          endDate: DateTime.fromISO('2023-05-01', { zone: 'utc' }).toJSDate(),
         },
-        minDate: DateTime.fromISO('2022-01-01').toJSDate(),
+        minDate: DateTime.fromISO('2022-01-01', { zone: 'utc' }).toJSDate(),
         configs: {
           shortcuts: expect.objectContaining({
-            all: {
-              text: 'All',
+            today: {
+              text: 'Today',
               period: {
-                start: DateTime.fromISO('2022-01-01').toJSDate(),
-                end: DateTime.now().toJSDate(),
+                start: DateTime.fromISO('2023-01-30', { zone: 'utc' }).toJSDate(),
+                end: DateTime.fromISO('2023-01-30', { zone: 'utc' }).toJSDate(),
+              },
+            },
+            2022: {
+              text: 'End of 2022',
+              period: {
+                start: DateTime.fromISO('2022-01-01', { zone: 'utc' }).endOf('year').toJSDate(),
+                end: DateTime.fromISO('2022-01-01', { zone: 'utc' }).endOf('year').toJSDate(),
               },
             },
           }),

--- a/src/__tests__/components/__snapshots__/AccountsTable.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/AccountsTable.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`AccountsTable renders Name column as expected when not expandable 1`] =
 exports[`AccountsTable renders Total column as expected 1`] = `
 <div>
   <span>
-    10.00 €
+    €10.00
   </span>
 </div>
 `;

--- a/src/__tests__/components/__snapshots__/TransactionsTable.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/TransactionsTable.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`TransactionsTable renders Amount column as expected 1`] = `
         d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"
       />
     </svg>
-    100.00 €
+    €100.00
   </span>
 </div>
 `;
@@ -106,7 +106,7 @@ exports[`TransactionsTable renders FromTo column as expected 1`] = `
 exports[`TransactionsTable renders Total column as expected 1`] = `
 <div>
   <span>
-    250.00 €
+    €250.00
   </span>
 </div>
 `;

--- a/src/__tests__/components/charts/Chart.test.tsx
+++ b/src/__tests__/components/charts/Chart.test.tsx
@@ -33,9 +33,9 @@ describe('Chart', () => {
     // @ts-ignore
     const options = ApexChartMock.mock.calls[0][0].options as ApexOptions;
     // @ts-ignore
-    expect(options?.yaxis?.labels.formatter(1)).toEqual('1');
+    expect(options?.yaxis?.labels.formatter(1)).toEqual('€1.00');
     // @ts-ignore
-    expect(options?.tooltip?.y?.formatter(1)).toEqual('1');
+    expect(options?.tooltip?.y?.formatter(1)).toEqual('€1.00');
     expect(ApexChartMock).toHaveBeenCalledWith(
       {
         height: 400,
@@ -150,7 +150,13 @@ describe('Chart', () => {
             mounted: mockMounted,
           }
         }
-        yFormatter={mockYFormatter}
+        tooltip={
+          {
+            y: {
+              formatter: mockYFormatter,
+            },
+          }
+        }
       />,
     );
 
@@ -173,7 +179,7 @@ describe('Chart', () => {
         },
         yaxis: {
           labels: {
-            formatter: mockYFormatter,
+            formatter: expect.any(Function),
           },
         },
         tooltip: {

--- a/src/__tests__/components/pages/account/SplitsHistogram.test.tsx
+++ b/src/__tests__/components/pages/account/SplitsHistogram.test.tsx
@@ -17,14 +17,14 @@ describe('SplitsHistogram', () => {
   });
 
   it('creates Chart with expected params', () => {
-    const { container } = render(<SplitsHistogram splits={[]} />);
+    render(<SplitsHistogram splits={[]} />);
 
     expect(Chart).toBeCalledWith(
       {
         series: [],
         title: 'Movements per month',
         type: 'bar',
-        unit: '',
+        unit: undefined,
         xCategories: [
           'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
         ],
@@ -40,7 +40,6 @@ describe('SplitsHistogram', () => {
       },
       {},
     );
-    expect(container).toMatchSnapshot();
   });
 
   it('builds series accumulating values', () => {
@@ -191,7 +190,7 @@ describe('SplitsHistogram', () => {
         ],
         title: 'Movements per month',
         type: 'bar',
-        unit: '€',
+        unit: 'EUR',
         xCategories: [
           'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
         ],

--- a/src/__tests__/components/pages/account/TotalLineChart.test.tsx
+++ b/src/__tests__/components/pages/account/TotalLineChart.test.tsx
@@ -16,19 +16,18 @@ describe('TotalLineChart', () => {
   });
 
   it('creates Chart with expected params', () => {
-    const { container } = render(<TotalLineChart splits={[]} />);
+    render(<TotalLineChart splits={[]} />);
 
     expect(Chart).toBeCalledWith(
       {
         height: 255,
         series: [{ data: [] }],
         type: 'line',
-        unit: '',
+        unit: undefined,
         xAxisType: 'datetime',
       },
       {},
     );
-    expect(container).toMatchSnapshot();
   });
 
   it('builds series accumulating values', () => {
@@ -85,7 +84,7 @@ describe('TotalLineChart', () => {
           },
         ],
         type: 'line',
-        unit: '€',
+        unit: 'EUR',
         xAxisType: 'datetime',
       },
       {},

--- a/src/__tests__/components/pages/account/__snapshots__/SplitsHistogram.test.tsx.snap
+++ b/src/__tests__/components/pages/account/__snapshots__/SplitsHistogram.test.tsx.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`SplitsHistogram creates Chart with expected params 1`] = `
-<div>
-  <div
-    data-testid="Chart"
-  />
-</div>
-`;

--- a/src/__tests__/components/pages/account/__snapshots__/TotalLineChart.test.tsx.snap
+++ b/src/__tests__/components/pages/account/__snapshots__/TotalLineChart.test.tsx.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`TotalLineChart creates Chart with expected params 1`] = `
-<div>
-  <div
-    data-testid="Chart"
-  />
-</div>
-`;

--- a/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
@@ -4,20 +4,20 @@ import { render } from '@testing-library/react';
 import { Account } from '@/book/entities';
 import Money from '@/book/Money';
 import Chart, { ChartProps } from '@/components/charts/Chart';
-import NetWorthRadial from '@/components/pages/accounts/NetWorthRadial';
+import NetWorthPie from '@/components/pages/accounts/NetWorthPie';
 import type { AccountsTree } from '@/types/accounts';
 
 jest.mock('@/components/charts/Chart', () => jest.fn(
   () => <div data-testid="Chart" />,
 ));
 
-describe('NetWorthRadial', () => {
+describe('NetWorthPie', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('creates Chart with no data when no accounts', () => {
-    render(<NetWorthRadial tree={{} as AccountsTree} />);
+    render(<NetWorthPie tree={{} as AccountsTree} />);
 
     expect(Chart).toBeCalledWith(
       {
@@ -78,7 +78,7 @@ describe('NetWorthRadial', () => {
 
   it('computes net worth as expected', () => {
     render(
-      <NetWorthRadial
+      <NetWorthPie
         tree={
           {
             account: { guid: 'root' } as Account,
@@ -103,7 +103,15 @@ describe('NetWorthRadial', () => {
     const options = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
     expect(options.series).toEqual([1000, 100]);
     expect(options.unit).toEqual('EUR');
-    expect(options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(0)).toEqual('€900.00');
+    expect(
+      options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(
+        {
+          globals: {
+            series: [1000, 100],
+          },
+        },
+      ),
+    ).toEqual('€900.00');
     expect(
       options?.dataLabels?.formatter?.(
         0,
@@ -122,7 +130,7 @@ describe('NetWorthRadial', () => {
 
   it('computes net worth when no liabilities', () => {
     render(
-      <NetWorthRadial
+      <NetWorthPie
         tree={
           {
             account: { guid: 'root' } as Account,
@@ -142,6 +150,14 @@ describe('NetWorthRadial', () => {
     const options = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
     expect(options.series).toEqual([1000, 0]);
     expect(options.unit).toEqual('EUR');
-    expect(options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(0)).toEqual('€1,000.00');
+    expect(
+      options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(
+        {
+          globals: {
+            series: [1000, 0],
+          },
+        },
+      ),
+    ).toEqual('€1,000.00');
   });
 });

--- a/src/__tests__/components/pages/accounts/NetWorthRadial.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthRadial.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { Account } from '@/book/entities';
+import Money from '@/book/Money';
+import Chart, { ChartProps } from '@/components/charts/Chart';
+import NetWorthRadial from '@/components/pages/accounts/NetWorthRadial';
+import type { AccountsTree } from '@/types/accounts';
+
+jest.mock('@/components/charts/Chart', () => jest.fn(
+  () => <div data-testid="Chart" />,
+));
+
+describe('NetWorthRadial', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates Chart with no data when no accounts', () => {
+    render(<NetWorthRadial tree={{} as AccountsTree} />);
+
+    expect(Chart).toBeCalledWith(
+      {
+        colors: ['#06B6D4', '#F97316'],
+        dataLabels: {
+          enabled: true,
+          dropShadow: {
+            enabled: false,
+          },
+          formatter: expect.any(Function),
+          style: {
+            colors: ['#DDDDDD'],
+          },
+        },
+        grid: {
+          padding: {
+            bottom: -110,
+          },
+        },
+        height: 300,
+        labels: ['Assets', 'Liabilities'],
+        plotOptions: {
+          pie: {
+            donut: {
+              labels: {
+                show: true,
+                total: {
+                  formatter: expect.any(Function),
+                  label: 'Net worth',
+                  show: true,
+                  showAlways: true,
+                },
+              },
+            },
+            endAngle: 90,
+            offsetY: 10,
+            startAngle: -90,
+          },
+        },
+        series: [],
+        showLegend: false,
+        states: {
+          hover: {
+            filter: {
+              type: 'none',
+            },
+          },
+        },
+        tooltip: {
+          enabled: false,
+        },
+        type: 'donut',
+        unit: '',
+      },
+      {},
+    );
+  });
+
+  it('computes net worth as expected', () => {
+    render(
+      <NetWorthRadial
+        tree={
+          {
+            account: { guid: 'root' } as Account,
+            total: new Money(0, 'EUR'),
+            children: [
+              {
+                account: { guid: 'assets', type: 'ASSET', commodity: { mnemonic: 'EUR' } },
+                total: new Money(1000, 'EUR'),
+                children: [],
+              },
+              {
+                account: { guid: 'liabilities', type: 'LIABILITY' },
+                total: new Money(100, 'EUR'),
+                children: [],
+              },
+            ],
+          }
+        }
+      />,
+    );
+
+    const options = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
+    expect(options.series).toEqual([1000, 100]);
+    expect(options.unit).toEqual('EUR');
+    expect(options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(0)).toEqual('€900.00');
+    expect(
+      options?.dataLabels?.formatter?.(
+        0,
+        {
+          w: {
+            globals: {
+              series: [1000, 100],
+              labels: ['Name'],
+            },
+          },
+          seriesIndex: 0,
+        },
+      ),
+    ).toEqual(['Name', '€1,000.00']);
+  });
+
+  it('computes net worth when no liabilities', () => {
+    render(
+      <NetWorthRadial
+        tree={
+          {
+            account: { guid: 'root' } as Account,
+            total: new Money(0, 'EUR'),
+            children: [
+              {
+                account: { guid: 'assets', type: 'ASSET', commodity: { mnemonic: 'EUR' } },
+                total: new Money(1000, 'EUR'),
+                children: [],
+              },
+            ],
+          }
+        }
+      />,
+    );
+
+    const options = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
+    expect(options.series).toEqual([1000, 0]);
+    expect(options.unit).toEqual('EUR');
+    expect(options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(0)).toEqual('€1,000.00');
+  });
+});

--- a/src/__tests__/components/pages/investments/DividendChart.test.tsx
+++ b/src/__tests__/components/pages/investments/DividendChart.test.tsx
@@ -126,7 +126,7 @@ describe('DividendChart', () => {
         ],
         showLegend: false,
         type: 'bar',
-        unit: '€',
+        unit: 'EUR',
       },
       {},
     );
@@ -137,7 +137,7 @@ describe('DividendChart', () => {
         id: 'barMonthly',
         stacked: true,
         type: 'bar',
-        unit: '€',
+        unit: 'EUR',
         xCategories: [
           'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
         ],

--- a/src/__tests__/components/pages/investments/WeightsChart.test.tsx
+++ b/src/__tests__/components/pages/investments/WeightsChart.test.tsx
@@ -41,7 +41,11 @@ describe('WeightsChart', () => {
         },
         series: [{ data: [] }],
         type: 'treemap',
-        yFormatter: expect.any(Function),
+        tooltip: {
+          y: {
+            formatter: expect.any(Function),
+          },
+        },
       },
       {},
     );
@@ -147,7 +151,11 @@ describe('WeightsChart', () => {
           },
         ],
         type: 'treemap',
-        yFormatter: expect.any(Function),
+        tooltip: {
+          y: {
+            formatter: expect.any(Function),
+          },
+        },
       },
       {},
     );

--- a/src/__tests__/helpers/number.test.ts
+++ b/src/__tests__/helpers/number.test.ts
@@ -1,4 +1,4 @@
-import { toAmountWithScale, toFixed } from '@/helpers/number';
+import { toAmountWithScale, toFixed, moneyToString } from '@/helpers/number';
 
 describe('toAmountWithScale', () => {
   it('works with 0', () => {
@@ -41,5 +41,15 @@ describe('toFixed', () => {
 
   it('works when decimals higher', () => {
     expect(toFixed(2.2536, 10)).toEqual(2.2536);
+  });
+});
+
+describe('moneyToString', () => {
+  it('returns string as expected', () => {
+    expect(moneyToString(1234567.89, 'EUR')).toEqual('€1,234,567.89');
+  });
+
+  it('uses EUR by default if empty currency passed', () => {
+    expect(moneyToString(1234567.89, '')).toEqual('€1,234,567.89');
   });
 });

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -8,6 +8,7 @@ import type { Account } from '@/book/entities';
 import Money from '@/book/Money';
 import AccountsTable from '@/components/AccountsTable';
 import AddAccountButton from '@/components/buttons/AddAccountButton';
+import NetWorthRadial from '@/components/pages/accounts/NetWorthRadial';
 import { PriceDBMap } from '@/book/prices';
 import DateRangeInput from '@/components/DateRangeInput';
 import { useApi } from '@/hooks';
@@ -64,7 +65,10 @@ export default function AccountsPage(): JSX.Element {
           <AddAccountButton />
         </div>
       </div>
-      <div className="grid grid-cols-12 items-top pb-4">
+      <div className="grid grid-cols-12 items-start items-top pb-4">
+        <div className="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700">
+          <NetWorthRadial tree={tree} />
+        </div>
         <div className="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700">
           <AccountsTable tree={tree} />
         </div>
@@ -88,10 +92,10 @@ function buildNestedRows(
 ): AccountsTree {
   const { childrenIds } = current;
   let total = current.getTotal(dateRange);
-  let subRows: AccountsTree[] = [];
+  let children: AccountsTree[] = [];
 
   if (current.type === 'ROOT') {
-    subRows = childrenIds.map(childId => {
+    children = childrenIds.map(childId => {
       const child = accounts.find(a => a.guid === childId) as Account;
       const childTree = buildNestedRows(child, accounts, todayQuotes, dateRange);
       return childTree;
@@ -105,7 +109,7 @@ function buildNestedRows(
       );
       total = total.convert(price.currency.mnemonic, price.value);
     }
-    subRows = childrenIds.map(childId => {
+    children = childrenIds.map(childId => {
       const child = accounts.find(a => a.guid === childId) as Account;
       const childTree = buildNestedRows(child, accounts, todayQuotes, dateRange);
       let childTotal = childTree.total;
@@ -125,6 +129,6 @@ function buildNestedRows(
   return {
     account: current,
     total,
-    children: subRows,
+    children,
   };
 }

--- a/src/app/dashboard/investments/page.tsx
+++ b/src/app/dashboard/investments/page.tsx
@@ -68,7 +68,7 @@ export default function InvestmentsPage(): JSX.Element {
                 title="Value/Cost"
                 stats={`${totalValue.format()}`}
                 description={
-                  `${toFixed(totalCost.toNumber()).toString()} total invested`
+                  `${totalCost.format()} total invested`
                 }
               />
             </div>
@@ -83,7 +83,7 @@ export default function InvestmentsPage(): JSX.Element {
                 title="Unrealized Profit"
                 stats={`${profitAbs.format()} (${toFixed(profitPct)}%)`}
                 description={
-                  `${toFixed(profitAbsWithDividends.toNumber())} (${toFixed(profitPctWithDividends)}%) with dividends`
+                  `${profitAbsWithDividends.format()} (${toFixed(profitPctWithDividends)}%) with dividends`
                 }
               />
             </div>

--- a/src/book/Money.ts
+++ b/src/book/Money.ts
@@ -2,8 +2,7 @@ import * as currencies from '@dinero.js/currencies';
 import type { Currency as DineroCurrency } from 'dinero.js';
 import * as djs from 'dinero.js';
 
-import { toAmountWithScale } from '@/helpers/number';
-import { currencyToSymbol } from './helpers';
+import { toAmountWithScale, moneyToString } from '@/helpers/number';
 
 export default class Money {
   private _raw: djs.Dinero<number>;
@@ -64,7 +63,7 @@ export default class Money {
   format(scale = 2): string {
     return djs.toDecimal(
       djs.transformScale(this._raw, scale),
-      ({ value, currency }) => `${value} ${currencyToSymbol(currency.code)}`,
+      ({ value, currency }) => moneyToString(Number(value), currency.code),
     );
   }
 

--- a/src/book/__tests__/Money.test.ts
+++ b/src/book/__tests__/Money.test.ts
@@ -26,9 +26,9 @@ describe('Money', () => {
   });
 
   describe('format', () => {
-    it('normalises scale to 2', () => {
+    it('localises money', () => {
       money = new Money(100, 'USD', 3);
-      expect(money.format()).toEqual('0.10 $');
+      expect(money.format()).toEqual('$0.10');
     });
   });
 

--- a/src/book/__tests__/entities/Account.test.ts
+++ b/src/book/__tests__/entities/Account.test.ts
@@ -1,4 +1,4 @@
-import { DateTime, Interval } from 'luxon';
+import { DateTime } from 'luxon';
 import { DataSource, BaseEntity } from 'typeorm';
 
 import {
@@ -352,10 +352,7 @@ describe('Account', () => {
       });
 
       expect(account.getTotal(
-        Interval.fromDateTimes(
-          DateTime.fromISO('2022-01-02'),
-          DateTime.fromISO('2023-01-03'),
-        ),
+        DateTime.fromISO('2023-01-02'),
       ).toString()).toEqual('0.15 EUR');
     });
   });

--- a/src/book/entities/Account.ts
+++ b/src/book/entities/Account.ts
@@ -9,7 +9,7 @@ import {
   TreeChildren,
   OneToMany,
 } from 'typeorm';
-import { Interval } from 'luxon';
+import { DateTime } from 'luxon';
 
 import type Commodity from './Commodity';
 import Money from '../Money';
@@ -91,15 +91,15 @@ export default class Account extends BaseEntity {
   @OneToMany('Split', (split: Split) => split.fk_account)
     splits!: Split[];
 
-  getTotal(interval?: Interval): Money {
+  getTotal(date?: DateTime): Money {
     if (this.type === 'ROOT') {
       // @ts-ignore
       return null;
     }
 
     let { splits } = this;
-    if (interval) {
-      splits = splits.filter(split => interval.contains(split.transaction.date));
+    if (date) {
+      splits = splits.filter(split => split.transaction.date < date);
     }
 
     const total = splits.reduce(

--- a/src/components/DateRangeInput.tsx
+++ b/src/components/DateRangeInput.tsx
@@ -1,74 +1,75 @@
 import React from 'react';
 import Datepicker from 'react-tailwindcss-datepicker';
-import { DateTime, Interval } from 'luxon';
+import { DateTime } from 'luxon';
 
 export type DateRangeInputProps = {
+  asSingle?: boolean,
   earliestDate?: DateTime,
-  dateRange?: Interval,
+  dateRange?: {
+    start?: DateTime,
+    end?: DateTime,
+  },
   onChange: Function,
 };
 
 export default function DateRangeInput({
   earliestDate,
-  dateRange = Interval.fromDateTimes(
-    DateTime.now().startOf('year'),
-    DateTime.now(),
-  ),
+  dateRange = {},
   onChange,
+  asSingle = false,
 }: DateRangeInputProps): JSX.Element {
+  const now = DateTime.now();
+  const shortcuts: { [key: string]: { text: string, period: { start: Date, end: Date } } } = {
+    today: {
+      text: 'Today',
+      period: {
+        start: now.toJSDate(),
+        end: now.toJSDate(),
+      },
+    },
+  };
+
+  Array.from(
+    { length: now.year - (earliestDate?.year || now.year) },
+    (x, i) => i + 1,
+  ).forEach(value => {
+    const yearDiff = value as number;
+    const key = now.year - yearDiff;
+    shortcuts[key] = {
+      text: `End of ${now.year - yearDiff}`,
+      period: {
+        start: now.minus({ year: yearDiff }).endOf('year').toJSDate(),
+        end: now.minus({ year: yearDiff }).endOf('year').toJSDate(),
+      },
+    };
+  });
+
   return (
     <Datepicker
       value={{
-        startDate: (dateRange?.start?.toJSDate() || null),
-        endDate: (dateRange?.end?.toJSDate() || null),
+        startDate: dateRange?.start?.toJSDate() || null,
+        endDate: dateRange?.end?.toJSDate() || null,
       }}
+      asSingle={asSingle}
+      useRange={!asSingle}
       minDate={earliestDate && earliestDate.toJSDate()}
-      maxDate={DateTime.now().toJSDate()}
+      maxDate={now.toJSDate()}
       displayFormat="DD/MMM/YY"
       placeholder="Select date range"
       primaryColor="cyan"
       onChange={(newValue) => {
-        if (newValue?.startDate && newValue?.endDate) {
-          onChange(Interval.fromDateTimes(
-            DateTime.fromISO(newValue.startDate as string),
-            DateTime.fromISO(newValue.endDate as string),
-          ));
+        if (newValue) {
+          onChange({
+            start: DateTime.fromISO(newValue.startDate as string),
+            end: DateTime.fromISO(newValue.endDate as string),
+          });
         }
       }}
       startWeekOn="mon"
       separator="-"
       showShortcuts
       configs={{
-        shortcuts: {
-          yearToDate: {
-            text: 'Year to date',
-            period: {
-              start: DateTime.now().startOf('year').toJSDate(),
-              end: DateTime.now().toJSDate(),
-            },
-          },
-          previousYear: {
-            text: 'Previous year',
-            period: {
-              start: DateTime.now().minus({ years: 1 }).startOf('year').toJSDate(),
-              end: DateTime.now().minus({ years: 1 }).endOf('year').toJSDate(),
-            },
-          },
-          last3Years: {
-            text: 'Last 3 years',
-            period: {
-              start: DateTime.now().minus({ years: 3 }).startOf('year').toJSDate(),
-              end: DateTime.now().toJSDate(),
-            },
-          },
-          all: {
-            text: 'All',
-            period: {
-              start: (earliestDate || DateTime.now().minus({ years: 10 })).toJSDate(),
-              end: DateTime.now().toJSDate(),
-            },
-          },
-        },
+        shortcuts,
       }}
       containerClassName="relative w-full text-sm text-slate-400"
       inputClassName="relative transition-all duration-300 py-2.5 pl-4 pr-14 w-full border-gray-300 rounded-lg tracking-wide placeholder-gray-400 bg-gunmetal-700"

--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import { ApexOptions } from 'apexcharts';
 
-import { toFixed } from '@/helpers/number';
+import { moneyToString } from '@/helpers/number';
 
 export type ChartProps = {
-  type: 'line' | 'bar' | 'pie' | 'donut' | 'treemap',
+  type: 'line' | 'bar' | 'pie' | 'donut' | 'treemap' | 'radialBar',
   series?: ApexOptions['series'],
   labels?: string[],
   id?: string,
@@ -18,13 +18,16 @@ export type ChartProps = {
   stacked?: boolean,
   height?: number,
   xAxisType?: 'datetime' | 'category' | 'numeric' | undefined,
-  yFormatter?: (val: number, opts?: any) => string,
   events?: {
     mounted?(chart: any, options?: any): void
     dataPointSelection?(e: any, chart?: any, options?: any): void
   },
   dataLabels?: ApexOptions['dataLabels'],
   plotOptions?: ApexOptions['plotOptions'],
+  grid?: ApexOptions['grid'],
+  colors?: ApexOptions['colors'],
+  tooltip?: ApexOptions['tooltip'],
+  states?: ApexOptions['states'],
 };
 
 // apexcharts import references window so we need this
@@ -43,12 +46,12 @@ export default function Chart({
   type,
   title,
   id,
-  yFormatter,
   series = [],
   labels = [],
   showLegend = true,
   stacked = false,
   xCategories = [],
+  colors,
   unit = '',
   height = 400,
   xAxisType = undefined,
@@ -57,21 +60,26 @@ export default function Chart({
   },
   plotOptions = {},
   events = {},
+  grid = {},
+  tooltip = {},
+  states = {},
 }: ChartProps): JSX.Element {
   if (!series?.length) {
     return (
       <span>Loading...</span>
     );
   }
-
-  if (!yFormatter) {
-    yFormatter = (val: number) => `${toFixed(val)}${unit}`;
-  }
+  const yFormatter = (val: number) => moneyToString(val, unit);
 
   let options = OPTIONS;
   options = {
     ...options,
+    grid: {
+      borderColor: '#777f85',
+      ...grid,
+    },
     labels,
+    colors,
     chart: {
       ...options.chart,
       id,
@@ -105,11 +113,16 @@ export default function Chart({
       y: {
         formatter: yFormatter,
       },
+      ...tooltip,
     },
     stroke: {
       ...options.stroke,
       width: type === 'line' ? 1 : 0,
       dashArray: type === 'line' ? 5 : 0,
+    },
+    states: {
+      ...options.states,
+      ...states,
     },
   };
 
@@ -127,9 +140,6 @@ export default function Chart({
 }
 
 const OPTIONS: ApexOptions = {
-  grid: {
-    borderColor: '#777f85',
-  },
   chart: {
     width: '100%',
     foreColor: '#94A3B8',

--- a/src/components/pages/account/SplitsHistogram.tsx
+++ b/src/components/pages/account/SplitsHistogram.tsx
@@ -3,7 +3,6 @@ import { ApexOptions } from 'apexcharts';
 
 import Chart from '@/components/charts/Chart';
 import { Split } from '@/book/entities';
-import { currencyToSymbol } from '@/book/helpers';
 
 const MONTHS: { [key:number]:string; } = {
   1: 'Jan',
@@ -70,7 +69,7 @@ export default function SplitsHistogram({
       series={series}
       title="Movements per month"
       xCategories={Object.values(MONTHS)}
-      unit={currencyToSymbol(splits[0]?.account.commodity.mnemonic || '')}
+      unit={splits[0]?.account.commodity.mnemonic}
       plotOptions={
         {
           bar: {

--- a/src/components/pages/account/TotalLineChart.tsx
+++ b/src/components/pages/account/TotalLineChart.tsx
@@ -3,7 +3,6 @@ import { ApexOptions } from 'apexcharts';
 
 import Chart from '@/components/charts/Chart';
 import { Split } from '@/book/entities';
-import { currencyToSymbol } from '@/book/helpers';
 
 export type TotalLineChartProps = {
   splits: Split[],
@@ -32,7 +31,7 @@ export default function TotalLineChart({
     <Chart
       type="line"
       series={series}
-      unit={currencyToSymbol(splits[0]?.account.commodity.mnemonic || '')}
+      unit={splits[0]?.account.commodity.mnemonic}
       height={255}
       xAxisType="datetime"
     />

--- a/src/components/pages/accounts/NetWorthPie.tsx
+++ b/src/components/pages/accounts/NetWorthPie.tsx
@@ -4,13 +4,13 @@ import Chart from '@/components/charts/Chart';
 import type { AccountsTree } from '@/types/accounts';
 import { moneyToString } from '@/helpers/number';
 
-export type NetWorthRadialProps = {
+export type NetWorthPieProps = {
   tree: AccountsTree,
 };
 
-export default function NetWorthRadial({
+export default function NetWorthPie({
   tree,
-}: NetWorthRadialProps): JSX.Element {
+}: NetWorthPieProps): JSX.Element {
   let series: number[] = [];
   let assetsTotal = 0;
   let liabilitiesTotal = 0;
@@ -76,7 +76,10 @@ export default function NetWorthRadial({
                 show: true,
                 showAlways: true,
                 label: 'Net worth',
-                formatter: () => moneyToString(assetsTotal - liabilitiesTotal, unit),
+                formatter: (opts) => moneyToString(
+                  (opts.globals.series[0] || 0) - opts.globals.series[1],
+                  unit,
+                ),
               },
             },
           },

--- a/src/components/pages/accounts/NetWorthRadial.tsx
+++ b/src/components/pages/accounts/NetWorthRadial.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+import Chart from '@/components/charts/Chart';
+import type { AccountsTree } from '@/types/accounts';
+import { moneyToString } from '@/helpers/number';
+
+export type NetWorthRadialProps = {
+  tree: AccountsTree,
+};
+
+export default function NetWorthRadial({
+  tree,
+}: NetWorthRadialProps): JSX.Element {
+  let series: number[] = [];
+  let assetsTotal = 0;
+  let liabilitiesTotal = 0;
+  let unit = '';
+
+  if ((tree?.children || []).length) {
+    const assetsAccount = tree.children.find(a => a.account.type === 'ASSET');
+    const liabilitiesAccount = tree.children.find(a => a.account.type === 'LIABILITY');
+
+    assetsTotal = assetsAccount?.total.toNumber() || 0;
+    liabilitiesTotal = liabilitiesAccount?.total.toNumber() || 0;
+    unit = assetsAccount?.account.commodity.mnemonic;
+    series = [assetsTotal, liabilitiesTotal];
+  }
+
+  return (
+    <Chart
+      type="donut"
+      series={series}
+      labels={['Assets', 'Liabilities']}
+      colors={['#06B6D4', '#F97316']}
+      height={300}
+      unit={unit}
+      showLegend={false}
+      tooltip={{
+        enabled: false,
+      }}
+      dataLabels={{
+        enabled: true,
+        // @ts-ignore types are wrong here as for a breakline we need to return
+        // an array
+        formatter: (val: number, opts) => {
+          const name = opts.w.globals.labels[opts.seriesIndex];
+          return [
+            name,
+            moneyToString(
+              opts.w.globals.series[opts.seriesIndex],
+              unit,
+            ),
+          ];
+        },
+        style: {
+          colors: ['#DDDDDD'],
+        },
+        dropShadow: {
+          enabled: false,
+        },
+      }}
+      grid={{
+        padding: {
+          bottom: -110,
+        },
+      }}
+      plotOptions={{
+        pie: {
+          startAngle: -90,
+          endAngle: 90,
+          offsetY: 10,
+          donut: {
+            labels: {
+              show: true,
+              total: {
+                show: true,
+                showAlways: true,
+                label: 'Net worth',
+                formatter: () => moneyToString(assetsTotal - liabilitiesTotal, unit),
+              },
+            },
+          },
+        },
+      }}
+      states={{
+        hover: {
+          filter: {
+            type: 'none',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/src/components/pages/investments/DividendChart.tsx
+++ b/src/components/pages/investments/DividendChart.tsx
@@ -37,7 +37,7 @@ export default function DividendChart({
               type="bar"
               series={[{ data: yearData, name: 'dividends' }]}
               showLegend={false}
-              unit={currencyToSymbol(currency)}
+              unit={currency}
               plotOptions={
                 {
                   bar: {
@@ -76,7 +76,7 @@ export default function DividendChart({
               id="barMonthly"
               type="bar"
               series={lastYearMonthlySeries}
-              unit={currencyToSymbol(currency)}
+              unit={currency}
               xCategories={Object.values(MONTHS)}
               stacked
             />

--- a/src/components/pages/investments/InvestmentsTable.tsx
+++ b/src/components/pages/investments/InvestmentsTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ColumnDef } from '@tanstack/react-table';
 import classNames from 'classnames';
 
-import { toFixed } from '@/helpers/number';
+import { toFixed, moneyToString } from '@/helpers/number';
 import Table from '@/components/Table';
 import type { InvestmentAccount } from '@/book/models';
 import { currencyToSymbol } from '@/book/helpers';
@@ -47,8 +47,7 @@ const columns: ColumnDef<InvestmentAccount>[] = [
         <span className="font-14">
           {row.original.quantity.toNumber()}
           @
-          {currencyToSymbol(row.original.currency)}
-          {toFixed(row.original.avgPrice)}
+          {moneyToString(row.original.avgPrice, row.original.currency)}
         </span>
       </p>
     ),
@@ -59,8 +58,7 @@ const columns: ColumnDef<InvestmentAccount>[] = [
     header: 'Today',
     cell: ({ row, getValue }) => (
       <p className="m-0 d-inline-block align-middle font-16">
-        {currencyToSymbol(row.original.currency)}
-        {toFixed(row.original.quoteInfo.price)}
+        {moneyToString(row.original.quoteInfo.price, row.original.currency)}
         <br />
         <span
           className={classNames('badge', {

--- a/src/components/pages/investments/WeightsChart.tsx
+++ b/src/components/pages/investments/WeightsChart.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import Chart from '@/components/charts/Chart';
 import type { InvestmentAccount } from '@/book/models';
 import Money from '@/book/Money';
-import { toFixed } from '@/helpers/number';
-import { currencyToSymbol } from '@/book/helpers';
+import { toFixed, moneyToString } from '@/helpers/number';
 
 export type WeightsChartProps = {
   investments: InvestmentAccount[],
@@ -15,7 +14,6 @@ export default function WeightsChart({
   investments,
   totalValue,
 }: WeightsChartProps): JSX.Element {
-  const currencySymbol = currencyToSymbol(totalValue.currency);
   const data: { [ticker: string]: {
     x: string,
     y: number,
@@ -89,12 +87,13 @@ export default function WeightsChart({
           },
         }
       }
-      yFormatter={
-        (val: number, { dataPointIndex, w }) => {
-          const ticker = w.globals.categoryLabels[dataPointIndex];
-          return `${val}${currencySymbol} (${data[ticker].pct}%)`;
-        }
-      }
+      tooltip={{
+        y: {
+          formatter: (val: number, { dataPointIndex, w }) => (
+            `${moneyToString(val, totalValue.currency)} (${data[w.globals.categoryLabels[dataPointIndex]].pct}%)`
+          ),
+        },
+      }}
     />
   );
 }

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -35,3 +35,10 @@ export function toAmountWithScale(n: number): {
 export function toFixed(n: number, decimals = 2): number {
   return parseFloat(n.toFixed(decimals));
 }
+
+export function moneyToString(n: number, currency: string): string {
+  return n.toLocaleString(navigator.language, {
+    style: 'currency',
+    currency: currency || 'EUR',
+  });
+}


### PR DESCRIPTION
This PR adds a donut pie chart in the home page to display total net worth (as Assets - Liabilities). In this PR I'm also changing the date range selector in the home page to be single date. This way you can check the state of your finances for a specific point in the past, the range was wrong as it was more oriented for selecting in timecharts which I haven't added yet.

In this PR I've also added proper formatting for money representations using the locale of the browser.