### PR TITLE
Add expenses/income histograms to home page

### DIFF
--- a/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
@@ -11,10 +11,9 @@ import Money from '@/book/Money';
 import AccountPage from '@/app/dashboard/accounts/[guid]/page';
 import TransactionsTable from '@/components/TransactionsTable';
 import TransactionFormButton from '@/components/buttons/TransactionFormButton';
-import SplitsHistogram from '@/components/pages/account/SplitsHistogram';
-import TotalLineChart from '@/components/pages/account/TotalLineChart';
 import { Account, Split } from '@/book/entities';
 import * as apiHook from '@/hooks/useApi';
+import { SplitsHistogram, TotalLineChart } from '@/components/pages/account';
 
 jest.mock('@/hooks/useApi', () => ({
   __esModule: true,

--- a/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/accounts/__snapshots__/page.test.tsx.snap
@@ -1,115 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AccountsPage generates tree as expected, no investments 1`] = `
-<div>
-  <div
-    class="flex items-center"
-  >
-    <span
-      class="text-xl font-medium"
-    >
-      Your finances
-    </span>
-    <span
-      class="ml-auto mr-3"
-    >
-      <div
-        data-testid="DateRangeInput"
-      />
-    </span>
-    <div>
-      <div
-        data-testid="AddAccountButton"
-      />
-    </div>
-  </div>
-  <div
-    class="grid grid-cols-12 items-start items-top pb-4"
-  >
-    <div
-      class="grid grid-cols-12 col-span-3"
-    >
-      <div
-        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
-      >
-        <div
-          data-testid="NetWorthPie"
-        />
-      </div>
-      <div
-        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
-      >
-        <div
-          data-testid="AccountsTable"
-        />
-      </div>
-    </div>
-    <div
-      class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
-    >
-      <div
-        data-testid="NetWorthHistogram"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`AccountsPage generates tree as expected, with investments 1`] = `
-<div>
-  <div
-    class="flex items-center"
-  >
-    <span
-      class="text-xl font-medium"
-    >
-      Your finances
-    </span>
-    <span
-      class="ml-auto mr-3"
-    >
-      <div
-        data-testid="DateRangeInput"
-      />
-    </span>
-    <div>
-      <div
-        data-testid="AddAccountButton"
-      />
-    </div>
-  </div>
-  <div
-    class="grid grid-cols-12 items-start items-top pb-4"
-  >
-    <div
-      class="grid grid-cols-12 col-span-3"
-    >
-      <div
-        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
-      >
-        <div
-          data-testid="NetWorthPie"
-        />
-      </div>
-      <div
-        class="col-span-12 p-4 mr-4 rounded-sm bg-gunmetal-700"
-      >
-        <div
-          data-testid="AccountsTable"
-        />
-      </div>
-    </div>
-    <div
-      class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
-    >
-      <div
-        data-testid="NetWorthHistogram"
-      />
-    </div>
-  </div>
-</div>
-`;
-
 exports[`AccountsPage passes empty data to components when loading when not ready 1`] = `
 <div>
   <div
@@ -155,11 +45,29 @@ exports[`AccountsPage passes empty data to components when loading when not read
       </div>
     </div>
     <div
-      class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      class="grid grid-cols-12 col-span-9"
     >
       <div
-        data-testid="NetWorthHistogram"
-      />
+        class="col-span-9 p-4 mb-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="NetWorthHistogram"
+        />
+      </div>
+      <div
+        class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="MonthlyTotalHistogram"
+        />
+      </div>
+      <div
+        class="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700"
+      >
+        <div
+          data-testid="MonthlyTotalHistogram"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/src/__tests__/app/dashboard/investments/page.test.tsx
+++ b/src/__tests__/app/dashboard/investments/page.test.tsx
@@ -4,10 +4,12 @@ import type { SWRResponse } from 'swr';
 
 import { Commodity } from '@/book/entities';
 import InvestmentsPage from '@/app/dashboard/investments/page';
-import WeightsChart from '@/components/pages/investments/WeightsChart';
 import StatisticsWidget from '@/components/StatisticsWidget';
-import InvestmentsTable from '@/components/pages/investments/InvestmentsTable';
-import DividendChart from '@/components/pages/investments/DividendChart';
+import {
+  WeightsChart,
+  DividendChart,
+  InvestmentsTable,
+} from '@/components/pages/investments';
 import Money from '@/book/Money';
 import { InvestmentAccount } from '@/book/models';
 import * as apiHook from '@/hooks/useApi';

--- a/src/__tests__/components/pages/accounts/MonthlyHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/MonthlyHistogram.test.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DateTime } from 'luxon';
+
+import Money from '@/book/Money';
+import { Account } from '@/book/entities';
+import Chart from '@/components/charts/Chart';
+import { MonthlyTotalHistogram } from '@/components/pages/accounts';
+
+jest.mock('@/components/charts/Chart', () => jest.fn(
+  () => <div data-testid="Chart" />,
+));
+
+describe('NetWorthHistogram', () => {
+  const now = DateTime.fromISO('2023-01-02');
+
+  beforeEach(() => {
+    jest.spyOn(DateTime, 'now').mockReturnValue(now);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with empty tree', () => {
+    render(<MonthlyTotalHistogram title="Title" />);
+
+    expect(Chart).toBeCalledWith(
+      {
+        height: 300,
+        type: 'bar',
+        unit: undefined,
+        series: [],
+        options: {
+          chart: {
+            stacked: true,
+          },
+          colors: [
+            '#2E93fA',
+            '#66DA26',
+            '#546E7A',
+            '#E91E63',
+            '#FF9800',
+            '#9C27B0',
+            '#00BCD4',
+            '#4CAF50',
+            '#FF5722',
+            '#FFC107',
+          ],
+          plotOptions: {
+            bar: {
+              columnWidth: '60%',
+            },
+          },
+          title: { text: 'Title' },
+          xaxis: { type: 'datetime' },
+        },
+      },
+      {},
+    );
+  });
+
+  // Checks that X range is computed as -8 months to now when
+  // not selected date is passed
+  it.each(
+    [undefined, now.minus({ months: 3 })],
+  )('selects default date now - 8 months', (date) => {
+    render(
+      <MonthlyTotalHistogram
+        title="Title"
+        selectedDate={date}
+        tree={
+          {
+            account: {
+              guid: 'Income',
+              type: 'INCOME',
+              commodity: { mnemonic: 'EUR' },
+            } as Account,
+            total: new Money(0, 'EUR'),
+            monthlyTotals: {},
+            children: [
+              {
+                account: {
+                  guid: 'Salary',
+                  name: 'Salary',
+                  type: 'INCOME',
+                  commodity: { mnemonic: 'EUR' },
+                },
+                total: new Money(2000, 'EUR'),
+                monthlyTotals: {
+                  'Nov/22': new Money(1000, 'EUR'),
+                  'Dec/22': new Money(1000, 'EUR'),
+                },
+                children: [],
+              },
+            ],
+          }
+        }
+      />,
+    );
+
+    const { series } = (Chart as jest.Mock).mock.calls[0][0];
+    expect(
+      series[0].data[0].x,
+    ).toEqual(now.minus({ months: 7 }).startOf('month').plus({ days: 1 }).toMillis());
+    expect(
+      series[0].data[series[0].data.length - 1].x,
+    ).toEqual(now.startOf('month').plus({ days: 1 }).toMillis());
+  });
+
+  it('selects date range of 8 months in the past', () => {
+    const selectedDate = now.minus({ years: 1 });
+    render(
+      <MonthlyTotalHistogram
+        title="Title"
+        selectedDate={selectedDate}
+        tree={
+          {
+            account: {
+              guid: 'Income',
+              type: 'INCOME',
+              commodity: { mnemonic: 'EUR' },
+            } as Account,
+            total: new Money(0, 'EUR'),
+            monthlyTotals: {},
+            children: [
+              {
+                account: {
+                  guid: 'Salary',
+                  name: 'Salary',
+                  type: 'INCOME',
+                  commodity: { mnemonic: 'EUR' },
+                },
+                total: new Money(2000, 'EUR'),
+                monthlyTotals: {
+                  'Nov/21': new Money(1000, 'EUR'),
+                  'Dec/21': new Money(1000, 'EUR'),
+                },
+                children: [],
+              },
+            ],
+          }
+        }
+      />,
+    );
+
+    const { series } = (Chart as jest.Mock).mock.calls[0][0];
+    expect(
+      series[0].data[0].x,
+    ).toEqual(selectedDate.minus({ months: 3 }).startOf('month').plus({ days: 1 }).toMillis());
+    expect(
+      series[0].data[series[0].data.length - 1].x,
+    ).toEqual(selectedDate.plus({ months: 4 }).startOf('month').plus({ days: 1 }).toMillis());
+  });
+
+  it('generates series from tree as expected', () => {
+    render(
+      <MonthlyTotalHistogram
+        title="Title"
+        tree={
+          {
+            account: {
+              guid: 'Income',
+              type: 'INCOME',
+              commodity: { mnemonic: 'EUR' },
+            } as Account,
+            total: new Money(0, 'EUR'),
+            monthlyTotals: {},
+            children: [
+              {
+                account: {
+                  guid: 'Salary',
+                  name: 'Salary',
+                  type: 'INCOME',
+                  commodity: { mnemonic: 'EUR' },
+                },
+                total: new Money(2000, 'EUR'),
+                monthlyTotals: {
+                  'Nov/22': new Money(1000, 'EUR'),
+                  'Dec/22': new Money(1000, 'EUR'),
+                },
+                children: [],
+              },
+              {
+                account: {
+                  guid: 'Dividends',
+                  name: 'Dividends',
+                  type: 'INCOME',
+                  commodity: { mnemonic: 'EUR' },
+                },
+                total: new Money(200, 'EUR'),
+                monthlyTotals: {
+                  'Nov/22': new Money(150, 'EUR'),
+                  'Dec/22': new Money(50, 'EUR'),
+                },
+                children: [],
+              },
+            ],
+          }
+        }
+      />,
+    );
+
+    const { series, unit } = (Chart as jest.Mock).mock.calls[0][0];
+    expect(unit).toEqual('EUR');
+    expect(series).toEqual([
+      {
+        name: 'Salary',
+        data: [
+          {
+            x: now.minus({ months: 7 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 6 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 5 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 4 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 3 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 2 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 1000,
+          },
+          {
+            x: now.minus({ months: 1 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 1000,
+          },
+          {
+            x: now.startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+        ],
+      },
+      {
+        name: 'Dividends',
+        data: [
+          {
+            x: now.minus({ months: 7 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 6 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 5 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 4 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 3 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+          {
+            x: now.minus({ months: 2 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 150,
+          },
+          {
+            x: now.minus({ months: 1 }).startOf('month').plus({ days: 1 }).toMillis(),
+            y: 50,
+          },
+          {
+            x: now.startOf('month').plus({ days: 1 }).toMillis(),
+            y: 0,
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import Money from '@/book/Money';
 import { Account } from '@/book/entities';
 import Chart from '@/components/charts/Chart';
-import NetWorthHistogram from '@/components/pages/accounts/NetWorthHistogram';
+import { NetWorthHistogram } from '@/components/pages/accounts';
 import type { AccountsTree } from '@/types/accounts';
 
 jest.mock('@/components/charts/Chart', () => jest.fn(
@@ -220,15 +220,15 @@ describe('NetWorthHistogram', () => {
           },
           {
             x: DateTime.fromISO('2022-11-01'),
-            y: 0,
-          },
-          {
-            x: DateTime.fromISO('2022-12-01'),
             y: 600,
           },
           {
-            x: DateTime.fromISO('2023-01-01'),
+            x: DateTime.fromISO('2022-12-01'),
             y: 400,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: 0,
           },
         ],
       },
@@ -242,15 +242,15 @@ describe('NetWorthHistogram', () => {
           },
           {
             x: DateTime.fromISO('2022-11-01'),
-            y: -0,
-          },
-          {
-            x: DateTime.fromISO('2022-12-01'),
             y: -400,
           },
           {
-            x: DateTime.fromISO('2023-01-01'),
+            x: DateTime.fromISO('2022-12-01'),
             y: -500,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: -0,
           },
         ],
       },
@@ -264,15 +264,15 @@ describe('NetWorthHistogram', () => {
           },
           {
             x: DateTime.fromISO('2022-11-01'),
-            y: 0,
-          },
-          {
-            x: DateTime.fromISO('2022-12-01'),
             y: 200,
           },
           {
-            x: DateTime.fromISO('2023-01-01'),
+            x: DateTime.fromISO('2022-12-01'),
             y: -100,
+          },
+          {
+            x: DateTime.fromISO('2023-01-01'),
+            y: 0,
           },
         ],
       },
@@ -286,11 +286,11 @@ describe('NetWorthHistogram', () => {
           },
           {
             x: DateTime.fromISO('2022-11-01'),
-            y: 0,
+            y: 200,
           },
           {
             x: DateTime.fromISO('2022-12-01'),
-            y: 200,
+            y: 100,
           },
           {
             x: DateTime.fromISO('2023-01-01'),
@@ -312,11 +312,11 @@ describe('NetWorthHistogram', () => {
           },
           {
             x: DateTime.fromISO('2022-11-01'),
-            y: 0,
+            y: 200,
           },
           {
             x: DateTime.fromISO('2022-12-01'),
-            y: 200,
+            y: 100,
           },
           {
             x: DateTime.fromISO('2023-01-01'),

--- a/src/app/dashboard/accounts/[guid]/page.tsx
+++ b/src/app/dashboard/accounts/[guid]/page.tsx
@@ -8,8 +8,7 @@ import type { SWRResponse } from 'swr';
 
 import type { Account } from '@/book/entities';
 import Money from '@/book/Money';
-import SplitsHistogram from '@/components/pages/account/SplitsHistogram';
-import TotalLineChart from '@/components/pages/account/TotalLineChart';
+import { SplitsHistogram, TotalLineChart } from '@/components/pages/account';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import { Split } from '@/book/entities';
 import TransactionsTable from '@/components/TransactionsTable';

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -8,8 +8,11 @@ import type { Account } from '@/book/entities';
 import Money from '@/book/Money';
 import AccountsTable from '@/components/AccountsTable';
 import AddAccountButton from '@/components/buttons/AddAccountButton';
-import NetWorthPie from '@/components/pages/accounts/NetWorthPie';
-import NetWorthHistogram from '@/components/pages/accounts/NetWorthHistogram';
+import {
+  NetWorthPie,
+  NetWorthHistogram,
+  MonthlyTotalHistogram,
+} from '@/components/pages/accounts';
 import { PriceDBMap } from '@/book/prices';
 import DateRangeInput from '@/components/DateRangeInput';
 import { useApi } from '@/hooks';
@@ -69,12 +72,28 @@ export default function AccountsPage(): JSX.Element {
             <AccountsTable tree={tree} />
           </div>
         </div>
-        <div className="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700">
-          <NetWorthHistogram
-            tree={tree}
-            startDate={earliestDate}
-            selectedDate={selectedDate}
-          />
+        <div className="grid grid-cols-12 col-span-9">
+          <div className="col-span-9 p-4 mb-4 mr-4 rounded-sm bg-gunmetal-700">
+            <NetWorthHistogram
+              tree={tree}
+              startDate={earliestDate}
+              selectedDate={selectedDate}
+            />
+          </div>
+          <div className="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700">
+            <MonthlyTotalHistogram
+              title="Income"
+              tree={tree.children.find(a => a.account.type === 'INCOME')}
+              selectedDate={selectedDate}
+            />
+          </div>
+          <div className="col-span-6 p-4 mr-4 rounded-sm bg-gunmetal-700">
+            <MonthlyTotalHistogram
+              title="Expenses"
+              tree={tree.children.find(a => a.account.type === 'EXPENSE')}
+              selectedDate={selectedDate}
+            />
+          </div>
         </div>
       </div>
     </>

--- a/src/app/dashboard/investments/page.tsx
+++ b/src/app/dashboard/investments/page.tsx
@@ -5,10 +5,12 @@ import classNames from 'classnames';
 import type { SWRResponse } from 'swr';
 
 import type { InvestmentAccount } from '@/book/models';
-import WeightsChart from '@/components/pages/investments/WeightsChart';
+import {
+  WeightsChart,
+  DividendChart,
+  InvestmentsTable,
+} from '@/components/pages/investments';
 import StatisticsWidget from '@/components/StatisticsWidget';
-import InvestmentsTable from '@/components/pages/investments/InvestmentsTable';
-import DividendChart from '@/components/pages/investments/DividendChart';
 import { toFixed } from '@/helpers/number';
 import Money from '@/book/Money';
 import { useApi } from '@/hooks';

--- a/src/components/pages/account/index.ts
+++ b/src/components/pages/account/index.ts
@@ -1,0 +1,2 @@
+export { default as TotalLineChart } from './TotalLineChart';
+export { default as SplitsHistogram } from './SplitsHistogram';

--- a/src/components/pages/accounts/MonthlyTotalHistogram.tsx
+++ b/src/components/pages/accounts/MonthlyTotalHistogram.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { DateTime, Interval } from 'luxon';
+
+import Chart from '@/components/charts/Chart';
+import type { AccountsTree } from '@/types/accounts';
+
+export type MonthlyTotalHistogramProps = {
+  title: string,
+  selectedDate?: DateTime,
+  tree?: AccountsTree,
+};
+
+export default function MonthlyTotalHistogram({
+  title,
+  selectedDate = DateTime.now().minus({ months: 4 }),
+  tree,
+}: MonthlyTotalHistogramProps): JSX.Element {
+  const now = DateTime.now();
+
+  if (now.diff(selectedDate, ['months']).months < 4) {
+    selectedDate = now.minus({ months: 4 });
+  }
+  const interval = Interval.fromDateTimes(
+    selectedDate.minus({ months: 4 }),
+    selectedDate.plus({ months: 4 }),
+  );
+
+  const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).plus({ month: 1 }).endOf('month'));
+
+  const series: {
+    name: string,
+    data: { x: number, y: number }[],
+  }[] = [];
+
+  if (tree) {
+    tree.children.forEach(leaf => {
+      series.push({
+        name: leaf.account.name,
+        data: dates.map(date => ({
+          y: leaf.monthlyTotals[date.toFormat('MMM/yy')]?.toNumber() || 0,
+          x: date.startOf('month').plus({ days: 1 }).toMillis(),
+        })),
+      });
+    });
+  }
+
+  return (
+    <Chart
+      type="bar"
+      series={series.filter(serie => !serie.data.every(n => n.y === 0))}
+      height={300}
+      unit={tree?.account.commodity.mnemonic}
+      options={{
+        chart: {
+          stacked: true,
+        },
+        colors: [
+          '#2E93fA',
+          '#66DA26',
+          '#546E7A',
+          '#E91E63',
+          '#FF9800',
+          '#9C27B0',
+          '#00BCD4',
+          '#4CAF50',
+          '#FF5722',
+          '#FFC107',
+        ],
+        title: {
+          text: title,
+        },
+        xaxis: {
+          type: 'datetime',
+        },
+        plotOptions: {
+          bar: {
+            columnWidth: '60%',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/src/components/pages/accounts/NetWorthHistogram.tsx
+++ b/src/components/pages/accounts/NetWorthHistogram.tsx
@@ -67,7 +67,7 @@ export default function NetWorthHistogram({
     incomeAccount = tree.children.find(a => a.account.type === 'INCOME');
     const expensesAccount = tree.children.find(a => a.account.type === 'EXPENSE');
     dates.forEach(date => {
-      const monthYear = (date as DateTime).minus({ month: 1 }).toFormat('MMM/yy');
+      const monthYear = (date as DateTime).toFormat('MMM/yy');
       const incomeAmount = (incomeAccount?.monthlyTotals[monthYear]?.toNumber() || 0);
       series[0].data.push({
         y: incomeAmount,

--- a/src/components/pages/accounts/index.ts
+++ b/src/components/pages/accounts/index.ts
@@ -1,0 +1,3 @@
+export { default as MonthlyTotalHistogram } from './MonthlyTotalHistogram';
+export { default as NetWorthHistogram } from './NetWorthHistogram';
+export { default as NetWorthPie } from './NetWorthPie';

--- a/src/components/pages/investments/index.ts
+++ b/src/components/pages/investments/index.ts
@@ -1,0 +1,3 @@
+export { default as WeightsChart } from './WeightsChart';
+export { default as DividendChart } from './DividendChart';
+export { default as InvestmentsTable } from './InvestmentsTable';


### PR DESCRIPTION
Adds expenses/income histograms in the home page to see monthly contribution to those types. The histograms have one serie per children account in that type, only first level taken into account. In the future we can allow users to dig deeper into categories (i.e. "Leisure" one may contain children accounts).

The histogram reacts to the date selection too.

Relates to #84 