### PR TITLE
Remove x-requested-with header

### DIFF
--- a/src/__tests__/lib/Stocker.test.ts
+++ b/src/__tests__/lib/Stocker.test.ts
@@ -18,7 +18,6 @@ describe('Stocker', () => {
         '/user/authorize',
         {
           queryStringParameters: { code: 'code_token' },
-          headers: { 'X-Requested-With': 'XmlHttpRequest' },
         },
       );
       expect(credentials).toEqual({ access_token: 'at' });

--- a/src/lib/Stocker.ts
+++ b/src/lib/Stocker.ts
@@ -18,9 +18,6 @@ export async function authorize(code: string): Promise<Credentials> {
     queryStringParameters: {
       code,
     },
-    headers: {
-      'X-Requested-With': 'XmlHttpRequest',
-    },
   };
 
   const resp = await API.get(API_NAME, '/user/authorize', options) as Credentials;


### PR DESCRIPTION
```
Access to XMLHttpRequest at '' from origin 'https://app.maffin.io' has been blocked by CORS policy: Request header field x-requested-with is not allowed by Access-Control-Allow-Headers in preflight response.
```

The header was added in https://github.com/maffin-io/maffin-app/pull/581. It's related to security but removing for now to fix the issue as web is not accessible