### PR TITLE
Fix monthly total calculations

### DIFF
--- a/src/__tests__/components/forms/price/PriceForm.test.tsx
+++ b/src/__tests__/components/forms/price/PriceForm.test.tsx
@@ -28,11 +28,13 @@ describe('PriceForm', () => {
     await datasource.initialize();
 
     eur = await Commodity.create({
+      guid: 'eur',
       mnemonic: 'EUR',
       namespace: 'CURRENCY',
     }).save();
 
     usd = await Commodity.create({
+      guid: 'usd',
       mnemonic: 'USD',
       namespace: 'CURRENCY',
     }).save();
@@ -109,6 +111,27 @@ describe('PriceForm', () => {
     // Can't check with toBeVisible due tailwindcss not being understood by jest
     expect(fieldsets[1]).toHaveClass('hidden');
     expect(fieldsets[2]).toHaveClass('hidden');
+  });
+
+  it('passed commodity is not shown as a currency option', async () => {
+    const user = userEvent.setup();
+    render(
+      <PriceForm
+        action="add"
+        onSave={() => {}}
+        defaultValues={{
+          fk_commodity: eur,
+        }}
+        hideDefaults
+      />,
+    );
+
+    const currencyInput = screen.getByRole('combobox', { name: 'currencyInput' });
+    await user.click(currencyInput);
+
+    const options = await screen.findAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0].textContent).toEqual('USD');
   });
 
   it('adds new Price and saves', async () => {

--- a/src/__tests__/components/onboarding/Onboarding.test.tsx
+++ b/src/__tests__/components/onboarding/Onboarding.test.tsx
@@ -112,6 +112,7 @@ describe('Onboarding', () => {
         placeholder: true,
         type: 'EQUITY',
         name: 'Equity',
+        hidden: true,
       }),
       expect.objectContaining({
         fk_commodity: eur,
@@ -154,12 +155,12 @@ describe('Onboarding', () => {
 
     expect(screen.getByText('add')).toBeEnabled();
     await user.click(screen.getByText('add'));
-    const bankAccount = await Account.findOneByOrFail({ name: 'My bank account' });
+    const bankAccount = await Account.findOneByOrFail({ name: 'My bank' });
     expect(bankAccount).toEqual(expect.objectContaining({
       fk_commodity: eur,
       placeholder: false,
       type: 'BANK',
-      name: 'My bank account',
+      name: 'My bank',
       parentId: accounts[2].guid,
     }));
 

--- a/src/__tests__/components/pages/accounts/IncomeExpenseHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/IncomeExpenseHistogram.test.tsx
@@ -53,12 +53,11 @@ describe('IncomeExpenseHistogram', () => {
               data: [],
               label: 'Savings',
               datalabels: {
-                clip: true,
                 anchor: 'end',
                 display: true,
                 formatter: expect.any(Function),
                 align: 'end',
-                backgroundColor: '#06B6D466',
+                backgroundColor: '#06B6D4FF',
                 borderRadius: 5,
                 color: '#FFF',
               },
@@ -67,6 +66,11 @@ describe('IncomeExpenseHistogram', () => {
           labels: [],
         },
         options: {
+          layout: {
+            padding: {
+              right: 15,
+            },
+          },
           maintainAspectRatio: false,
           interaction: {
             mode: 'index',
@@ -142,6 +146,7 @@ describe('IncomeExpenseHistogram', () => {
               type: 'time',
             },
             y: {
+              grace: 1,
               border: {
                 display: false,
               },
@@ -165,9 +170,6 @@ describe('IncomeExpenseHistogram', () => {
           income: {
             '11/2022': new Money(-600, 'EUR'),
             '12/2022': new Money(-400, 'EUR'),
-          },
-          equity: {
-            '11/2022': new Money(-200, 'EUR'),
           },
           expense: {
             '11/2022': new Money(400, 'EUR'),
@@ -196,7 +198,7 @@ describe('IncomeExpenseHistogram', () => {
               label: 'Expenses',
             }),
             expect.objectContaining({
-              data: [-0, -0, 200, -100, -0],
+              data: [0, 0, 200, -100, 0],
               label: 'Savings',
             }),
           ],

--- a/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
@@ -49,6 +49,11 @@ describe('NetWorthHistogram', () => {
           labels: [],
         },
         options: {
+          layout: {
+            padding: {
+              right: 15,
+            },
+          },
           maintainAspectRatio: false,
           interaction: {
             mode: 'index',
@@ -127,6 +132,7 @@ describe('NetWorthHistogram', () => {
               type: 'time',
             },
             y: {
+              grace: 1,
               border: {
                 display: false,
               },
@@ -149,10 +155,13 @@ describe('NetWorthHistogram', () => {
         data: {
           asset: {
             '11/2022': new Money(800, 'EUR'),
-            '12/2022': new Money(400, 'EUR'),
+            '12/2022': new Money(1200, 'EUR'),
+            '01/2023': new Money(1200, 'EUR'),
           },
           liability: {
             '11/2022': new Money(-200, 'EUR'),
+            '12/2022': new Money(-200, 'EUR'),
+            '01/2023': new Money(-200, 'EUR'),
           },
         },
       } as SWRResponse,

--- a/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
@@ -37,7 +37,7 @@ describe('NetWorthPie', () => {
           datasets: [
             {
               backgroundColor: ['#06B6D4', '#F97316'],
-              data: [0, -0],
+              data: [0, 0],
             },
           ],
           labels: ['Assets', 'Liabilities'],
@@ -54,11 +54,6 @@ describe('NetWorthPie', () => {
             datalabels: {
               borderRadius: 2,
               color: '#DDDDDD',
-              font: {
-                family: 'Intervariable',
-                size: 14,
-                weight: 300,
-              },
               formatter: expect.any(Function),
               padding: 6,
               textAlign: 'center',
@@ -73,22 +68,18 @@ describe('NetWorthPie', () => {
     );
   });
 
-  it('computes net worth as expected', () => {
+  it('shows net worth as expected', () => {
+    jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-02-20') as DateTime<true>);
     jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
       {
         data: {
           asset: {
             '01/2023': new Money(500, 'EUR'),
-            '02/2023': new Money(500, 'EUR'),
-          },
-          // To check we don't add equity to the calculations as
-          // equity transactions go to assets
-          equity: {
-            '11/2022': new Money(-200, 'EUR'),
+            '02/2023': new Money(1000, 'EUR'),
           },
           liability: {
             '01/2023': new Money(-50, 'EUR'),
-            '02/2023': new Money(-50, 'EUR'),
+            '02/2023': new Money(-100, 'EUR'),
           },
         },
       } as SWRResponse,
@@ -112,13 +103,13 @@ describe('NetWorthPie', () => {
     );
   });
 
-  it('computes net worth when no liabilities', () => {
+  it('shows net worth when no liabilities', () => {
     jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
       {
         data: {
           asset: {
             '01/2023': new Money(500, 'EUR'),
-            '02/2023': new Money(500, 'EUR'),
+            '02/2023': new Money(1000, 'EUR'),
           },
         },
       } as SWRResponse,
@@ -132,7 +123,7 @@ describe('NetWorthPie', () => {
           datasets: [
             {
               backgroundColor: ['#06B6D4', '#F97316'],
-              data: [1000, -0],
+              data: [1000, 0],
             },
           ],
           labels: ['Assets', 'Liabilities'],
@@ -148,11 +139,11 @@ describe('NetWorthPie', () => {
         data: {
           asset: {
             '01/2023': new Money(500, 'EUR'),
-            '02/2023': new Money(500, 'EUR'),
+            '02/2023': new Money(1000, 'EUR'),
           },
           liability: {
             '01/2023': new Money(-50, 'EUR'),
-            '02/2023': new Money(-50, 'EUR'),
+            '02/2023': new Money(-100, 'EUR'),
           },
         },
       } as SWRResponse,

--- a/src/__tests__/components/pages/accounts/__snapshots__/LatestTransactions.test.tsx.snap
+++ b/src/__tests__/components/pages/accounts/__snapshots__/LatestTransactions.test.tsx.snap
@@ -233,7 +233,6 @@ exports[`LatestTransactions renders with empty txs 1`] = `
     <p>
       Latest transactions
     </p>
-    0
   </div>
 </div>
 `;

--- a/src/__tests__/components/selectors/CommoditySelector.test.tsx
+++ b/src/__tests__/components/selectors/CommoditySelector.test.tsx
@@ -60,7 +60,7 @@ describe('CommoditySelector', () => {
       } as Commodity,
       {
         mnemonic: 'IDVY.AS',
-        namespace: 'EQUITY',
+        namespace: 'STOCK',
       } as Commodity,
     ];
     jest.spyOn(apiHook, 'useCommodities').mockReturnValue(
@@ -69,12 +69,47 @@ describe('CommoditySelector', () => {
       } as SWRResponse,
     );
 
-    render(<CommoditySelector namespace="EQUITY" />);
+    render(<CommoditySelector namespace="STOCK" />);
 
     await screen.findByTestId('Selector');
     expect(Selector).toHaveBeenCalledWith(
       expect.objectContaining({
         options: [options[2]],
+      }),
+      {},
+    );
+  });
+
+  it('filters by ignore', async () => {
+    const options = [
+      {
+        guid: '1',
+        mnemonic: 'EUR',
+        namespace: 'CURRENCY',
+      } as Commodity,
+      {
+        guid: '2',
+        mnemonic: 'USD',
+        namespace: 'CURRENCY',
+      } as Commodity,
+      {
+        guid: '3',
+        mnemonic: 'IDVY.AS',
+        namespace: 'STOCK',
+      } as Commodity,
+    ];
+    jest.spyOn(apiHook, 'useCommodities').mockReturnValue(
+      {
+        data: options,
+      } as SWRResponse,
+    );
+
+    render(<CommoditySelector ignore={['2', '3']} />);
+
+    await screen.findByTestId('Selector');
+    expect(Selector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [options[0]],
       }),
       {},
     );

--- a/src/components/forms/price/PriceForm.tsx
+++ b/src/components/forms/price/PriceForm.tsx
@@ -95,6 +95,7 @@ export default function PriceForm({
                   placeholder="Convert to"
                   onChange={field.onChange}
                   namespace="CURRENCY"
+                  ignore={[(defaultValues?.fk_commodity as Commodity)?.guid || '']}
                   isDisabled={disabled || action !== 'add'}
                   defaultValue={defaultValues?.fk_currency as Commodity}
                 />

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -126,7 +126,7 @@ export default function Onboarding({
                 }}
                 hideDefaults
                 defaultValues={{
-                  name: 'My bank account',
+                  name: 'My bank',
                   parent: accounts.type_asset as Account,
                   type: 'BANK',
                   fk_commodity: useMainCurrency().data as Commodity,
@@ -339,6 +339,7 @@ async function createInitialAccounts(setAccounts: Function, currency: Commodity)
       placeholder: true,
       fk_commodity: currency,
       parent: root,
+      hidden: true,
     }),
   ]);
 

--- a/src/components/pages/accounts/AccountsTable.tsx
+++ b/src/components/pages/accounts/AccountsTable.tsx
@@ -67,19 +67,23 @@ function getTreeTotals(
   current.childrenIds.forEach(childId => {
     const childAccount = accounts[childId];
     if (!childAccount.hidden) {
-      leaves.push(getTreeTotals(accounts[childId], accounts, monthlyTotals, selectedDate));
+      leaves.push(getTreeTotals(childAccount, accounts, monthlyTotals, selectedDate));
     }
   });
 
-  const accountTotal = Object.entries(monthlyTotals[current.guid] || {}).reduce(
-    (total, [monthYear, amount]) => {
-      if (DateTime.fromFormat(monthYear, 'MM/yyyy') <= selectedDate) {
-        return total.add(amount);
-      }
-      return total;
-    },
-    new Money(0, current.commodity?.mnemonic || ''),
-  );
+  let accountTotal = (monthlyTotals[current.guid] || {})[selectedDate.toFormat('MM/yyyy')]
+    || new Money(0, current.commodity?.mnemonic || '');
+  if (!isAsset(current) && !isLiability(current)) {
+    accountTotal = Object.entries(monthlyTotals[current.guid] || {}).reduce(
+      (total, [monthYear, amount]) => {
+        if (DateTime.fromFormat(monthYear, 'MM/yyyy') <= selectedDate) {
+          return total.add(amount);
+        }
+        return total;
+      },
+      new Money(0, current.commodity?.mnemonic || ''),
+    );
+  }
 
   return {
     account: current,

--- a/src/components/pages/accounts/IncomeExpenseHistogram.tsx
+++ b/src/components/pages/accounts/IncomeExpenseHistogram.tsx
@@ -52,12 +52,11 @@ export default function IncomeExpenseHistogram({
       data: [],
       backgroundColor: '#06B6D4',
       datalabels: {
-        clip: true,
         anchor: 'end',
         display: true,
         formatter: (value) => moneyToString(value, unit),
         align: 'end',
-        backgroundColor: '#06B6D466',
+        backgroundColor: '#06B6D4FF',
         borderRadius: 5,
         color: '#FFF',
       },
@@ -72,7 +71,7 @@ export default function IncomeExpenseHistogram({
 
     datasets[0].data.push(-incomeAmount);
     datasets[1].data.push(-expenseAmount);
-    datasets[2].data.push(netProfit);
+    datasets[2].data.push(netProfit || 0);
   });
 
   if (now.diff(selectedDate, ['months']).months < 4) {
@@ -92,6 +91,11 @@ export default function IncomeExpenseHistogram({
           datasets,
         }}
         options={{
+          layout: {
+            padding: {
+              right: 15,
+            },
+          },
           maintainAspectRatio: false,
           interaction: {
             mode: 'index',
@@ -116,6 +120,7 @@ export default function IncomeExpenseHistogram({
               },
             },
             y: {
+              grace: 1,
               position: 'left',
               border: {
                 display: false,

--- a/src/components/pages/accounts/LatestTransactions.tsx
+++ b/src/components/pages/accounts/LatestTransactions.tsx
@@ -70,7 +70,7 @@ export default function LatestTransactions(): JSX.Element {
               </div>
             );
           })
-        )
+        ) || ''
       }
     </div>
   );

--- a/src/components/pages/accounts/NetWorthHistogram.tsx
+++ b/src/components/pages/accounts/NetWorthHistogram.tsx
@@ -86,7 +86,7 @@ export default function NetWorthHistogram({
         },
         formatter: (value) => moneyToString(value, unit),
         align: 'end',
-        backgroundColor: '#0E749066',
+        backgroundColor: '#0E7490FF',
         borderRadius: 5,
         color: '#FFF',
       },
@@ -95,15 +95,11 @@ export default function NetWorthHistogram({
 
   dates.forEach(date => {
     const monthYear = (date as DateTime).toFormat('MM/yyyy');
-    const assetTotal = (
-      datasets[0].data[datasets[0].data.length - 1] as number || 0
-    ) + (assetSeries?.[monthYear]?.toNumber() || 0);
+    const assetTotal = assetSeries?.[monthYear]?.toNumber() || 0;
     datasets[0].data.push(assetTotal);
 
     if (liabilitiesSeries) {
-      const liabilityTotal = (
-        datasets[1].data[datasets[1].data.length - 1] as number || 0
-      ) + (liabilitiesSeries?.[monthYear]?.toNumber() || 0);
+      const liabilityTotal = liabilitiesSeries?.[monthYear]?.toNumber() || 0;
       datasets[1].data.push(liabilityTotal);
       datasets[2].data.push(assetTotal + liabilityTotal);
     }
@@ -126,6 +122,11 @@ export default function NetWorthHistogram({
           datasets,
         }}
         options={{
+          layout: {
+            padding: {
+              right: 15,
+            },
+          },
           maintainAspectRatio: false,
           interaction: {
             mode: 'index',
@@ -151,6 +152,7 @@ export default function NetWorthHistogram({
               },
             },
             y: {
+              grace: 1,
               position: 'left',
               border: {
                 display: false,

--- a/src/components/pages/accounts/NetWorthPie.tsx
+++ b/src/components/pages/accounts/NetWorthPie.tsx
@@ -20,26 +20,8 @@ export default function NetWorthPie({
   const { data: currency } = API.useMainCurrency();
   const unit = currency?.mnemonic || '';
 
-  let assetsTotal = 0;
-  let liabilitiesTotal = 0;
-  assetsTotal = Object.entries(assetsSeries || {}).reduce(
-    (total, [monthYear, amount]) => {
-      if (DateTime.fromFormat(monthYear, 'MM/yyyy') <= selectedDate) {
-        return total.add(amount);
-      }
-      return total;
-    },
-    new Money(0, unit),
-  ).toNumber();
-  liabilitiesTotal = Object.entries(liabilitiesSeries || {}).reduce(
-    (total, [monthYear, amount]) => {
-      if (DateTime.fromFormat(monthYear, 'MM/yyyy') <= selectedDate) {
-        return total.add(amount);
-      }
-      return total;
-    },
-    new Money(0, unit),
-  ).toNumber() * -1;
+  const assetsTotal = assetsSeries?.[selectedDate.toFormat('MM/yyyy')] || new Money(0, unit);
+  const liabilitiesTotal = liabilitiesSeries?.[selectedDate.toFormat('MM/yyyy')] || new Money(0, unit);
 
   return (
     <>
@@ -49,7 +31,7 @@ export default function NetWorthPie({
           datasets: [
             {
               backgroundColor: ['#06B6D4', '#F97316'],
-              data: [assetsTotal, liabilitiesTotal],
+              data: [assetsTotal.toNumber(), Math.abs(liabilitiesTotal.toNumber())],
             },
           ],
         }}
@@ -75,11 +57,6 @@ export default function NetWorthPie({
                 }
                 return '';
               },
-              font: {
-                weight: 300,
-                family: 'Intervariable',
-                size: 14,
-              },
               padding: 6,
             },
           },
@@ -87,7 +64,9 @@ export default function NetWorthPie({
       />
       <div className="-mt-12">
         <p className="flex justify-center">Net worth</p>
-        <p className="flex justify-center text-xl">{moneyToString(assetsTotal - liabilitiesTotal, unit)}</p>
+        <p className="flex justify-center text-xl">
+          {moneyToString(assetsTotal.toNumber() + liabilitiesTotal.toNumber(), unit)}
+        </p>
       </div>
     </>
   );

--- a/src/components/selectors/CommoditySelector.tsx
+++ b/src/components/selectors/CommoditySelector.tsx
@@ -14,11 +14,13 @@ false,
 GroupBase<Commodity>
 > {
   namespace?: 'OTHER' | 'STOCK' | 'MUTUAL' | 'CURRENCY' | undefined,
+  ignore?: string[], // guid of Commodities to not show
 }
 
 export default function CommoditySelector(
   {
     namespace,
+    ignore,
     placeholder = 'Choose commodity',
     id = 'commoditySelector',
     ...props
@@ -30,6 +32,12 @@ export default function CommoditySelector(
   if (namespace) {
     commodities = commodities.filter(
       commodity => namespace === commodity.namespace,
+    );
+  }
+
+  if (ignore) {
+    commodities = commodities.filter(
+      commodity => !ignore.includes(commodity.guid),
     );
   }
 

--- a/src/lib/createEquityAccount.ts
+++ b/src/lib/createEquityAccount.ts
@@ -22,6 +22,7 @@ export default async function createEquityAccount(
       fk_commodity: await getMainCurrency(),
       description: 'Equity accounts are used to store the opening balances when you create new accounts',
       parent: root,
+      hidden: true,
     }).save();
   }
 


### PR DESCRIPTION
The whole net worth and monthly totals was calculated the wrong way. We took a pragmatic approach of taking the latest exchange rates which would show the latest net worth (for current month) the right way. However, this means that for previous month, the net worth was wrong because the exchange rate of other commodities is probably different.

Current changes fix this by changing how we calculate monthlyTotals:

- For assets/liabilities, each month we aggregate the value of all previous months and then convert it using **that month exchange rate**
- For income/expense, we still use the same approach. Each month **only contains the same month totals** and we convert using that month exchange rate.

This is so we can answer this two questions:

- How much did I have in my different currency bank (in total) at this date?
- How much did I spent in this different currency account at this date?

Note the first question requires to accumulate all previous transactions to see the current value while the second only requires current month transactions