### PR TITLE
Set latest split date when adding tx

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -16,7 +16,7 @@ const config = {
   coverageThreshold: {
     global: {
       lines: 93.4,
-      branches: 87.8,
+      branches: 87.7,
     },
   },
   testEnvironment: 'jest-environment-jsdom',

--- a/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/[guid]/page.test.tsx
@@ -119,7 +119,7 @@ describe('AccountPage', () => {
       {
         account: accounts.guid,
         defaultValues: {
-          date: DateTime.now().toISODate(),
+          date: '2023-01-01',
           description: '',
           fk_currency: {
             mnemonic: 'EUR',

--- a/src/app/dashboard/accounts/[guid]/page.tsx
+++ b/src/app/dashboard/accounts/[guid]/page.tsx
@@ -31,6 +31,7 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
   const router = useRouter();
   let { data: accounts } = useAccounts();
   let { data: splits } = useSplits(params.guid);
+  const latestDate = splits?.[0].transaction.date;
 
   // We cant use fallback data to set a default as SWR treats
   // fallback data as stale data which means with immutable we will
@@ -116,7 +117,7 @@ export default function AccountPage({ params }: AccountPageProps): JSX.Element {
             account={account}
             defaultValues={
               {
-                date: DateTime.now().toISODate() as string,
+                date: (latestDate || DateTime.now()).toISODate() as string,
                 description: '',
                 splits: [],
                 fk_currency: account.commodity,

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -117,7 +117,7 @@
   }
 
   .amount-negative {
-    @apply text-red-600 dark:text-red-500;
+    @apply text-red-600 dark:text-red-400/90;
   }
 
   .header {


### PR DESCRIPTION
When doing a run of adding expenses, you usually start from the oldest untracked and keep following chronologically. Currently, the date is auto populated to "now" but it's annoying to change that every time. This change makes that the latest transaction's in the account is populated in the form instead.

Closes #288 

