### PR TITLE
Take enter date into account when sorting splits

### DIFF
--- a/src/__tests__/lib/queries/getLatestTxs.test.ts
+++ b/src/__tests__/lib/queries/getLatestTxs.test.ts
@@ -15,6 +15,7 @@ describe('getLatestTsx', () => {
       },
       order: {
         date: 'DESC',
+        enterDate: 'DESC',
       },
       take: 5,
     });

--- a/src/lib/queries/getLatestTxs.ts
+++ b/src/lib/queries/getLatestTxs.ts
@@ -9,6 +9,7 @@ export default async function getLatestTxs(): Promise<Transaction[]> {
     },
     order: {
       date: 'DESC',
+      enterDate: 'DESC',
     },
     take: 5,
   });

--- a/src/lib/queries/getSplits.ts
+++ b/src/lib/queries/getSplits.ts
@@ -46,6 +46,7 @@ export default async function getSplits(account: string): Promise<Split[]> {
     order: {
       fk_transaction: {
         date: 'DESC',
+        enterDate: 'DESC',
       },
       // This is so debit is always before credit
       // so we avoid negative amounts when display


### PR DESCRIPTION
Sort by enter date before quantity as per user request