### PR TITLE
Save datasource in context

### DIFF
--- a/src/__tests__/app/dashboard/layout.test.tsx
+++ b/src/__tests__/app/dashboard/layout.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import type { UseDataSourceReturn } from '@/hooks';
+import type { DataSourceContextType } from '@/hooks';
 import DashboardLayout from '@/app/dashboard/layout';
 import Topbar from '@/layout/Topbar';
 import LeftSidebar from '@/layout/LeftSidebar';
@@ -42,7 +42,7 @@ describe('DashboardLayout', () => {
       },
     });
     jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { isLoaded: true } as UseDataSourceReturn,
+      { isLoaded: true } as DataSourceContextType,
     );
   });
 
@@ -62,7 +62,7 @@ describe('DashboardLayout', () => {
 
   it('returns loading when datasource not available', async () => {
     jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { isLoaded: false } as UseDataSourceReturn,
+      { isLoaded: false } as DataSourceContextType,
     );
     jest.spyOn(userHooks, 'default').mockReturnValue({
       user: {

--- a/src/__tests__/components/buttons/AddAccountButton.test.tsx
+++ b/src/__tests__/components/buttons/AddAccountButton.test.tsx
@@ -9,8 +9,8 @@ import {
 import AddAccountButton from '@/components/buttons/AddAccountButton';
 import AccountForm from '@/components/forms/account/AccountForm';
 import Modal from '@/components/Modal';
-import type { UseDataSourceReturn } from '@/hooks';
-import * as dataSourceHooks from '@/hooks/useDataSource';
+import { DataSourceContext } from '@/hooks';
+import type { DataSourceContextType } from '@/hooks';
 
 jest.mock('@/components/Modal', () => jest.fn(
   (props: React.PropsWithChildren) => (
@@ -19,17 +19,11 @@ jest.mock('@/components/Modal', () => jest.fn(
     </div>
   ),
 ));
-const ModalMock = Modal as jest.MockedFunction<typeof Modal>;
 
 jest.mock('@/components/forms/account/AccountForm', () => jest.fn(
   () => <div data-testid="AccountForm" />,
 ).mockName('AccountForm'));
 const AccountFormMock = AccountForm as jest.MockedFunction<typeof AccountForm>;
-
-jest.mock('@/hooks/useDataSource', () => ({
-  __esModule: true,
-  ...jest.requireActual('@/hooks/useDataSource'),
-}));
 
 describe('AddAccountButton', () => {
   afterEach(() => {
@@ -37,9 +31,7 @@ describe('AddAccountButton', () => {
   });
 
   it('renders hidden modal on mount', async () => {
-    render(
-      <AddAccountButton />,
-    );
+    render(<AddAccountButton />);
     expect(Modal).toHaveBeenLastCalledWith(
       expect.objectContaining({
         open: false,
@@ -49,7 +41,7 @@ describe('AddAccountButton', () => {
       {},
     );
 
-    const { children } = ModalMock.mock.calls[0][0];
+    const { children } = (Modal as jest.Mock).mock.calls[0][0];
     // @ts-ignore
     expect(children.type.getMockName()).toEqual('AccountForm');
     expect(AccountForm).toHaveBeenLastCalledWith(
@@ -62,11 +54,11 @@ describe('AddAccountButton', () => {
 
   it('closes modal and saves', async () => {
     const mockSave = jest.fn();
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { save: mockSave as Function } as UseDataSourceReturn,
+    render(
+      <DataSourceContext.Provider value={{ save: mockSave as Function } as DataSourceContextType}>
+        <AddAccountButton />
+      </DataSourceContext.Provider>,
     );
-
-    render(<AddAccountButton />);
 
     // open modal to prove that onSave closes it
     const button = await screen.findByRole('button', { name: /add account/i });

--- a/src/__tests__/components/buttons/ImportButton.test.tsx
+++ b/src/__tests__/components/buttons/ImportButton.test.tsx
@@ -6,13 +6,8 @@ import {
 import userEvent from '@testing-library/user-event';
 
 import ImportButton from '@/components/buttons/ImportButton';
-import type { UseDataSourceReturn } from '@/hooks';
-import * as dataSourceHooks from '@/hooks/useDataSource';
-
-jest.mock('@/hooks/useDataSource', () => ({
-  __esModule: true,
-  ...jest.requireActual('@/hooks/useDataSource'),
-}));
+import { DataSourceContext } from '@/hooks';
+import type { DataSourceContextType } from '@/hooks';
 
 describe('ImportButton', () => {
   afterEach(() => {
@@ -20,10 +15,11 @@ describe('ImportButton', () => {
   });
 
   it('loads while unavailable datasource', async () => {
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { isLoaded: false } as UseDataSourceReturn,
+    const { container } = render(
+      <DataSourceContext.Provider value={{ isLoaded: false } as DataSourceContextType}>
+        <ImportButton />
+      </DataSourceContext.Provider>,
     );
-    const { container } = render(<ImportButton />);
 
     const e = await screen.findByRole('menuitem', { name: 'Import' });
     expect(e).toBeDisabled();
@@ -31,10 +27,11 @@ describe('ImportButton', () => {
   });
 
   it('renders as expected when datasource ready', async () => {
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { isLoaded: true } as UseDataSourceReturn,
+    render(
+      <DataSourceContext.Provider value={{ isLoaded: true } as DataSourceContextType}>
+        <ImportButton />
+      </DataSourceContext.Provider>,
     );
-    render(<ImportButton />);
 
     const e = await screen.findByRole('menuitem', { name: 'Import' });
     expect(e).not.toBeDisabled();
@@ -42,16 +39,19 @@ describe('ImportButton', () => {
 
   it('uploads and imports data into datasource', async () => {
     const mockImportBook = jest.fn();
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      {
-        isLoaded: true,
-        importBook: mockImportBook as Function,
-      } as UseDataSourceReturn,
-    );
     const file = new File(['hello'], 'hello.png', { type: 'image/png' });
     const user = userEvent.setup();
 
-    render(<ImportButton />);
+    render(
+      <DataSourceContext.Provider
+        value={{
+          isLoaded: true,
+          importBook: mockImportBook as Function,
+        } as DataSourceContextType}
+      >
+        <ImportButton />
+      </DataSourceContext.Provider>,
+    );
 
     const importButton = await screen.findByRole('menuitem', { name: 'Import' });
     await user.click(importButton);

--- a/src/__tests__/components/buttons/SaveButton.test.tsx
+++ b/src/__tests__/components/buttons/SaveButton.test.tsx
@@ -9,28 +9,17 @@ import {
 import { SWRConfig, mutate } from 'swr';
 
 import SaveButton from '@/components/buttons/SaveButton';
-import type { UseDataSourceReturn } from '@/hooks';
-import * as dataSourceHooks from '@/hooks/useDataSource';
-
-jest.mock('@/hooks/useDataSource', () => ({
-  __esModule: true,
-  ...jest.requireActual('@/hooks/useDataSource'),
-}));
-
-jest.mock('@/hooks/useBookStorage', () => ({
-  __esModule: true,
-  ...jest.requireActual('@/hooks/useBookStorage'),
-}));
+import { DataSourceContext } from '@/hooks';
+import type { DataSourceContextType } from '@/hooks';
 
 describe('SaveButton', () => {
   it('loads while unavailable datasource', async () => {
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { isLoaded: false } as UseDataSourceReturn,
-    );
     const { container } = render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <SaveButton />
-      </SWRConfig>,
+      <DataSourceContext.Provider value={{ isLoaded: false } as DataSourceContextType}>
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <SaveButton />
+        </SWRConfig>
+      </DataSourceContext.Provider>,
     );
 
     await screen.findByText('...');
@@ -38,13 +27,12 @@ describe('SaveButton', () => {
   });
 
   it('renders as expected when datasource ready and not saving', async () => {
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { isLoaded: true } as UseDataSourceReturn,
-    );
     const { container } = render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <SaveButton />
-      </SWRConfig>,
+      <DataSourceContext.Provider value={{ isLoaded: true } as DataSourceContextType}>
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <SaveButton />
+        </SWRConfig>
+      </DataSourceContext.Provider>,
     );
 
     await screen.findByText('Save');
@@ -52,10 +40,11 @@ describe('SaveButton', () => {
   });
 
   it('renders as expected when datasource ready and saving', async () => {
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      { isLoaded: true } as UseDataSourceReturn,
+    const { container } = render(
+      <DataSourceContext.Provider value={{ isLoaded: true } as DataSourceContextType}>
+        <SaveButton />
+      </DataSourceContext.Provider>,
     );
-    const { container } = render(<SaveButton />);
 
     act(() => {
       mutate('/state/save', true, { revalidate: false });
@@ -67,16 +56,17 @@ describe('SaveButton', () => {
 
   it('calls datasource save on click', async () => {
     const mockSave = jest.fn();
-    jest.spyOn(dataSourceHooks, 'default').mockReturnValue(
-      {
-        isLoaded: true,
-        save: mockSave as Function,
-      } as UseDataSourceReturn,
-    );
     render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <SaveButton />
-      </SWRConfig>,
+      <DataSourceContext.Provider
+        value={{
+          isLoaded: true,
+          save: mockSave as Function,
+        } as DataSourceContextType}
+      >
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <SaveButton />
+        </SWRConfig>
+      </DataSourceContext.Provider>,
     );
 
     const button = screen.getByText('Save');

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import { useDataSource } from '@/hooks';
+import { useDataSource, DataSourceContext } from '@/hooks';
 import useUser from '@/hooks/useUser';
 import Footer from '@/layout/Footer';
 import LeftSidebar from '@/layout/LeftSidebar';
@@ -12,9 +12,9 @@ export default function DashboardLayout({
   children,
 }: React.PropsWithChildren): JSX.Element {
   const { user } = useUser();
-  const { isLoaded } = useDataSource();
+  const hookData = useDataSource();
 
-  if (!user || !isLoaded || user.isLoggedIn === false) {
+  if (!user || !hookData.isLoaded || user.isLoggedIn === false) {
     return <div>Loading...</div>;
   }
 
@@ -22,8 +22,10 @@ export default function DashboardLayout({
     <div className="w-full h-full overflow-hidden">
       <LeftSidebar />
       <div className="mt-20 ml-20 p-3 z-0">
-        <Topbar />
-        {children}
+        <DataSourceContext.Provider value={hookData}>
+          <Topbar />
+          {children}
+        </DataSourceContext.Provider>
       </div>
       <Footer />
     </div>

--- a/src/components/buttons/AddAccountButton.tsx
+++ b/src/components/buttons/AddAccountButton.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import Modal from '@/components/Modal';
 import { BiPlusCircle } from 'react-icons/bi';
 
-import { useDataSource } from '@/hooks';
+import { DataSourceContext } from '@/hooks';
 import AccountForm from '@/components/forms/account/AccountForm';
 
 export default function AddAccountButton(): JSX.Element {
-  const { save } = useDataSource();
+  const { save } = React.useContext(DataSourceContext);
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
 
   return (

--- a/src/components/buttons/ImportButton.tsx
+++ b/src/components/buttons/ImportButton.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { BiImport } from 'react-icons/bi';
 
-import { useDataSource } from '@/hooks';
+import { DataSourceContext } from '@/hooks';
 
 export default function ImportButton(): JSX.Element {
-  const { isLoaded, importBook } = useDataSource();
+  const { isLoaded, importBook } = React.useContext(DataSourceContext);
   const fileImportInput = React.useRef<HTMLInputElement>(null);
 
   return (

--- a/src/components/buttons/SaveButton.tsx
+++ b/src/components/buttons/SaveButton.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { BiCloudUpload, BiLoader } from 'react-icons/bi';
 import useSWRImmutable from 'swr/immutable';
 
-import { useDataSource } from '@/hooks';
+import { DataSourceContext } from '@/hooks';
 
 export default function SaveButton(): JSX.Element {
   const { data: isSaving } = useSWRImmutable(
     '/state/save',
     () => false,
   );
-  const { isLoaded, save } = useDataSource();
+  const { isLoaded, save } = React.useContext(DataSourceContext);
 
   if (!isLoaded) {
     return (

--- a/src/components/buttons/TransactionFormButton.tsx
+++ b/src/components/buttons/TransactionFormButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BiPlusCircle } from 'react-icons/bi';
 
-import { useDataSource } from '@/hooks';
+import { DataSourceContext } from '@/hooks';
 import TransactionForm from '@/components/forms/transaction/TransactionForm';
 import Modal from '@/components/Modal';
 import type { FormValues } from '@/components/forms/transaction/types';
@@ -21,7 +21,7 @@ export default function TransactionFormButton(
     className = 'btn-primary',
   }: TransactionFormButtonProps,
 ): JSX.Element {
-  const { save } = useDataSource();
+  const { save } = React.useContext(DataSourceContext);
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
 
   let title = 'Add transaction';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,5 @@
-export { default as useDataSource } from './useDataSource';
-export type { UseDataSourceReturn } from './useDataSource';
+export { default as useDataSource, DataSourceContext } from './useDataSource';
+export type { DataSourceContextType } from './useDataSource';
 export { default as useBookStorage } from './useBookStorage';
 export { default as useGapiClient } from './useGapiClient';
 export { default as useUser } from './useUser';

--- a/src/hooks/useDataSource.ts
+++ b/src/hooks/useDataSource.ts
@@ -14,7 +14,7 @@ import {
   Transaction,
 } from '@/book/entities';
 
-export type UseDataSourceReturn = {
+export type DataSourceContextType = {
   datasource: DataSource | null,
   save: () => Promise<void>,
   importBook: (rawBook: Uint8Array) => Promise<void>,
@@ -28,7 +28,14 @@ const DATASOURCE: DataSource = new DataSource({
   entities: [Account, Book, Commodity, Price, Split, Transaction],
 });
 
-export default function useDataSource(): UseDataSourceReturn {
+export const DataSourceContext = React.createContext<DataSourceContextType>({
+  datasource: DATASOURCE,
+  save: async () => {},
+  importBook: async () => {},
+  isLoaded: false,
+});
+
+export default function useDataSource(): DataSourceContextType {
   const { storage } = useBookStorage();
   const [isLoaded, setIsLoaded] = React.useState(DATASOURCE.isInitialized);
 
@@ -71,35 +78,35 @@ export default function useDataSource(): UseDataSourceReturn {
     };
   }
 
-  async function save() {
-    mutate('/state/save', true, { revalidate: false });
-    const rawBook = DATASOURCE.sqljsManager.exportDatabase();
-    await (storage as BookStorage).save(rawBook);
-    mutate('/state/save', false, { revalidate: false });
-  }
-
-  async function importBook(rawData: Uint8Array) {
-    const tempDataSource = new DataSource({
-      type: 'sqljs',
-      synchronize: true,
-      database: rawData,
-      logging: false,
-      entities: [Account, Book, Commodity, Price, Split, Transaction],
-    });
-    await tempDataSource.initialize();
-    const rawBook = tempDataSource.sqljsManager.exportDatabase();
-
-    await DATASOURCE.sqljsManager.loadDatabase(rawBook);
-    mutate((key: string) => key.startsWith('/api'));
-    await save();
-  }
-
   return {
     datasource: DATASOURCE,
-    save,
-    importBook,
+    save: () => save(storage),
+    importBook: (rawData: Uint8Array) => importBook(storage, rawData),
     isLoaded,
   };
+}
+
+async function save(storage: BookStorage | null) {
+  mutate('/state/save', true, { revalidate: false });
+  const rawBook = DATASOURCE.sqljsManager.exportDatabase();
+  await (storage as BookStorage).save(rawBook);
+  mutate('/state/save', false, { revalidate: false });
+}
+
+async function importBook(storage: BookStorage | null, rawData: Uint8Array) {
+  const tempDataSource = new DataSource({
+    type: 'sqljs',
+    synchronize: true,
+    database: rawData,
+    logging: false,
+    entities: [Account, Book, Commodity, Price, Split, Transaction],
+  });
+  await tempDataSource.initialize();
+  const rawBook = tempDataSource.sqljsManager.exportDatabase();
+
+  await DATASOURCE.sqljsManager.loadDatabase(rawBook);
+  mutate((key: string) => key.startsWith('/api'));
+  await save(storage);
 }
 
 // TODO: Need to mutate the accounts SWR key so Root is shown!


### PR DESCRIPTION
Instead of re-processing the `useDataSource` hook on every component that needs it, we now store the datasource in a context in `dashboard/layout.tsx` and then use the context in the components that need it. This avoids multiple re-processing of datasource and storage hooks (which caused network requests, see issue #133).

Fixes #133 