### PR TITLE
Move usePrices to query

### DIFF
--- a/src/__tests__/app/dashboard/commodities/[guid]/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/commodities/[guid]/__snapshots__/page.test.tsx.snap
@@ -41,7 +41,14 @@ exports[`CommodityPage renders as expected with commodity 1`] = `
         <span
           class="title text-lg"
         >
-          EUR - USD price data
+          EUR - 
+          <a
+            href="/dashboard/commodities/c1"
+          >
+            USD
+          </a>
+           
+          price data
         </span>
       </div>
       <div
@@ -70,7 +77,14 @@ exports[`CommodityPage renders as expected with commodity 1`] = `
         <span
           class="title text-lg"
         >
-          EUR - SGD price data
+          EUR - 
+          <a
+            href="/dashboard/commodities/c2"
+          >
+            SGD
+          </a>
+           
+          price data
         </span>
       </div>
       <div

--- a/src/__tests__/app/dashboard/commodities/[guid]/page.test.tsx
+++ b/src/__tests__/app/dashboard/commodities/[guid]/page.test.tsx
@@ -3,8 +3,7 @@ import {
   render,
   screen,
 } from '@testing-library/react';
-import type { SWRResponse } from 'swr';
-import { UseQueryResult } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import { Commodity, Price } from '@/book/entities';
 import CommodityPage from '@/app/dashboard/commodities/[guid]/page';
@@ -51,7 +50,7 @@ jest.mock('@/components/Loading', () => jest.fn(
 describe('CommodityPage', () => {
   beforeEach(() => {
     jest.spyOn(apiHook, 'useCommodity').mockReturnValue({ data: undefined } as UseQueryResult<Commodity>);
-    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
   });
 
   afterEach(() => {
@@ -78,7 +77,7 @@ describe('CommodityPage', () => {
     jest.spyOn(apiHook, 'useCommodity').mockReturnValue(
       { data: { guid: 'guid', mnemonic: 'EUR' } as Commodity } as UseQueryResult<Commodity>,
     );
-    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: new PriceDBMap([]) } as SWRResponse);
+    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: new PriceDBMap([]) } as UseQueryResult<PriceDBMap>);
 
     render(<CommodityPage params={{ guid: 'guid' }} />);
 
@@ -113,7 +112,7 @@ describe('CommodityPage', () => {
         },
       } as Price,
     ];
-    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: new PriceDBMap(prices) } as SWRResponse);
+    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: new PriceDBMap(prices) } as UseQueryResult<PriceDBMap>);
 
     const { container } = render(<CommodityPage params={{ guid: 'guid' }} />);
 
@@ -219,7 +218,7 @@ describe('CommodityPage', () => {
         },
       } as Price,
     ];
-    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: new PriceDBMap(prices) } as SWRResponse);
+    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: new PriceDBMap(prices) } as UseQueryResult<PriceDBMap>);
     render(<CommodityPage params={{ guid: 'guid' }} />);
 
     await screen.findByText('GOOGL');

--- a/src/__tests__/components/forms/price/PriceForm.test.tsx
+++ b/src/__tests__/components/forms/price/PriceForm.test.tsx
@@ -283,7 +283,6 @@ describe('PriceForm', () => {
       fk_currency: usd,
       valueDenom: 1,
       valueNum: 120,
-      source: null,
     });
   });
 

--- a/src/__tests__/components/forms/transaction/MainSplit.test.tsx
+++ b/src/__tests__/components/forms/transaction/MainSplit.test.tsx
@@ -7,8 +7,7 @@ import {
 import { DateTime } from 'luxon';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
-import type { SWRResponse } from 'swr';
-import { UseQueryResult } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import MainSplit from '@/components/forms/transaction/MainSplit';
 import * as queries from '@/lib/queries';
@@ -41,6 +40,8 @@ describe('MainSplit', () => {
     jest.spyOn(queries, 'getMainCurrency').mockResolvedValue(eur);
     jest.spyOn(apiHook, 'useAccounts')
       .mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
+    jest.spyOn(apiHook, 'usePrices')
+      .mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
     // @ts-ignore
     jest.spyOn(Price, 'create').mockReturnValue({ value: 1 });
   });
@@ -140,7 +141,7 @@ describe('MainSplit', () => {
             commodity: eur,
             value: 1.013,
           } as Price]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       render(
         <FormWrapper
@@ -181,7 +182,7 @@ describe('MainSplit', () => {
             currency: eur,
             value: 500,
           } as Price]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       render(
         <FormWrapper
@@ -242,7 +243,7 @@ describe('MainSplit', () => {
               value: 0.987,
             } as Price,
           ]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       render(
         <FormWrapper

--- a/src/__tests__/components/forms/transaction/SplitField.test.tsx
+++ b/src/__tests__/components/forms/transaction/SplitField.test.tsx
@@ -7,7 +7,6 @@ import {
 import { DateTime } from 'luxon';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import {
@@ -44,7 +43,7 @@ describe('SplitField', () => {
 
     jest.spyOn(queries, 'getMainCurrency').mockResolvedValue(eur);
     jest.spyOn(apiHook, 'usePrices')
-      .mockReturnValue({ data: undefined } as SWRResponse);
+      .mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
     jest.spyOn(apiHook, 'useAccounts')
       .mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
     // @ts-ignore
@@ -419,7 +418,7 @@ describe('SplitField', () => {
             commodity: usd,
             value: 0.987,
           } as Price]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
       jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
         {
           data: [
@@ -469,7 +468,7 @@ describe('SplitField', () => {
             currency: eur,
             value: 500,
           } as Price]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
       jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
         {
           data: [
@@ -518,7 +517,7 @@ describe('SplitField', () => {
             commodity: usd,
             value: 0.987,
           } as Price]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
       jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
         {
           data: [
@@ -590,7 +589,7 @@ describe('SplitField', () => {
             currency: eur,
             value: 0.987,
           } as Price]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
       jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
         {
           data: [
@@ -667,7 +666,7 @@ describe('SplitField', () => {
               value: 1.05,
             } as Price,
           ]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
         {

--- a/src/__tests__/components/forms/transaction/SplitsField.test.tsx
+++ b/src/__tests__/components/forms/transaction/SplitsField.test.tsx
@@ -20,6 +20,7 @@ import SplitsField from '@/components/forms/transaction/SplitsField';
 import * as queries from '@/lib/queries';
 import * as apiHook from '@/hooks/api';
 import type { FormValues } from '@/components/forms/transaction/types';
+import type { PriceDBMap } from '@/book/prices';
 
 jest.mock('@/lib/queries', () => ({
   __esModule: true,
@@ -34,11 +35,10 @@ jest.mock('@/hooks/api', () => ({
 describe('SplitsField', () => {
   let datasource: DataSource;
   beforeEach(async () => {
-    jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
-      {
-        data: undefined,
-      } as UseQueryResult<Account[]>,
-    );
+    jest.spyOn(apiHook, 'useAccounts')
+      .mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
+    jest.spyOn(apiHook, 'usePrices')
+      .mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,

--- a/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
+++ b/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
@@ -8,7 +8,6 @@ import {
 import userEvent from '@testing-library/user-event';
 import { DataSource, IsNull } from 'typeorm';
 import * as swr from 'swr';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import {
@@ -68,7 +67,7 @@ describe('TransactionForm', () => {
     jest.spyOn(queries, 'getMainCurrency').mockResolvedValue(eur);
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
     jest.spyOn(apiHook, 'usePrices')
-      .mockReturnValue({ data: undefined } as SWRResponse);
+      .mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
 
     root = await Account.create({
       guid: 'root_account_guid',
@@ -304,7 +303,7 @@ describe('TransactionForm', () => {
               value: 0.7,
             } as Price,
           ]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
     });
 
     /**
@@ -567,7 +566,7 @@ describe('TransactionForm', () => {
               value: 1 / 0.7,
             } as Price,
           ]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       const tickerAccount = await Account.create({
         guid: 'account_guid_3',
@@ -712,7 +711,7 @@ describe('TransactionForm', () => {
               value: 1 / 0.7,
             } as Price,
           ]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       const tickerAccount = await Account.create({
         guid: 'account_guid_3',
@@ -860,7 +859,7 @@ describe('TransactionForm', () => {
               value: 1 / 0.7,
             } as Price,
           ]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       const tickerAccount = await Account.create({
         guid: 'account_guid_3',
@@ -1042,7 +1041,7 @@ describe('TransactionForm', () => {
               value: 1 / 0.7,
             } as Price,
           ]),
-        } as SWRResponse);
+        } as UseQueryResult<PriceDBMap>);
 
       const tickerAccount = await Account.create({
         guid: 'account_guid_3',

--- a/src/__tests__/components/pages/account/InvestmentChart.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentChart.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { DateTime } from 'luxon';
 import { render, screen } from '@testing-library/react';
 import type { SWRResponse } from 'swr';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import Line from '@/components/charts/Line';
 import {
@@ -30,7 +31,7 @@ jest.mock('@/hooks/api', () => ({
 
 describe('InvestmentChart', () => {
   beforeEach(() => {
-    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({ data: undefined } as SWRResponse);
     jest.spyOn(Price, 'create').mockReturnValue({
       guid: 'missing_price',
@@ -67,14 +68,17 @@ describe('InvestmentChart', () => {
       mnemonic: 'EUR',
     };
     jest.spyOn(apiHook, 'usePrices').mockReturnValue({
-      data: [
+      data: new PriceDBMap([
         {
           date: DateTime.fromISO('2023-01-01'),
           value: 100,
+          commodity: {
+            mnemonic: 'USD',
+          },
           currency: eur,
-        },
-      ],
-    } as SWRResponse);
+        } as Price,
+      ]),
+    } as UseQueryResult<PriceDBMap>);
 
     const account = {
       guid: 'guid',
@@ -168,7 +172,7 @@ describe('InvestmentChart', () => {
           commodity: googl,
         } as Price,
       ]),
-    } as SWRResponse);
+    } as UseQueryResult<PriceDBMap>);
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: new InvestmentAccount(
         account,
@@ -412,7 +416,7 @@ describe('InvestmentChart', () => {
           commodity: googl,
         } as Price,
       ]),
-    } as SWRResponse);
+    } as UseQueryResult<PriceDBMap>);
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: new InvestmentAccount(
         account,

--- a/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { DateTime } from 'luxon';
 import type { SWRResponse } from 'swr';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import { InvestmentInfo } from '@/components/pages/account';
 import InvestmentChart from '@/components/pages/account/InvestmentChart';
@@ -34,7 +35,7 @@ describe('InvestmentInfo', () => {
   let ticker: Commodity;
 
   beforeEach(() => {
-    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({ data: undefined } as SWRResponse);
     jest.spyOn(Price, 'create').mockImplementation();
 
@@ -90,7 +91,7 @@ describe('InvestmentInfo', () => {
           commodity: ticker,
         } as Price,
       ]),
-    } as SWRResponse);
+    } as UseQueryResult<PriceDBMap>);
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: {
         cost: new Money(100, 'EUR'),
@@ -186,7 +187,7 @@ describe('InvestmentInfo', () => {
           commodity: ticker,
         } as Price,
       ]),
-    } as SWRResponse);
+    } as UseQueryResult<PriceDBMap>);
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: {
         cost: new Money(100, 'EUR'),

--- a/src/__tests__/hooks/api.test.tsx
+++ b/src/__tests__/hooks/api.test.tsx
@@ -81,19 +81,6 @@ describe('API', () => {
     expect(f).toBeCalledWith('guid');
   });
 
-  it('calls useSWRImmutable with expected params for usePrices', () => {
-    // @ts-ignore
-    renderHook(() => API.usePrices({ guid: 'guid' }));
-
-    expect(swrImmutable.default).toBeCalledWith(
-      '/api/prices/guid',
-      expect.any(Function),
-    );
-
-    expect(queries.getPrices).toBeCalledTimes(1);
-    expect(queries.getPrices).toBeCalledWith({ from: { guid: 'guid' } });
-  });
-
   it.each([
     'useInvestment',
     'useInvestments',
@@ -130,6 +117,21 @@ describe('API', () => {
       const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
       callArgs.queryFn();
       expect(queries.getMainCurrency).toBeCalled();
+    });
+  });
+
+  describe('usePrices', () => {
+    it('calls query as expected', async () => {
+      renderHook(() => API.usePrices({ guid: 'guid' } as Commodity));
+
+      expect(query.useQuery).toBeCalledWith({
+        queryKey: ['/api/prices', { commodity: 'guid' }],
+        queryFn: expect.any(Function),
+      });
+
+      const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+      callArgs.queryFn();
+      expect(queries.getPrices).toBeCalledWith({ from: { guid: 'guid' } });
     });
   });
 

--- a/src/app/dashboard/commodities/[guid]/page.tsx
+++ b/src/app/dashboard/commodities/[guid]/page.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { BiEdit, BiPlusCircle } from 'react-icons/bi';
+import Link from 'next/link';
 
 import { useCommodity, usePrices } from '@/hooks/api';
 import FormButton from '@/components/buttons/FormButton';
@@ -102,7 +103,14 @@ export default function CommodityPage({ params }: CommodityPageProps): JSX.Eleme
               <div key={key}>
                 <div className="header">
                   <span className="title text-lg">
-                    {`${commodity.mnemonic} - ${byCurrencyPrices[0].currency.mnemonic} price data`}
+                    {`${commodity.mnemonic} - `}
+                    <Link
+                      href={`/dashboard/commodities/${byCurrencyPrices[0].currency.guid}`}
+                    >
+                      {byCurrencyPrices[0].currency.mnemonic}
+                    </Link>
+                    {' '}
+                    price data
                   </span>
                 </div>
                 <div className="grid grid-cols-12 card">

--- a/src/components/forms/price/PriceForm.tsx
+++ b/src/components/forms/price/PriceForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { DateTime } from 'luxon';
 import { useForm, Controller } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';
-import { mutate } from 'swr';
 import classNames from 'classnames';
 
 import { Price } from '@/book/entities';
@@ -150,16 +149,10 @@ async function onSubmit(
   });
 
   if (action === 'add' || action === 'update') {
-    await Price.upsert(
-      [price],
-      {
-        conflictPaths: ['fk_commodity', 'fk_currency', 'date'],
-      },
-    );
+    await price.save();
   } else if (action === 'delete') {
-    await Price.remove(price);
+    await price.remove();
   }
-  mutate(`/api/prices/${price.commodity.guid}`);
 
   onSave(price);
 }

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -6,7 +6,7 @@ import {
   UseQueryResult,
 } from '@tanstack/react-query';
 
-import { Commodity, Transaction } from '@/book/entities';
+import { Commodity, Price, Transaction } from '@/book/entities';
 import { InvestmentAccount } from '@/book/models';
 import * as queries from '@/lib/queries';
 import type { PriceDBMap } from '@/book/prices';
@@ -108,10 +108,9 @@ export function useInvestments(): SWRResponse<InvestmentAccount[]> {
 /**
  * Returns prices for a given commodity
  */
-export function usePrices(c: Commodity | undefined): SWRResponse<PriceDBMap> {
-  const key = `/api/prices/${c?.guid}`;
-  return useSWRImmutable(
-    c?.guid ? key : null,
-    fetcher(async () => queries.getPrices({ from: c }), key),
-  );
+export function usePrices(c: Commodity | undefined): UseQueryResult<PriceDBMap> {
+  return useQuery({
+    queryKey: [Price.CACHE_KEY, { commodity: c?.guid }],
+    queryFn: fetcher(() => queries.getPrices({ from: c }), `${Price.CACHE_KEY}/${c?.guid}`),
+  });
 }


### PR DESCRIPTION
Started trying to optimise the `usePrices` query by modifying the cached data but then realizing it's a bit more complicated due to using `upserts` for inserting new prices which means we have to check via `guid` but also via the conflict keys when upserting. For now taking the strategy of invalidating the keys.