### PR TITLE
Fix instant refresh for onboarding opening balance

### DIFF
--- a/src/__tests__/components/forms/account/AccountForm.test.tsx
+++ b/src/__tests__/components/forms/account/AccountForm.test.tsx
@@ -397,6 +397,12 @@ describe('AccountForm', () => {
         valueNum: -1000,
       },
     ]);
+
+    expect(swr.mutate).toBeCalledTimes(4);
+    expect(swr.mutate).toHaveBeenNthCalledWith(1, '/api/accounts');
+    expect(swr.mutate).toHaveBeenNthCalledWith(2, '/api/accounts', expect.any(Function), { revalidate: false });
+    expect(swr.mutate).toHaveBeenNthCalledWith(3, '/api/monthly-totals', undefined);
+    expect(swr.mutate).toHaveBeenNthCalledWith(4, '/api/txs/latest', undefined);
   });
 
   it.each([

--- a/src/components/forms/account/AccountForm.tsx
+++ b/src/components/forms/account/AccountForm.tsx
@@ -285,17 +285,19 @@ async function onSubmit(
 
   if (action === 'add') {
     await account.save();
+    mutate('/api/accounts');
     if (data.balance) {
       await createBalance(data, account);
     }
   } else if (action === 'update') {
     await account.save();
+    mutate('/api/accounts');
   } else if (action === 'delete') {
     await Account.remove(account);
+    mutate('/api/accounts');
     router.replace('/dashboard/accounts');
   }
 
-  mutate('/api/accounts');
   onSave(account);
 }
 

--- a/src/components/forms/account/AccountForm.tsx
+++ b/src/components/forms/account/AccountForm.tsx
@@ -354,4 +354,5 @@ async function createBalance(data: FormValues, account: Account) {
 
   // Opening balances affect net worth
   mutate('/api/monthly-totals', undefined);
+  mutate('/api/txs/latest', undefined);
 }


### PR DESCRIPTION
I reordered the mutate calls and this made the monthly balance to update with a big delay. Re-ordering like this so it is instant.