### PR TITLE
Fix transactions table action buttons

### DIFF
--- a/src/__tests__/components/buttons/TransactionFormButton.test.tsx
+++ b/src/__tests__/components/buttons/TransactionFormButton.test.tsx
@@ -94,7 +94,7 @@ describe('TransactionFormButton', () => {
     expect(TransactionForm).toHaveBeenLastCalledWith(
       {
         action,
-        defaultValues: {},
+        defaultValues: undefined,
         onSave: expect.any(Function),
       },
       {},
@@ -174,6 +174,7 @@ describe('TransactionFormButton', () => {
       },
       splits: [split1, split2],
     } as Transaction);
+
     render(
       <TransactionFormButton
         defaultValues={{
@@ -226,6 +227,53 @@ describe('TransactionFormButton', () => {
         {},
       );
     });
+  });
+
+  it('uses latest default values always when update', async () => {
+    jest.spyOn(Transaction, 'findOneOrFail').mockResolvedValue({
+      currency: {
+        mnemonic: 'EUR',
+      },
+      splits: [] as Split[],
+    } as Transaction);
+
+    const { rerender } = render(
+      <TransactionFormButton
+        action="update"
+        defaultValues={{
+          description: 'hello',
+        } as FormValues}
+        account={{
+          guid: '1',
+          name: 'account',
+        } as Account}
+      />,
+    );
+
+    rerender(
+      <TransactionFormButton
+        action="update"
+        defaultValues={{
+          description: 'haha',
+        } as FormValues}
+        account={{
+          guid: '1',
+          name: 'account',
+        } as Account}
+      />,
+    );
+
+    const button = await screen.findByRole('button', { name: /add transaction/i });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(TransactionForm).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        defaultValues: expect.objectContaining({
+          description: 'haha',
+        }),
+      }),
+      {},
+    ));
   });
 
   it('passes expected data to TransactionForm', async () => {

--- a/src/app/dashboard/accounts/[guid]/page.tsx
+++ b/src/app/dashboard/accounts/[guid]/page.tsx
@@ -33,7 +33,7 @@ export type AccountPageProps = {
 export default function AccountPage({ params }: AccountPageProps): JSX.Element {
   let { data: accounts } = useAccounts();
   let { data: splits } = useSplits(params.guid);
-  const latestDate = splits?.[0]?.transaction.date;
+  const latestDate = splits?.[0]?.transaction?.date;
 
   // We cant use fallback data to set a default as SWR treats
   // fallback data as stale data which means with immutable we will

--- a/src/components/buttons/TransactionFormButton.tsx
+++ b/src/components/buttons/TransactionFormButton.tsx
@@ -26,7 +26,7 @@ export default function TransactionFormButton({
 }: TransactionFormButtonProps): JSX.Element {
   const { save } = React.useContext(DataSourceContext);
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
-  const [defaults, setDefaults] = React.useState(defaultValues);
+  const [defaults, setDefaults] = React.useState<Partial<FormValues>>();
 
   let title = `Add transaction to ${account?.name}`;
   if (action === 'update') {
@@ -85,7 +85,7 @@ export default function TransactionFormButton({
               },
             });
             setDefaults({
-              ...defaults,
+              ...defaultValues,
               // The currency is not loaded in the transactions table view
               // so we load it here.
               fk_currency: tx.currency,


### PR DESCRIPTION
This was a nasty bug. So `TransactionFormButton` was being rendered with some defaultValues and then when re-rendered with new default values, they were not being applied because `React.useState` only applies the values on the first render. Changed the code so the passed default values are always used and applied