### PR TITLE
Fix commodities

### DIFF
--- a/src/__tests__/lib/queries/getAccounts.test.ts
+++ b/src/__tests__/lib/queries/getAccounts.test.ts
@@ -59,7 +59,6 @@ describe('getAccounts', () => {
     const accounts = await getAccounts();
 
     expect(accounts.root.guid).toEqual('a');
-    expect(accounts.a.guid).toEqual('a');
     expect(accounts.assets.guid).toEqual('assets');
     expect(accounts.expenses.guid).toEqual('expenses');
   });

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -32,7 +32,8 @@ export function useCommodities(): SWRResponse<Commodity[]> {
   const key = '/api/commodities';
   return useSWRImmutable(
     key,
-    fetcher(Commodity.find, key),
+    // Needs to be encapsulated in arrow function or it doesnt work properly
+    fetcher(async () => Commodity.find(), key),
   );
 }
 

--- a/src/lib/queries/getAccounts.ts
+++ b/src/lib/queries/getAccounts.ts
@@ -9,7 +9,10 @@ export default async function getAccounts(): Promise<AccountsMap> {
     if (account.type === 'ROOT' && !account.name.startsWith('Template')) {
       accountsMap.root = account;
     }
-    accountsMap[account.guid] = account;
+
+    if (account.type !== 'ROOT') {
+      accountsMap[account.guid] = account;
+    }
   });
 
   return accountsMap;


### PR DESCRIPTION
So for some reason, having inline `Commodity.find` passed to the fetcher directly fails and we need to encapsulate it within an arrow function. Probably some `this` context or something like that as it fails with `Commodity` being `undefined`