### PR TITLE
Load original transaction

### DIFF
--- a/src/__tests__/components/pages/account/TransactionsTable.test.tsx
+++ b/src/__tests__/components/pages/account/TransactionsTable.test.tsx
@@ -317,6 +317,7 @@ describe('TransactionsTable', () => {
         action: 'update',
         className: 'link',
         children: <BiEdit className="flex" />,
+        guid: 'tx_guid',
         defaultValues: {
           ...splits1[0].transaction,
           date: '2023-01-01',
@@ -330,6 +331,7 @@ describe('TransactionsTable', () => {
         action: 'delete',
         className: 'link',
         children: <BiXCircle className="flex" />,
+        guid: 'tx_guid',
         defaultValues: {
           ...splits1[0].transaction,
           date: '2023-01-01',

--- a/src/components/pages/account/TransactionsTable.tsx
+++ b/src/components/pages/account/TransactionsTable.tsx
@@ -77,6 +77,7 @@ const columns: ColumnDef<Split>[] = [
     cell: ({ row }) => (
       <>
         <TransactionFormButton
+          guid={row.original.transaction.guid}
           action="update"
           defaultValues={
             {
@@ -90,6 +91,7 @@ const columns: ColumnDef<Split>[] = [
           <BiEdit className="flex" />
         </TransactionFormButton>
         <TransactionFormButton
+          guid={row.original.transaction.guid}
           action="delete"
           defaultValues={
             {

--- a/src/lib/queries/getSplits.ts
+++ b/src/lib/queries/getSplits.ts
@@ -32,6 +32,7 @@ export default async function getSplits(account: string): Promise<Split[]> {
         guid: true,
       },
       fk_transaction: {
+        guid: true,
         date: true,
         description: true,
         splits: {


### PR DESCRIPTION
Edit/Update was broken because the transaction passed to the Form didn't have all the fields that are needed. Now, when the action is `update` or `delete` in the transaction form button, we load the original transaction and pass that as default value