### PR TITLE
Support dividend txs not in main currency

### DIFF
--- a/src/__tests__/hooks/api.test.tsx
+++ b/src/__tests__/hooks/api.test.tsx
@@ -4,7 +4,7 @@ import * as swr from 'swr';
 import { BareFetcher, SWRResponse } from 'swr';
 
 import { Account, Commodity } from '@/book/entities';
-import { PriceDB, PriceDBMap } from '@/book/prices';
+import { PriceDBMap } from '@/book/prices';
 import * as API from '@/hooks/api';
 import * as queries from '@/lib/queries';
 import * as gapiHooks from '@/hooks/useGapiClient';
@@ -18,9 +18,6 @@ jest.mock('@/lib/queries');
 jest.mock('@/book/prices', () => ({
   __esModule: true,
   ...jest.requireActual('@/book/prices'),
-  PriceDB: {
-    getTodayQuotes: jest.fn(),
-  },
 }));
 
 jest.mock('@/lib/getUser', () => ({
@@ -42,7 +39,6 @@ describe('API', () => {
   beforeEach(() => {
     jest.spyOn(Commodity, 'findOneByOrFail').mockImplementation();
     jest.spyOn(Commodity, 'find').mockImplementation();
-    jest.spyOn(PriceDB, 'getTodayQuotes').mockImplementation();
     jest.spyOn(getUserModule, 'default').mockImplementation();
     jest.spyOn(swrImmutable, 'default').mockImplementation(
       jest.fn((key, f: BareFetcher | null) => {

--- a/src/components/forms/transaction/MainSplit.tsx
+++ b/src/components/forms/transaction/MainSplit.tsx
@@ -45,6 +45,8 @@ export default function MainSplit({
           : prices.getPrice(account.commodity.mnemonic, txCurrency.mnemonic, d);
 
         setExchangeRate(rate);
+      } else {
+        setExchangeRate(Price.create({ valueNum: 1, valueDenom: 1 }));
       }
     }
   }, [txCurrency, date, form.formState.isDirty, account, prices]);


### PR DESCRIPTION
After https://github.com/maffin-io/maffin-app/pull/515 we changed the tx currency for non currency related transactions to be the linked currency to that commodity. This meant that we can add txs in currency different than the main currency and that's something we didn't allow. This PR fixes the code in order to allow for those type of transactions.