### PR TITLE
Fix networth histogram period

### DIFF
--- a/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
@@ -221,6 +221,10 @@ describe('NetWorthHistogram', () => {
         type: 'column',
         data: [
           {
+            x: DateTime.fromISO('2022-09-01'),
+            y: -0,
+          },
+          {
             x: DateTime.fromISO('2022-10-01'),
             y: -0,
           },
@@ -242,6 +246,10 @@ describe('NetWorthHistogram', () => {
         name: 'Expenses',
         type: 'column',
         data: [
+          {
+            x: DateTime.fromISO('2022-09-01'),
+            y: -0,
+          },
           {
             x: DateTime.fromISO('2022-10-01'),
             y: -0,
@@ -265,6 +273,10 @@ describe('NetWorthHistogram', () => {
         type: 'column',
         data: [
           {
+            x: DateTime.fromISO('2022-09-01'),
+            y: -0,
+          },
+          {
             x: DateTime.fromISO('2022-10-01'),
             y: -0,
           },
@@ -286,6 +298,10 @@ describe('NetWorthHistogram', () => {
         name: 'Net worth',
         type: 'line',
         data: [
+          {
+            x: DateTime.fromISO('2022-09-01'),
+            y: 0,
+          },
           {
             x: DateTime.fromISO('2022-10-01'),
             y: 0,
@@ -312,6 +328,10 @@ describe('NetWorthHistogram', () => {
         name: 'Net worth',
         type: 'line',
         data: [
+          {
+            x: DateTime.fromISO('2022-09-01'),
+            y: 0,
+          },
           {
             x: DateTime.fromISO('2022-10-01'),
             y: 0,

--- a/src/components/pages/accounts/NetWorthHistogram.tsx
+++ b/src/components/pages/accounts/NetWorthHistogram.tsx
@@ -28,7 +28,7 @@ export default function NetWorthHistogram({
     selectedDate.plus({ months: 3 }),
   );
   const interval = Interval.fromDateTimes(
-    startDate || now,
+    startDate?.minus({ month: 1 }) || now,
     now,
   );
   const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).plus({ month: 1 }));


### PR DESCRIPTION
Before this change, the networth histogram was ignoring the first month of the data, skewing the net worth calculations