### PR TITLE
Add net worth histogram

### DIFF
--- a/src/__tests__/apis/Stocker.test.ts
+++ b/src/__tests__/apis/Stocker.test.ts
@@ -33,7 +33,7 @@ describe('Stocker', () => {
     });
 
     it('calls API with expected params', async () => {
-      const result = await instance.getPrice('A', DateTime.fromISO('2023-01-01', { zone: 'utc' }));
+      const result = await instance.getPrice('A', DateTime.fromISO('2023-01-01'));
 
       expect(API.get).toHaveBeenCalledWith(
         'stocker',

--- a/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AccountsPage generates tree as expected, no investments 1`] = `
 <div>
   <div
-    class="flex items-center pb-4"
+    class="flex items-center"
   >
     <span
       class="text-xl font-medium"
@@ -27,17 +27,28 @@ exports[`AccountsPage generates tree as expected, no investments 1`] = `
     class="grid grid-cols-12 items-start items-top pb-4"
   >
     <div
-      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      class="grid grid-cols-12 col-span-3"
     >
       <div
-        data-testid="NetWorthPie"
-      />
+        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="NetWorthPie"
+        />
+      </div>
+      <div
+        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="AccountsTable"
+        />
+      </div>
     </div>
     <div
-      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
       <div
-        data-testid="AccountsTable"
+        data-testid="NetWorthHistogram"
       />
     </div>
   </div>
@@ -47,7 +58,7 @@ exports[`AccountsPage generates tree as expected, no investments 1`] = `
 exports[`AccountsPage generates tree as expected, with investments 1`] = `
 <div>
   <div
-    class="flex items-center pb-4"
+    class="flex items-center"
   >
     <span
       class="text-xl font-medium"
@@ -71,17 +82,28 @@ exports[`AccountsPage generates tree as expected, with investments 1`] = `
     class="grid grid-cols-12 items-start items-top pb-4"
   >
     <div
-      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      class="grid grid-cols-12 col-span-3"
     >
       <div
-        data-testid="NetWorthPie"
-      />
+        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="NetWorthPie"
+        />
+      </div>
+      <div
+        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="AccountsTable"
+        />
+      </div>
     </div>
     <div
-      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
       <div
-        data-testid="AccountsTable"
+        data-testid="NetWorthHistogram"
       />
     </div>
   </div>
@@ -91,7 +113,7 @@ exports[`AccountsPage generates tree as expected, with investments 1`] = `
 exports[`AccountsPage passes empty data to components when loading when not ready 1`] = `
 <div>
   <div
-    class="flex items-center pb-4"
+    class="flex items-center"
   >
     <span
       class="text-xl font-medium"
@@ -115,17 +137,28 @@ exports[`AccountsPage passes empty data to components when loading when not read
     class="grid grid-cols-12 items-start items-top pb-4"
   >
     <div
-      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      class="grid grid-cols-12 col-span-3"
     >
       <div
-        data-testid="NetWorthPie"
-      />
+        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="NetWorthPie"
+        />
+      </div>
+      <div
+        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="AccountsTable"
+        />
+      </div>
     </div>
     <div
-      class="col-span-3 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
     >
       <div
-        data-testid="AccountsTable"
+        data-testid="NetWorthHistogram"
       />
     </div>
   </div>

--- a/src/__tests__/components/DateRangeInput.test.tsx
+++ b/src/__tests__/components/DateRangeInput.test.tsx
@@ -11,7 +11,7 @@ jest.mock('react-tailwindcss-datepicker', () => jest.fn(
 
 describe('DateRangeInput', () => {
   beforeEach(() => {
-    jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-30', { zone: 'utc' }));
+    jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-30'));
   });
 
   afterEach(() => {
@@ -64,11 +64,11 @@ describe('DateRangeInput', () => {
         onChange={jest.fn()}
         dateRange={
           {
-            start: DateTime.fromISO('2023-05-01', { zone: 'utc' }),
-            end: DateTime.fromISO('2023-05-01', { zone: 'utc' }),
+            start: DateTime.fromISO('2023-05-01'),
+            end: DateTime.fromISO('2023-05-01'),
           }
         }
-        earliestDate={DateTime.fromISO('2022-01-01', { zone: 'utc' })}
+        earliestDate={DateTime.fromISO('2022-01-01')}
       />,
     );
 
@@ -77,24 +77,24 @@ describe('DateRangeInput', () => {
         asSingle: true,
         useRange: false,
         value: {
-          startDate: DateTime.fromISO('2023-05-01', { zone: 'utc' }).toJSDate(),
-          endDate: DateTime.fromISO('2023-05-01', { zone: 'utc' }).toJSDate(),
+          startDate: DateTime.fromISO('2023-05-01').toJSDate(),
+          endDate: DateTime.fromISO('2023-05-01').toJSDate(),
         },
-        minDate: DateTime.fromISO('2022-01-01', { zone: 'utc' }).toJSDate(),
+        minDate: DateTime.fromISO('2022-01-01').toJSDate(),
         configs: {
           shortcuts: expect.objectContaining({
             today: {
               text: 'Today',
               period: {
-                start: DateTime.fromISO('2023-01-30', { zone: 'utc' }).toJSDate(),
-                end: DateTime.fromISO('2023-01-30', { zone: 'utc' }).toJSDate(),
+                start: DateTime.fromISO('2023-01-30').toJSDate(),
+                end: DateTime.fromISO('2023-01-30').toJSDate(),
               },
             },
             2022: {
               text: 'End of 2022',
               period: {
-                start: DateTime.fromISO('2022-01-01', { zone: 'utc' }).endOf('year').toJSDate(),
-                end: DateTime.fromISO('2022-01-01', { zone: 'utc' }).endOf('year').toJSDate(),
+                start: DateTime.fromISO('2022-01-01').endOf('year').toJSDate(),
+                end: DateTime.fromISO('2022-01-01').endOf('year').toJSDate(),
               },
             },
           }),

--- a/src/__tests__/components/TransactionsTable.test.tsx
+++ b/src/__tests__/components/TransactionsTable.test.tsx
@@ -265,7 +265,7 @@ describe('TransactionsTable', () => {
 
     expect(
       // @ts-ignore
-      dateCol.accessorFn({ transaction: { date: DateTime.fromISO('2023-01-01', { zone: 'utc' }) } }),
+      dateCol.accessorFn({ transaction: { date: DateTime.fromISO('2023-01-01') } }),
     ).toEqual(1672531200000);
 
     expect(dateCol.cell).not.toBeUndefined();

--- a/src/__tests__/components/charts/Chart.test.tsx
+++ b/src/__tests__/components/charts/Chart.test.tsx
@@ -42,33 +42,31 @@ describe('Chart', () => {
         options: {
           chart: {
             foreColor: '#94A3B8',
-            id: undefined,
             toolbar: {
               show: false,
             },
-            stacked: false,
             width: '100%',
             zoom: {
               autoScaleYaxis: true,
               enabled: true,
               type: 'x',
             },
-            events: {},
-            sparkline: {
-              enabled: false,
-            },
           },
           dataLabels: {
             enabled: false,
+            style: {
+              colors: ['#DDDDDD'],
+              fontFamily: 'Intervariable',
+              fontWeight: '300',
+              fontSize: '14px',
+            },
+            dropShadow: {
+              enabled: false,
+            },
           },
           grid: {
             borderColor: '#777f85',
           },
-          labels: [],
-          legend: {
-            show: true,
-          },
-          plotOptions: {},
           states: {
             active: {
               allowMultipleDataPointsSelection: false,
@@ -80,12 +78,7 @@ describe('Chart', () => {
           },
           stroke: {
             curve: 'smooth',
-            dashArray: 0,
             width: 0,
-          },
-          title: {
-            align: 'left',
-            text: undefined,
           },
           tooltip: {
             fillSeriesColor: true,
@@ -104,8 +97,6 @@ describe('Chart', () => {
             axisBorder: {
               show: false,
             },
-            categories: [],
-            type: undefined,
           },
           yaxis: {
             labels: {
@@ -121,42 +112,33 @@ describe('Chart', () => {
     );
   });
 
-  it('sets optional params', () => {
+  it('merges params', () => {
     const mockYFormatter = jest.fn();
     const mockMounted = jest.fn();
     render(
       <Chart
         series={[1]}
-        title="title"
-        showLegend={false}
-        xCategories={['a', 'b']}
-        xAxisType="datetime"
         type="bar"
-        stacked
         unit="unit"
         height={200}
-        dataLabels={
-          { enabled: true }
-        }
-        plotOptions={
-          {
+        options={{
+          dataLabels: { enabled: true },
+          plotOptions: {
             area: {
               fillTo: 'origin',
             },
-          }
-        }
-        events={
-          {
-            mounted: mockMounted,
-          }
-        }
-        tooltip={
-          {
+          },
+          chart: {
+            events: {
+              mounted: mockMounted,
+            },
+          },
+          tooltip: {
             y: {
               formatter: mockYFormatter,
             },
-          }
-        }
+          },
+        }}
       />,
     );
 
@@ -166,21 +148,6 @@ describe('Chart', () => {
           events: {
             mounted: mockMounted,
           },
-          stacked: true,
-        },
-        title: {
-          text: 'title',
-        },
-        legend: {
-          show: false,
-        },
-        xaxis: {
-          categories: ['a', 'b'],
-        },
-        yaxis: {
-          labels: {
-            formatter: expect.any(Function),
-          },
         },
         tooltip: {
           y: {
@@ -189,6 +156,15 @@ describe('Chart', () => {
         },
         dataLabels: {
           enabled: true,
+          style: {
+            colors: ['#DDDDDD'],
+            fontFamily: 'Intervariable',
+            fontWeight: '300',
+            fontSize: '14px',
+          },
+          dropShadow: {
+            enabled: false,
+          },
         },
         plotOptions: {
           area: {

--- a/src/__tests__/components/pages/account/SplitsHistogram.test.tsx
+++ b/src/__tests__/components/pages/account/SplitsHistogram.test.tsx
@@ -22,19 +22,27 @@ describe('SplitsHistogram', () => {
     expect(Chart).toBeCalledWith(
       {
         series: [],
-        title: 'Movements per month',
         type: 'bar',
         unit: undefined,
-        xCategories: [
-          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-        ],
-        events: {
-          mounted: expect.any(Function),
-        },
-        plotOptions: {
-          bar: {
-            columnWidth: '55%',
-            horizontal: false,
+        options: {
+          title: {
+            text: 'Movements per month',
+          },
+          xaxis: {
+            categories: [
+              'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+            ],
+          },
+          chart: {
+            events: {
+              mounted: expect.any(Function),
+            },
+          },
+          plotOptions: {
+            bar: {
+              columnWidth: '70%',
+              horizontal: false,
+            },
           },
         },
       },
@@ -56,7 +64,7 @@ describe('SplitsHistogram', () => {
               },
             },
             transaction: {
-              date: DateTime.fromISO('2023-01-02', { zone: 'utc' }),
+              date: DateTime.fromISO('2023-01-02'),
             },
             quantity: 100,
           } as Split,
@@ -70,7 +78,7 @@ describe('SplitsHistogram', () => {
               },
             },
             transaction: {
-              date: DateTime.fromISO('2022-01-01', { zone: 'utc' }),
+              date: DateTime.fromISO('2022-01-01'),
             },
             quantity: -200,
           } as Split,
@@ -188,19 +196,27 @@ describe('SplitsHistogram', () => {
             name: '2023',
           },
         ],
-        title: 'Movements per month',
         type: 'bar',
         unit: 'EUR',
-        xCategories: [
-          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-        ],
-        events: {
-          mounted: expect.any(Function),
-        },
-        plotOptions: {
-          bar: {
-            columnWidth: '55%',
-            horizontal: false,
+        options: {
+          title: {
+            text: 'Movements per month',
+          },
+          xaxis: {
+            categories: [
+              'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+            ],
+          },
+          chart: {
+            events: {
+              mounted: expect.any(Function),
+            },
+          },
+          plotOptions: {
+            bar: {
+              columnWidth: '70%',
+              horizontal: false,
+            },
           },
         },
       },
@@ -220,7 +236,7 @@ describe('SplitsHistogram', () => {
               },
             },
             transaction: {
-              date: DateTime.fromISO('2023-01-02', { zone: 'utc' }),
+              date: DateTime.fromISO('2023-01-02'),
             },
             quantity: 100,
           } as Split,
@@ -234,7 +250,7 @@ describe('SplitsHistogram', () => {
               },
             },
             transaction: {
-              date: DateTime.fromISO('2022-01-01', { zone: 'utc' }),
+              date: DateTime.fromISO('2022-01-01'),
             },
             quantity: -200,
           } as Split,
@@ -242,7 +258,7 @@ describe('SplitsHistogram', () => {
       />,
     );
 
-    const mountedEvent = ChartMock.mock.calls[0][0].events?.mounted as Function;
+    const mountedEvent = ChartMock.mock.calls[0][0].options?.chart?.events?.mounted as Function;
     const mockHideSeries = jest.fn();
     mountedEvent({ hideSeries: mockHideSeries });
     expect(mockHideSeries).toBeCalledTimes(1);

--- a/src/__tests__/components/pages/account/TotalLineChart.test.tsx
+++ b/src/__tests__/components/pages/account/TotalLineChart.test.tsx
@@ -24,7 +24,11 @@ describe('TotalLineChart', () => {
         series: [{ data: [] }],
         type: 'line',
         unit: undefined,
-        xAxisType: 'datetime',
+        options: {
+          xaxis: {
+            type: 'datetime',
+          },
+        },
       },
       {},
     );
@@ -44,7 +48,7 @@ describe('TotalLineChart', () => {
               },
             },
             transaction: {
-              date: DateTime.fromISO('2023-01-02', { zone: 'utc' }),
+              date: DateTime.fromISO('2023-01-02'),
             },
             quantity: 100,
           } as Split,
@@ -58,7 +62,7 @@ describe('TotalLineChart', () => {
               },
             },
             transaction: {
-              date: DateTime.fromISO('2023-01-01', { zone: 'utc' }),
+              date: DateTime.fromISO('2023-01-01'),
             },
             quantity: -200,
           } as Split,
@@ -85,7 +89,11 @@ describe('TotalLineChart', () => {
         ],
         type: 'line',
         unit: 'EUR',
-        xAxisType: 'datetime',
+        options: {
+          xaxis: {
+            type: 'datetime',
+          },
+        },
       },
       {},
     );

--- a/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
@@ -1,0 +1,329 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DateTime } from 'luxon';
+
+import Money from '@/book/Money';
+import { Account } from '@/book/entities';
+import Chart from '@/components/charts/Chart';
+import NetWorthHistogram from '@/components/pages/accounts/NetWorthHistogram';
+import type { AccountsTree } from '@/types/accounts';
+
+jest.mock('@/components/charts/Chart', () => jest.fn(
+  () => <div data-testid="Chart" />,
+));
+
+describe('NetWorthHistogram', () => {
+  beforeEach(() => {
+    jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-02'));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with empty tree', () => {
+    render(<NetWorthHistogram tree={{} as AccountsTree} />);
+
+    expect(Chart).toBeCalledTimes(2);
+    expect(Chart).toHaveBeenNthCalledWith(
+      1,
+      {
+        height: 350,
+        type: 'line',
+        series: [
+          {
+            data: [],
+            type: 'column',
+            name: 'Income',
+          },
+          {
+            data: [],
+            type: 'column',
+            name: 'Expenses',
+          },
+          {
+            data: [],
+            type: 'column',
+            name: 'Net profit',
+          },
+          {
+            data: [],
+            type: 'line',
+            name: 'Net worth',
+          },
+        ],
+        options: {
+          chart: {
+            id: 'netWorthHistogram',
+          },
+          xaxis: {
+            type: 'datetime',
+            crosshairs: {
+              show: true,
+              width: 'barWidth',
+              opacity: 0.1,
+              stroke: {
+                width: 0,
+              },
+            },
+          },
+          colors: ['#22C55E', '#EF4444', '#06B6D4', '#06B6D4'],
+          plotOptions: {
+            bar: {
+              columnWidth: '70%',
+            },
+          },
+          markers: {
+            size: 2,
+            strokeColors: '#06B6D4',
+          },
+          legend: {
+            position: 'top',
+            onItemClick: {
+              toggleDataSeries: false,
+            },
+          },
+          yaxis: [
+            {
+              seriesName: 'Income',
+              title: {
+                text: 'Net profit',
+              },
+              labels: {
+                formatter: expect.any(Function),
+              },
+              forceNiceScale: true,
+            },
+            {
+              seriesName: 'Income',
+              show: false,
+              labels: {
+                formatter: expect.any(Function),
+              },
+            },
+            {
+              seriesName: 'Income',
+              show: false,
+              labels: {
+                formatter: expect.any(Function),
+              },
+            },
+            {
+              opposite: true,
+              seriesName: 'Net worth',
+              title: {
+                text: 'Net worth',
+              },
+              forceNiceScale: true,
+              labels: {
+                formatter: expect.any(Function),
+              },
+            },
+          ],
+        },
+      },
+      {},
+    );
+
+    expect(Chart).toHaveBeenNthCalledWith(
+      2,
+      {
+        height: 100,
+        type: 'line',
+        series: [
+          {
+            data: [],
+            name: 'Net worth',
+            type: 'line',
+          },
+        ],
+        options: {
+          chart: {
+            brush: {
+              enabled: true,
+              target: 'netWorthHistogram',
+            },
+            selection: {
+              enabled: true,
+              xaxis: {
+                min: DateTime.now().minus({ months: 6 }).toMillis(),
+                max: DateTime.now().toMillis(),
+              },
+              fill: {
+                color: '#888',
+                opacity: 0.4,
+              },
+              stroke: {
+                color: '#0D47A1',
+              },
+            },
+          },
+          colors: ['#06B6D4'],
+          grid: {
+            show: false,
+          },
+          xaxis: {
+            type: 'datetime',
+          },
+          yaxis: {
+            show: false,
+          },
+        },
+      },
+      {},
+    );
+  });
+
+  it('generates series from tree as expected', () => {
+    render(
+      <NetWorthHistogram
+        startDate={DateTime.fromISO('2022-09-01')}
+        tree={
+          {
+            account: { guid: 'root' } as Account,
+            total: new Money(0, 'EUR'),
+            monthlyTotals: {},
+            children: [
+              {
+                account: { guid: 'income', type: 'INCOME', commodity: { mnemonic: 'EUR' } },
+                total: new Money(1000, 'EUR'),
+                monthlyTotals: {
+                  'Nov/22': new Money(600, 'EUR'),
+                  'Dec/22': new Money(400, 'EUR'),
+                },
+                children: [],
+              },
+              {
+                account: { guid: 'expenses', type: 'EXPENSE' },
+                total: new Money(500, 'EUR'),
+                monthlyTotals: {
+                  'Nov/22': new Money(400, 'EUR'),
+                  'Dec/22': new Money(500, 'EUR'),
+                },
+                children: [],
+              },
+            ],
+          }
+        }
+      />,
+    );
+
+    const mainSeries = (Chart as jest.Mock).mock.calls[0][0].series;
+    expect(mainSeries).toEqual([
+      {
+        name: 'Income',
+        type: 'column',
+        data: [
+          {
+            x: DateTime.fromISO('2022-10-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-11-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-12-01'),
+            y: 600,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: 400,
+          },
+        ],
+      },
+      {
+        name: 'Expenses',
+        type: 'column',
+        data: [
+          {
+            x: DateTime.fromISO('2022-10-01'),
+            y: -0,
+          },
+          {
+            x: DateTime.fromISO('2022-11-01'),
+            y: -0,
+          },
+          {
+            x: DateTime.fromISO('2022-12-01'),
+            y: -400,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: -500,
+          },
+        ],
+      },
+      {
+        name: 'Net profit',
+        type: 'column',
+        data: [
+          {
+            x: DateTime.fromISO('2022-10-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-11-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-12-01'),
+            y: 200,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: -100,
+          },
+        ],
+      },
+      {
+        name: 'Net worth',
+        type: 'line',
+        data: [
+          {
+            x: DateTime.fromISO('2022-10-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-11-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-12-01'),
+            y: 200,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: 100,
+          },
+        ],
+      },
+    ]);
+
+    const brushSeries = (Chart as jest.Mock).mock.calls[1][0].series;
+    expect(brushSeries).toEqual([
+      {
+        name: 'Net worth',
+        type: 'line',
+        data: [
+          {
+            x: DateTime.fromISO('2022-10-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-11-01'),
+            y: 0,
+          },
+          {
+            x: DateTime.fromISO('2022-12-01'),
+            y: 200,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: 100,
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
@@ -21,56 +21,54 @@ describe('NetWorthPie', () => {
 
     expect(Chart).toBeCalledWith(
       {
-        colors: ['#06B6D4', '#F97316'],
-        dataLabels: {
-          enabled: true,
-          dropShadow: {
-            enabled: false,
-          },
-          formatter: expect.any(Function),
-          style: {
-            colors: ['#DDDDDD'],
-          },
-        },
-        grid: {
-          padding: {
-            bottom: -110,
-          },
-        },
-        height: 300,
-        labels: ['Assets', 'Liabilities'],
-        plotOptions: {
-          pie: {
-            donut: {
-              labels: {
-                show: true,
-                total: {
-                  formatter: expect.any(Function),
-                  label: 'Net worth',
-                  show: true,
-                  showAlways: true,
-                },
-              },
-            },
-            endAngle: 90,
-            offsetY: 10,
-            startAngle: -90,
-          },
-        },
         series: [],
-        showLegend: false,
-        states: {
-          hover: {
-            filter: {
-              type: 'none',
-            },
-          },
-        },
-        tooltip: {
-          enabled: false,
-        },
         type: 'donut',
         unit: '',
+        height: 300,
+        options: {
+          colors: ['#06B6D4', '#F97316'],
+          dataLabels: {
+            enabled: true,
+            formatter: expect.any(Function),
+          },
+          grid: {
+            padding: {
+              bottom: -110,
+            },
+          },
+          labels: ['Assets', 'Liabilities'],
+          plotOptions: {
+            pie: {
+              donut: {
+                labels: {
+                  show: true,
+                  total: {
+                    formatter: expect.any(Function),
+                    label: 'Net worth',
+                    show: true,
+                    showAlways: true,
+                  },
+                },
+              },
+              endAngle: 90,
+              offsetY: 10,
+              startAngle: -90,
+            },
+          },
+          legend: {
+            show: false,
+          },
+          states: {
+            hover: {
+              filter: {
+                type: 'none',
+              },
+            },
+          },
+          tooltip: {
+            enabled: false,
+          },
+        },
       },
       {},
     );
@@ -83,15 +81,18 @@ describe('NetWorthPie', () => {
           {
             account: { guid: 'root' } as Account,
             total: new Money(0, 'EUR'),
+            monthlyTotals: {},
             children: [
               {
                 account: { guid: 'assets', type: 'ASSET', commodity: { mnemonic: 'EUR' } },
                 total: new Money(1000, 'EUR'),
+                monthlyTotals: {},
                 children: [],
               },
               {
                 account: { guid: 'liabilities', type: 'LIABILITY' },
                 total: new Money(100, 'EUR'),
+                monthlyTotals: {},
                 children: [],
               },
             ],
@@ -100,11 +101,11 @@ describe('NetWorthPie', () => {
       />,
     );
 
-    const options = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
-    expect(options.series).toEqual([1000, 100]);
-    expect(options.unit).toEqual('EUR');
+    const props = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
+    expect(props.series).toEqual([1000, 100]);
+    expect(props.unit).toEqual('EUR');
     expect(
-      options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(
+      props.options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(
         {
           globals: {
             series: [1000, 100],
@@ -113,7 +114,7 @@ describe('NetWorthPie', () => {
       ),
     ).toEqual('€900.00');
     expect(
-      options?.dataLabels?.formatter?.(
+      props.options?.dataLabels?.formatter?.(
         0,
         {
           w: {
@@ -135,10 +136,12 @@ describe('NetWorthPie', () => {
           {
             account: { guid: 'root' } as Account,
             total: new Money(0, 'EUR'),
+            monthlyTotals: {},
             children: [
               {
                 account: { guid: 'assets', type: 'ASSET', commodity: { mnemonic: 'EUR' } },
                 total: new Money(1000, 'EUR'),
+                monthlyTotals: {},
                 children: [],
               },
             ],
@@ -147,11 +150,11 @@ describe('NetWorthPie', () => {
       />,
     );
 
-    const options = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
-    expect(options.series).toEqual([1000, 0]);
-    expect(options.unit).toEqual('EUR');
+    const props = (Chart as jest.Mock).mock.calls[0][0] as ChartProps;
+    expect(props.series).toEqual([1000, 0]);
+    expect(props.unit).toEqual('EUR');
     expect(
-      options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(
+      props.options?.plotOptions?.pie?.donut?.labels?.total?.formatter?.(
         {
           globals: {
             series: [1000, 0],

--- a/src/__tests__/components/pages/investments/DividendChart.test.tsx
+++ b/src/__tests__/components/pages/investments/DividendChart.test.tsx
@@ -42,11 +42,11 @@ describe('DividendChart', () => {
               },
               dividends: [
                 {
-                  when: DateTime.fromISO('2023-01-01', { zone: 'utc' }),
+                  when: DateTime.fromISO('2023-01-01'),
                   amountInCurrency: new Money(100, 'EUR'),
                 },
                 {
-                  when: DateTime.fromISO('2023-05-01', { zone: 'utc' }),
+                  when: DateTime.fromISO('2023-05-01'),
                   amountInCurrency: new Money(130, 'EUR'),
                 },
               ],
@@ -57,11 +57,11 @@ describe('DividendChart', () => {
               },
               dividends: [
                 {
-                  when: DateTime.fromISO('2022-02-02', { zone: 'utc' }),
+                  when: DateTime.fromISO('2022-02-02'),
                   amountInCurrency: new Money(150, 'EUR'),
                 },
                 {
-                  when: DateTime.fromISO('2023-05-20', { zone: 'utc' }),
+                  when: DateTime.fromISO('2023-05-20'),
                   amountInCurrency: new Money(130, 'EUR'),
                 },
               ],
@@ -74,15 +74,6 @@ describe('DividendChart', () => {
     expect(Chart).toHaveBeenNthCalledWith(
       1,
       {
-        events: {
-          dataPointSelection: expect.any(Function),
-        },
-        plotOptions: {
-          bar: {
-            barHeight: '55%',
-            horizontal: true,
-          },
-        },
         series: [
           {
             name: 'dividends',
@@ -124,9 +115,24 @@ describe('DividendChart', () => {
             ],
           },
         ],
-        showLegend: false,
         type: 'bar',
         unit: 'EUR',
+        options: {
+          legend: {
+            show: false,
+          },
+          chart: {
+            events: {
+              dataPointSelection: expect.any(Function),
+            },
+          },
+          plotOptions: {
+            bar: {
+              barHeight: '55%',
+              horizontal: true,
+            },
+          },
+        },
       },
       {},
     );
@@ -134,13 +140,8 @@ describe('DividendChart', () => {
     expect(Chart).toHaveBeenNthCalledWith(
       2,
       {
-        id: 'barMonthly',
-        stacked: true,
         type: 'bar',
         unit: 'EUR',
-        xCategories: [
-          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-        ],
         series: [
           {
             name: 'Account1',
@@ -151,6 +152,17 @@ describe('DividendChart', () => {
             data: [0, 0, 0, 0, 130, 0, 0, 0, 0, 0, 0, 0],
           },
         ],
+        options: {
+          chart: {
+            id: 'barMonthly',
+            stacked: true,
+          },
+          xaxis: {
+            categories: [
+              'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+            ],
+          },
+        },
       },
       {},
     );
@@ -170,11 +182,11 @@ describe('DividendChart', () => {
               },
               dividends: [
                 {
-                  when: DateTime.fromISO('2022-01-01', { zone: 'utc' }),
+                  when: DateTime.fromISO('2022-01-01'),
                   amountInCurrency: new Money(100, 'EUR'),
                 },
                 {
-                  when: DateTime.fromISO('2023-01-01', { zone: 'utc' }),
+                  when: DateTime.fromISO('2023-01-01'),
                   amountInCurrency: new Money(130, 'EUR'),
                 },
               ],
@@ -184,7 +196,9 @@ describe('DividendChart', () => {
       />,
     );
 
-    const dataPointSelection = ChartMock.mock.calls[0][0].events?.dataPointSelection as Function;
+    const dataPointSelection = (
+      ChartMock.mock.calls[0][0].options?.chart?.events?.dataPointSelection as Function
+    );
 
     const mockChart = {
       w: {
@@ -253,11 +267,11 @@ describe('DividendChart', () => {
               },
               dividends: [
                 {
-                  when: DateTime.fromISO('2023-01-01', { zone: 'utc' }),
+                  when: DateTime.fromISO('2023-01-01'),
                   amountInCurrency: new Money(100, 'EUR'),
                 },
                 {
-                  when: DateTime.fromISO('2023-01-20', { zone: 'utc' }),
+                  when: DateTime.fromISO('2023-01-20'),
                   amountInCurrency: new Money(130, 'EUR'),
                 },
               ],
@@ -267,7 +281,9 @@ describe('DividendChart', () => {
       />,
     );
 
-    const dataPointSelection = ChartMock.mock.calls[0][0].events?.dataPointSelection as Function;
+    const dataPointSelection = (
+      ChartMock.mock.calls[0][0].options?.chart?.events?.dataPointSelection as Function
+    );
 
     const mockChart = {
       w: {

--- a/src/__tests__/components/pages/investments/WeightsChart.test.tsx
+++ b/src/__tests__/components/pages/investments/WeightsChart.test.tsx
@@ -22,28 +22,30 @@ describe('WeightsChart', () => {
 
     expect(Chart).toHaveBeenCalledWith(
       {
-        dataLabels: {
-          enabled: true,
-          formatter: expect.any(Function),
-          offsetY: -4,
-          style: {
-            fontSize: '12px',
-          },
-        },
-        height: 650,
-        plotOptions: {
-          treemap: {
-            colorScale: {
-              ranges: [],
-            },
-            useFillColorAsStroke: true,
-          },
-        },
         series: [{ data: [] }],
         type: 'treemap',
-        tooltip: {
-          y: {
+        height: 650,
+        options: {
+          dataLabels: {
+            enabled: true,
             formatter: expect.any(Function),
+            offsetY: -4,
+            style: {
+              fontSize: '12px',
+            },
+          },
+          plotOptions: {
+            treemap: {
+              colorScale: {
+                ranges: [],
+              },
+              useFillColorAsStroke: true,
+            },
+          },
+          tooltip: {
+            y: {
+              formatter: expect.any(Function),
+            },
           },
         },
       },
@@ -89,40 +91,7 @@ describe('WeightsChart', () => {
 
     expect(Chart).toHaveBeenCalledWith(
       {
-        dataLabels: {
-          enabled: true,
-          formatter: expect.any(Function),
-          offsetY: -4,
-          style: {
-            fontSize: '12px',
-          },
-        },
         height: 650,
-        plotOptions: {
-          treemap: {
-            colorScale: {
-              ranges: [
-                {
-                  color: '#d12b2b',
-                  from: 100,
-                  to: 100,
-                },
-                {
-                  color: '#52b12c',
-                  from: 300,
-                  to: 300,
-                },
-                {
-                  color: '#a4d690',
-                  from: 200,
-                  to: 200,
-                },
-
-              ],
-            },
-            useFillColorAsStroke: true,
-          },
-        },
         series: [
           {
             data: [
@@ -151,9 +120,44 @@ describe('WeightsChart', () => {
           },
         ],
         type: 'treemap',
-        tooltip: {
-          y: {
+        options: {
+          dataLabels: {
+            enabled: true,
             formatter: expect.any(Function),
+            offsetY: -4,
+            style: {
+              fontSize: '12px',
+            },
+          },
+          plotOptions: {
+            treemap: {
+              colorScale: {
+                ranges: [
+                  {
+                    color: '#d12b2b',
+                    from: 100,
+                    to: 100,
+                  },
+                  {
+                    color: '#52b12c',
+                    from: 300,
+                    to: 300,
+                  },
+                  {
+                    color: '#a4d690',
+                    from: 200,
+                    to: 200,
+                  },
+
+                ],
+              },
+              useFillColorAsStroke: true,
+            },
+          },
+          tooltip: {
+            y: {
+              formatter: expect.any(Function),
+            },
           },
         },
       },

--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -7,27 +7,11 @@ import { ApexOptions } from 'apexcharts';
 import { moneyToString } from '@/helpers/number';
 
 export type ChartProps = {
-  type: 'line' | 'bar' | 'pie' | 'donut' | 'treemap' | 'radialBar',
+  options?: ApexOptions,
   series?: ApexOptions['series'],
-  labels?: string[],
-  id?: string,
-  title?: string,
-  showLegend?: boolean,
-  xCategories?: string[],
-  unit?: string,
-  stacked?: boolean,
+  type?: 'bar' | 'line' | 'pie' | 'donut' | 'treemap',
   height?: number,
-  xAxisType?: 'datetime' | 'category' | 'numeric' | undefined,
-  events?: {
-    mounted?(chart: any, options?: any): void
-    dataPointSelection?(e: any, chart?: any, options?: any): void
-  },
-  dataLabels?: ApexOptions['dataLabels'],
-  plotOptions?: ApexOptions['plotOptions'],
-  grid?: ApexOptions['grid'],
-  colors?: ApexOptions['colors'],
-  tooltip?: ApexOptions['tooltip'],
-  states?: ApexOptions['states'],
+  unit?: string,
 };
 
 // apexcharts import references window so we need this
@@ -43,93 +27,60 @@ const ApexChart = dynamic(
 );
 
 export default function Chart({
-  type,
-  title,
-  id,
+  options = {},
   series = [],
-  labels = [],
-  showLegend = true,
-  stacked = false,
-  xCategories = [],
-  colors,
-  unit = '',
+  type = 'line',
   height = 400,
-  xAxisType = undefined,
-  dataLabels = {
-    enabled: false,
-  },
-  plotOptions = {},
-  events = {},
-  grid = {},
-  tooltip = {},
-  states = {},
+  unit = 'EUR',
 }: ChartProps): JSX.Element {
   if (!series?.length) {
     return (
       <span>Loading...</span>
     );
   }
-  const yFormatter = (val: number) => moneyToString(val, unit);
 
-  let options = OPTIONS;
-  options = {
+  OPTIONS.yaxis = {
+    labels: {
+      formatter: (val: number) => moneyToString(val, unit),
+    },
+  };
+  OPTIONS.tooltip = {
+    ...OPTIONS.tooltip,
+    y: {
+      formatter: (val: number) => moneyToString(val, unit),
+    },
+  };
+
+  const mergedOptions: ApexOptions = {
+    ...OPTIONS,
     ...options,
-    grid: {
-      borderColor: '#777f85',
-      ...grid,
-    },
-    labels,
-    colors,
     chart: {
+      ...OPTIONS.chart,
       ...options.chart,
-      id,
-      sparkline: {
-        enabled: type === 'treemap',
-      },
-      stacked,
-      events,
-    },
-    dataLabels,
-    plotOptions,
-    legend: {
-      show: showLegend,
-    },
-    title: {
-      text: title,
-      align: 'left',
-    },
-    xaxis: {
-      ...options.xaxis,
-      categories: xCategories,
-      type: xAxisType,
-    },
-    yaxis: {
-      labels: {
-        formatter: (type !== 'treemap' && !plotOptions.bar?.horizontal) ? yFormatter : undefined,
-      },
     },
     tooltip: {
+      ...OPTIONS.tooltip,
       ...options.tooltip,
-      y: {
-        formatter: yFormatter,
-      },
-      ...tooltip,
+    },
+    dataLabels: {
+      ...OPTIONS.dataLabels,
+      ...options.dataLabels,
     },
     stroke: {
-      ...options.stroke,
+      ...OPTIONS.stroke,
       width: type === 'line' ? 1 : 0,
-      dashArray: type === 'line' ? 5 : 0,
+      ...options.stroke,
     },
-    states: {
-      ...options.states,
-      ...states,
+    xaxis: {
+      ...OPTIONS.xaxis,
+      ...options.xaxis,
     },
   };
 
   return (
     // @ts-ignore
     <ApexChart
-      options={options}
+      options={mergedOptions}
       series={series}
       type={type}
       // https://stackoverflow.com/questions/75103994
@@ -152,8 +103,22 @@ const OPTIONS: ApexOptions = {
       autoScaleYaxis: true,
     },
   },
+  grid: {
+    borderColor: '#777f85',
+  },
+  dataLabels: {
+    enabled: false,
+    style: {
+      colors: ['#DDDDDD'],
+      fontFamily: 'Intervariable',
+      fontWeight: '300',
+      fontSize: '14px',
+    },
+    dropShadow: {
+      enabled: false,
+    },
+  },
   stroke: {
-    dashArray: 5,
     curve: 'smooth',
   },
   xaxis: {

--- a/src/components/pages/account/SplitsHistogram.tsx
+++ b/src/components/pages/account/SplitsHistogram.tsx
@@ -67,29 +67,33 @@ export default function SplitsHistogram({
     <Chart
       type="bar"
       series={series}
-      title="Movements per month"
-      xCategories={Object.values(MONTHS)}
       unit={splits[0]?.account.commodity.mnemonic}
-      plotOptions={
-        {
+      options={{
+        title: {
+          text: 'Movements per month',
+        },
+        xaxis: {
+          categories: Object.values(MONTHS),
+        },
+        plotOptions: {
           bar: {
             horizontal: false,
-            columnWidth: '55%',
+            columnWidth: '70%',
           },
-        }
-      }
-      events={
-        {
-          mounted: (chart) => hiddenSeries.forEach(name => {
-            try {
-              chart.hideSeries(name);
-            } catch {
-              // this fails sometimes for some reason but still renders
-              // as expected. Adding the catch to protect against that.
-            }
-          }),
-        }
-      }
+        },
+        chart: {
+          events: {
+            mounted: (chart) => hiddenSeries.forEach(name => {
+              try {
+                chart.hideSeries(name);
+              } catch {
+                // this fails sometimes for some reason but still renders
+                // as expected. Adding the catch to protect against that.
+              }
+            }),
+          },
+        },
+      }}
     />
   );
 }

--- a/src/components/pages/account/TotalLineChart.tsx
+++ b/src/components/pages/account/TotalLineChart.tsx
@@ -33,7 +33,11 @@ export default function TotalLineChart({
       series={series}
       unit={splits[0]?.account.commodity.mnemonic}
       height={255}
-      xAxisType="datetime"
+      options={{
+        xaxis: {
+          type: 'datetime',
+        },
+      }}
     />
   );
 }

--- a/src/components/pages/accounts/NetWorthHistogram.tsx
+++ b/src/components/pages/accounts/NetWorthHistogram.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { DateTime, Interval } from 'luxon';
+
+import Chart from '@/components/charts/Chart';
+import type { AccountsTree } from '@/types/accounts';
+import { moneyToString } from '@/helpers/number';
+
+export type NetWorthHistogramProps = {
+  startDate?: DateTime,
+  tree: AccountsTree,
+};
+
+export default function NetWorthHistogram({
+  startDate,
+  tree,
+}: NetWorthHistogramProps): JSX.Element {
+  const interval = Interval.fromDateTimes(
+    startDate || DateTime.now(),
+    DateTime.now(),
+  );
+  const dates = interval.splitBy({ month: 1 }).map((d) => (d.start as DateTime).plus({ month: 1 }));
+  dates.pop();
+
+  // Seems apexcharts types are not correct so need to define manually
+  const series: {
+    name: string,
+    type: string,
+    data: {
+      x: DateTime,
+      y: number,
+    }[],
+  }[] = [
+    {
+      name: 'Income',
+      type: 'column',
+      data: [],
+    },
+    {
+      name: 'Expenses',
+      type: 'column',
+      data: [],
+    },
+    {
+      name: 'Net profit',
+      type: 'column',
+      data: [],
+    },
+    {
+      name: 'Net worth',
+      type: 'line',
+      data: [],
+    },
+  ];
+
+  let incomeAccount: AccountsTree | undefined;
+  if ((tree?.children || []).length) {
+    incomeAccount = tree.children.find(a => a.account.type === 'INCOME');
+    const expensesAccount = tree.children.find(a => a.account.type === 'EXPENSE');
+    dates.forEach(date => {
+      const monthYear = (date as DateTime).minus({ month: 1 }).toFormat('MMM/yy');
+      const incomeAmount = (incomeAccount?.monthlyTotals[monthYear]?.toNumber() || 0);
+      series[0].data.push({
+        y: incomeAmount,
+        x: date,
+      });
+
+      const expenseAmount = (expensesAccount?.monthlyTotals[monthYear]?.toNumber() || 0);
+      series[1].data.push({
+        y: -expenseAmount,
+        x: date,
+      });
+
+      const netProfit = incomeAmount - expenseAmount;
+      series[2].data.push({
+        y: netProfit,
+        x: date,
+      });
+
+      const previousNetWorth = series[3].data[series[3].data.length - 1]?.y || 0;
+      series[3].data.push({
+        y: previousNetWorth + netProfit,
+        x: date,
+      });
+    });
+  }
+
+  return (
+    <>
+      <Chart
+        type="line"
+        series={series}
+        height={350}
+        options={{
+          chart: {
+            id: 'netWorthHistogram',
+          },
+          xaxis: {
+            type: 'datetime',
+            crosshairs: {
+              show: true,
+              width: 'barWidth',
+              opacity: 0.1,
+              stroke: {
+                width: 0,
+              },
+            },
+          },
+          colors: ['#22C55E', '#EF4444', '#06B6D4', '#06B6D4'],
+          plotOptions: {
+            bar: {
+              columnWidth: '70%',
+            },
+          },
+          markers: {
+            size: 2,
+            strokeColors: '#06B6D4',
+          },
+          legend: {
+            position: 'top',
+            onItemClick: {
+              toggleDataSeries: false,
+            },
+          },
+          yaxis: [
+            {
+              seriesName: 'Income',
+              title: {
+                text: 'Net profit',
+              },
+              labels: {
+                formatter: (val: number) => moneyToString(
+                  val,
+                  incomeAccount?.account.commodity.mnemonic,
+                ),
+              },
+              forceNiceScale: true,
+            },
+            {
+              seriesName: 'Income',
+              show: false,
+              labels: {
+                formatter: (val: number) => moneyToString(
+                  val,
+                  incomeAccount?.account.commodity.mnemonic,
+                ),
+              },
+            },
+            {
+              seriesName: 'Income',
+              show: false,
+              labels: {
+                formatter: (val: number) => moneyToString(
+                  val,
+                  incomeAccount?.account.commodity.mnemonic,
+                ),
+              },
+            },
+            {
+              opposite: true,
+              seriesName: 'Net worth',
+              title: {
+                text: 'Net worth',
+              },
+              forceNiceScale: true,
+              labels: {
+                formatter: (val: number) => moneyToString(
+                  val,
+                  incomeAccount?.account.commodity.mnemonic,
+                ),
+              },
+            },
+          ],
+        }}
+      />
+
+      <Chart
+        height={100}
+        type="line"
+        series={[series[3]]}
+        options={
+          {
+            chart: {
+              brush: {
+                enabled: true,
+                target: 'netWorthHistogram',
+              },
+              selection: {
+                enabled: true,
+                xaxis: {
+                  min: DateTime.now().minus({ months: 6 }).toMillis(),
+                  max: DateTime.now().toMillis(),
+                },
+                fill: {
+                  color: '#888',
+                  opacity: 0.4,
+                },
+                stroke: {
+                  color: '#0D47A1',
+                },
+              },
+            },
+            colors: ['#06B6D4'],
+            grid: {
+              show: false,
+            },
+            xaxis: {
+              type: 'datetime',
+            },
+            yaxis: {
+              show: false,
+            },
+          }
+        }
+      />
+    </>
+  );
+}

--- a/src/components/pages/accounts/NetWorthPie.tsx
+++ b/src/components/pages/accounts/NetWorthPie.tsx
@@ -30,65 +30,63 @@ export default function NetWorthPie({
     <Chart
       type="donut"
       series={series}
-      labels={['Assets', 'Liabilities']}
-      colors={['#06B6D4', '#F97316']}
       height={300}
       unit={unit}
-      showLegend={false}
-      tooltip={{
-        enabled: false,
-      }}
-      dataLabels={{
-        enabled: true,
-        // @ts-ignore types are wrong here as for a breakline we need to return
-        // an array
-        formatter: (val: number, opts) => {
-          const name = opts.w.globals.labels[opts.seriesIndex];
-          return [
-            name,
-            moneyToString(
-              opts.w.globals.series[opts.seriesIndex],
-              unit,
-            ),
-          ];
+      options={{
+        labels: ['Assets', 'Liabilities'],
+        colors: ['#06B6D4', '#F97316'],
+        legend: {
+          show: false,
         },
-        style: {
-          colors: ['#DDDDDD'],
-        },
-        dropShadow: {
+        tooltip: {
           enabled: false,
         },
-      }}
-      grid={{
-        padding: {
-          bottom: -110,
+        dataLabels: {
+          enabled: true,
+          // @ts-ignore types are wrong here as for a breakline we need to return
+          // an array
+          formatter: (val: number, opts) => {
+            const name = opts.w.globals.labels[opts.seriesIndex];
+            return [
+              name,
+              moneyToString(
+                opts.w.globals.series[opts.seriesIndex],
+                unit,
+              ),
+            ];
+          },
         },
-      }}
-      plotOptions={{
-        pie: {
-          startAngle: -90,
-          endAngle: 90,
-          offsetY: 10,
-          donut: {
-            labels: {
-              show: true,
-              total: {
+        grid: {
+          padding: {
+            bottom: -110,
+          },
+        },
+        plotOptions: {
+          pie: {
+            startAngle: -90,
+            endAngle: 90,
+            offsetY: 10,
+            donut: {
+              labels: {
                 show: true,
-                showAlways: true,
-                label: 'Net worth',
-                formatter: (opts) => moneyToString(
-                  (opts.globals.series[0] || 0) - opts.globals.series[1],
-                  unit,
-                ),
+                total: {
+                  show: true,
+                  showAlways: true,
+                  label: 'Net worth',
+                  formatter: (opts) => moneyToString(
+                    (opts.globals.series[0] || 0) - opts.globals.series[1],
+                    unit,
+                  ),
+                },
               },
             },
           },
         },
-      }}
-      states={{
-        hover: {
-          filter: {
-            type: 'none',
+        states: {
+          hover: {
+            filter: {
+              type: 'none',
+            },
           },
         },
       }}

--- a/src/components/pages/investments/DividendChart.tsx
+++ b/src/components/pages/investments/DividendChart.tsx
@@ -36,49 +36,57 @@ export default function DividendChart({
             <Chart
               type="bar"
               series={[{ data: yearData, name: 'dividends' }]}
-              showLegend={false}
               unit={currency}
-              plotOptions={
-                {
+              options={{
+                legend: {
+                  show: false,
+                },
+                plotOptions: {
                   bar: {
                     horizontal: true,
                     barHeight: '55%',
                   },
-                }
-              }
-              events={
-                {
-                  dataPointSelection: (e, chart) => {
-                    const seriesIndex = 0;
+                },
+                chart: {
+                  events: {
+                    dataPointSelection: (e, chart) => {
+                      const seriesIndex = 0;
 
-                    const selectedPoint = chart.w.globals.selectedDataPoints[0][0];
-                    if (selectedPoint === undefined) {
-                      return [];
-                    }
-                    const selected = chart.w.config.series[seriesIndex].data[selectedPoint] as {
-                      x: string,
-                      y: number,
-                      dividends: { [month: string]: { amount: number, ticker: string }[] },
-                    };
+                      const selectedPoint = chart.w.globals.selectedDataPoints[0][0];
+                      if (selectedPoint === undefined) {
+                        return [];
+                      }
+                      const selected = chart.w.config.series[seriesIndex].data[selectedPoint] as {
+                        x: string,
+                        y: number,
+                        dividends: { [month: string]: { amount: number, ticker: string }[] },
+                      };
 
-                    return ApexCharts.exec('barMonthly', 'updateOptions', {
-                      series: buildMonthlySeries(selected),
-                    });
+                      return ApexCharts.exec('barMonthly', 'updateOptions', {
+                        series: buildMonthlySeries(selected),
+                      });
+                    },
                   },
-                }
-              }
+                },
+              }}
             />
           </div>
         </div>
         <div className="col-span-8">
           <div id="chart-monthly">
             <Chart
-              id="barMonthly"
               type="bar"
               series={lastYearMonthlySeries}
               unit={currency}
-              xCategories={Object.values(MONTHS)}
-              stacked
+              options={{
+                chart: {
+                  id: 'barMonthly',
+                  stacked: true,
+                },
+                xaxis: {
+                  categories: Object.values(MONTHS),
+                },
+              }}
             />
           </div>
         </div>

--- a/src/components/pages/investments/WeightsChart.tsx
+++ b/src/components/pages/investments/WeightsChart.tsx
@@ -62,8 +62,8 @@ export default function WeightsChart({
       type="treemap"
       series={series}
       height={650}
-      dataLabels={
-        {
+      options={{
+        dataLabels: {
           enabled: true,
           style: {
             fontSize: '12px',
@@ -71,10 +71,8 @@ export default function WeightsChart({
           // @ts-ignore
           formatter: (text: string) => `${text}: ${data[text].today}`,
           offsetY: -4,
-        }
-      }
-      plotOptions={
-        {
+        },
+        plotOptions: {
           treemap: {
             useFillColorAsStroke: true,
             colorScale: {
@@ -85,13 +83,13 @@ export default function WeightsChart({
               })),
             },
           },
-        }
-      }
-      tooltip={{
-        y: {
-          formatter: (val: number, { dataPointIndex, w }) => (
-            `${moneyToString(val, totalValue.currency)} (${data[w.globals.categoryLabels[dataPointIndex]].pct}%)`
-          ),
+        },
+        tooltip: {
+          y: {
+            formatter: (val: number, { dataPointIndex, w }) => (
+              `${moneyToString(val, totalValue.currency)} (${data[w.globals.categoryLabels[dataPointIndex]].pct}%)`
+            ),
+          },
         },
       }}
     />

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,9 +4,12 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import crypto from 'crypto';
+import { Settings } from 'luxon';
 
 Object.defineProperty(global.self, 'crypto', {
   value: {
     randomUUID: () => crypto.randomUUID(),
   },
 });
+
+Settings.defaultZone = 'utc';

--- a/src/types/accounts.d.ts
+++ b/src/types/accounts.d.ts
@@ -3,5 +3,6 @@ import Money from '@/book/Money';
 export type AccountsTree = {
   account: Account,
   total: Money, // Total including the children totals
+  monthlyTotals: { [key: string]: Money },
   children: AccountsTree[],
 };


### PR DESCRIPTION
The PR adds a net worth histogram calculated from monthly income - expenses, accumulating net profit. 

<img width="466" alt="Screenshot 2023-08-04 at 6 33 36 PM" src="https://github.com/maffin-io/maffin-app/assets/3578154/49ade044-cd20-4de0-9140-9fdd4dc17711">

The calculation uses a different approach from the piechart net worth which uses assets - liabilities. With my numbers, I'm getting a difference of 3k and I don't know why, maybe I'm missing something or maybe some accounting is done wrong somewhere... will investigate with simpler books to see if this is repeated.

Relates to #84 