### PR TITLE
Fix no close price stocker

### DIFF
--- a/amplify/backend/function/stockerlambda/ts/__tests__/yahoo.test.ts
+++ b/amplify/backend/function/stockerlambda/ts/__tests__/yahoo.test.ts
@@ -99,6 +99,39 @@ describe('getPrice', () => {
     );
   });
 
+  /**
+   * Yahoo finance sometimes returns 0 for previousClosePrice and it breaks our numbers. This is
+   * a patch for it
+   */
+  it('sets previous close same as current price when previous close is 0', async () => {
+    mockAxiosGet.mockImplementation(() => Promise.resolve({
+      data: {
+        chart: {
+          result: [
+            {
+              meta: {
+                currency: 'EUR',
+                chartPreviousClose: 0,
+                regularMarketPrice: 212.5,
+              },
+            },
+          ],
+          error: null,
+        },
+      },
+      status: 404,
+    }));
+
+    const resp = await yh.getPrice('ticker');
+
+    expect(resp).toEqual({
+      price: 212.5,
+      changePct: 0,
+      changeAbs: 0,
+      currency: 'EUR',
+    });
+  });
+
   it('queries for previous day when on Sunday', async () => {
     await yh.getPrice('ticker', 1696089600);
 

--- a/amplify/backend/function/stockerlambda/ts/yahoo.ts
+++ b/amplify/backend/function/stockerlambda/ts/yahoo.ts
@@ -58,7 +58,7 @@ export async function getPrice(ticker: string, when?: number): Promise<Price> {
 
   const currency = toCurrency(result[0].meta.currency);
   const price = toStandardUnit(result[0].meta.regularMarketPrice, currency);
-  const previousClose = toStandardUnit(result[0].meta.chartPreviousClose, currency);
+  const previousClose = toStandardUnit(result[0].meta.chartPreviousClose, currency) || price;
   const change = price - previousClose;
 
   return {


### PR DESCRIPTION
Sometimes yahoo finance returns 0 for close price and that breaks percentage change calculations. With this fix, whenever we find a 0 close price, we set it to the same current price.