### PR TITLE
Move use investments to query

### DIFF
--- a/src/__tests__/app/dashboard/investments/page.test.tsx
+++ b/src/__tests__/app/dashboard/investments/page.test.tsx
@@ -51,7 +51,7 @@ describe('InvestmentsPage', () => {
   });
 
   it('shows loading when loading data', async () => {
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ isLoading: true } as UseQueryResult<InvestmentAccount[]>);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ isPending: true } as UseQueryResult<InvestmentAccount[]>);
     render(<InvestmentsPage />);
 
     await screen.findByTestId('Loading');

--- a/src/__tests__/app/dashboard/investments/page.test.tsx
+++ b/src/__tests__/app/dashboard/investments/page.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { Commodity } from '@/book/entities';
@@ -43,7 +42,7 @@ jest.mock('@/components/Loading', () => jest.fn(
 
 describe('InvestmentsPage', () => {
   beforeEach(() => {
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as UseQueryResult<InvestmentAccount[]>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: undefined } as UseQueryResult<Commodity>);
   });
 
@@ -52,14 +51,14 @@ describe('InvestmentsPage', () => {
   });
 
   it('shows loading when loading data', async () => {
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ isLoading: true } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ isLoading: true } as UseQueryResult<InvestmentAccount[]>);
     render(<InvestmentsPage />);
 
     await screen.findByTestId('Loading');
   });
 
   it('renders while loading data', async () => {
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: [] } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: [] as InvestmentAccount[] } as UseQueryResult<InvestmentAccount[]>);
     render(<InvestmentsPage />);
     await screen.findByText('You have no investments yet!');
   });
@@ -80,7 +79,7 @@ describe('InvestmentsPage', () => {
       realizedDividendsInCurrency: new Money(5, 'EUR'),
     } as InvestmentAccount;
 
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValueOnce({ data: [investment1] } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValueOnce({ data: [investment1] } as UseQueryResult<InvestmentAccount[]>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: mainCurrency } as UseQueryResult<Commodity>);
 
     const { container } = render(<InvestmentsPage />);
@@ -153,7 +152,7 @@ describe('InvestmentsPage', () => {
       realizedDividendsInCurrency: new Money(5, 'USD'),
     } as InvestmentAccount;
 
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValueOnce({ data: [investment1] } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValueOnce({ data: [investment1] } as UseQueryResult<InvestmentAccount[]>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: mainCurrency } as UseQueryResult<Commodity>);
 
     const { container } = render(<InvestmentsPage />);

--- a/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
+++ b/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
@@ -1237,10 +1237,8 @@ describe('TransactionForm', () => {
     expect(screen.getByText('add')).toBeEnabled();
     await user.click(screen.getByText('add'));
 
-    expect(swr.mutate).toBeCalledTimes(3);
-    expect(swr.mutate).toHaveBeenNthCalledWith(1, '/api/investments', undefined);
-    expect(swr.mutate).toHaveBeenNthCalledWith(2, '/api/investments/stock_account');
-    expect(swr.mutate).toHaveBeenNthCalledWith(3, '/api/monthly-totals', undefined);
+    expect(swr.mutate).toBeCalledTimes(1);
+    expect(swr.mutate).toHaveBeenNthCalledWith(1, '/api/monthly-totals', undefined);
   });
 
   describe('actions', () => {

--- a/src/__tests__/components/pages/account/InvestmentChart.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentChart.test.tsx
@@ -32,7 +32,7 @@ jest.mock('@/hooks/api', () => ({
 describe('InvestmentChart', () => {
   beforeEach(() => {
     jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
-    jest.spyOn(apiHook, 'useInvestment').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestment').mockReturnValue({ data: undefined } as UseQueryResult<InvestmentAccount>);
     jest.spyOn(Price, 'create').mockReturnValue({
       guid: 'missing_price',
       date: DateTime.now(),
@@ -91,6 +91,7 @@ describe('InvestmentChart', () => {
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: new InvestmentAccount(
         account,
+        account.splits,
         'EUR',
         new PriceDBMap([
           // @ts-ignore
@@ -105,7 +106,7 @@ describe('InvestmentChart', () => {
           } as Price,
         ]),
       ),
-    } as SWRResponse);
+    } as UseQueryResult<InvestmentAccount>);
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-02-02') as DateTime<true>);
 
     render(
@@ -176,6 +177,7 @@ describe('InvestmentChart', () => {
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: new InvestmentAccount(
         account,
+        account.splits,
         'EUR',
         new PriceDBMap([
           // @ts-ignore
@@ -190,7 +192,7 @@ describe('InvestmentChart', () => {
           } as Price,
         ]),
       ),
-    } as SWRResponse);
+    } as UseQueryResult<InvestmentAccount>);
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-04-01') as DateTime<true>);
 
     render(
@@ -420,6 +422,7 @@ describe('InvestmentChart', () => {
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: new InvestmentAccount(
         account,
+        account.splits,
         'EUR',
         new PriceDBMap([
           // @ts-ignore

--- a/src/__tests__/components/pages/investments/DividendChart.test.tsx
+++ b/src/__tests__/components/pages/investments/DividendChart.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { DateTime } from 'luxon';
 import { render, act } from '@testing-library/react';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import Money from '@/book/Money';
@@ -26,7 +25,7 @@ describe('DividendChart', () => {
   beforeEach(() => {
     jest.spyOn(DateTime, 'now').mockReturnValue(now as DateTime<true>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as UseQueryResult<InvestmentAccount[]>);
   });
 
   afterEach(() => {
@@ -191,7 +190,7 @@ describe('DividendChart', () => {
             ],
           } as InvestmentAccount,
         ],
-      } as SWRResponse,
+      } as UseQueryResult<InvestmentAccount[]>,
     );
 
     const { container } = render(<DividendChart />);
@@ -254,7 +253,7 @@ describe('DividendChart', () => {
             ],
           } as InvestmentAccount,
         ],
-      } as SWRResponse,
+      } as UseQueryResult<InvestmentAccount[]>,
     );
 
     render(<DividendChart />);
@@ -323,7 +322,7 @@ describe('DividendChart', () => {
             ],
           } as InvestmentAccount,
         ],
-      } as SWRResponse,
+      } as UseQueryResult<InvestmentAccount[]>,
     );
 
     render(<DividendChart />);

--- a/src/__tests__/components/pages/investments/InvestmentsTable.test.tsx
+++ b/src/__tests__/components/pages/investments/InvestmentsTable.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import type { SWRResponse } from 'swr';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import Money from '@/book/Money';
 import { InvestmentAccount } from '@/book/models';
@@ -19,7 +19,7 @@ jest.mock('@/hooks/api', () => ({
 
 describe('InvestmentsTable', () => {
   it('creates empty Table with expected params', async () => {
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as UseQueryResult<InvestmentAccount[]>);
 
     render(<InvestmentsTable />);
 
@@ -98,7 +98,7 @@ describe('InvestmentsTable', () => {
             realizedDividendsInCurrency: new Money(5, 'EUR'),
           } as InvestmentAccount,
         ],
-      } as SWRResponse,
+      } as UseQueryResult<InvestmentAccount[]>,
     );
 
     render(<InvestmentsTable />);

--- a/src/__tests__/components/pages/investments/WeightsChart.test.tsx
+++ b/src/__tests__/components/pages/investments/WeightsChart.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import Money from '@/book/Money';
@@ -23,7 +22,7 @@ jest.mock('@/components/charts/Tree', () => jest.fn(
 
 describe('WeightsChart', () => {
   beforeEach(() => {
-    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useInvestments').mockReturnValue({ data: undefined } as UseQueryResult<InvestmentAccount[]>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
   });
 
@@ -105,7 +104,7 @@ describe('WeightsChart', () => {
             } as Account,
           } as InvestmentAccount,
         ],
-      } as SWRResponse,
+      } as UseQueryResult<InvestmentAccount[]>,
     );
 
     render(<WeightsChart totalValue={new Money(600, 'EUR')} />);

--- a/src/__tests__/hooks/api.test.tsx
+++ b/src/__tests__/hooks/api.test.tsx
@@ -64,36 +64,6 @@ describe('API', () => {
     });
   });
 
-  describe('useMainCurrency', () => {
-    it('calls query as expected', async () => {
-      renderHook(() => API.useMainCurrency());
-
-      expect(query.useQuery).toBeCalledWith({
-        queryKey: ['/api/commodities', { guid: 'main' }],
-        queryFn: expect.any(Function),
-      });
-
-      const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
-      callArgs.queryFn();
-      expect(queries.getMainCurrency).toBeCalled();
-    });
-  });
-
-  describe('usePrices', () => {
-    it('calls query as expected', async () => {
-      renderHook(() => API.usePrices({ guid: 'guid' } as Commodity));
-
-      expect(query.useQuery).toBeCalledWith({
-        queryKey: ['/api/prices', { commodity: 'guid' }],
-        queryFn: expect.any(Function),
-      });
-
-      const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
-      callArgs.queryFn();
-      expect(queries.getPrices).toBeCalledWith({ from: { guid: 'guid' } });
-    });
-  });
-
   describe('useLatestTxs', () => {
     it('calls query as expected', async () => {
       renderHook(() => API.useLatestTxs());

--- a/src/__tests__/hooks/api.test.tsx
+++ b/src/__tests__/hooks/api.test.tsx
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react';
 import * as swrImmutable from 'swr/immutable';
-import * as swr from 'swr';
 import * as query from '@tanstack/react-query';
 import { BareFetcher, SWRResponse } from 'swr';
 
@@ -8,7 +7,6 @@ import { Commodity } from '@/book/entities';
 import { PriceDBMap } from '@/book/prices';
 import * as API from '@/hooks/api';
 import * as queries from '@/lib/queries';
-import { InvestmentAccount } from '@/book/models';
 import { AccountsMap } from '@/types/book';
 
 jest.mock('swr');
@@ -49,45 +47,6 @@ describe('API', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it.each([
-    ['useInvestments', '/api/investments', queries.getInvestments],
-  ])('calls useSWRImmutable with expected params for %s', (name, key, f) => {
-    // @ts-ignore
-    renderHook(() => API[name]());
-
-    expect(swrImmutable.default).toBeCalledWith(
-      key,
-      expect.any(Function),
-    );
-
-    expect(f).toBeCalledTimes(1);
-    expect(f).toBeCalledWith();
-  });
-
-  it.each([
-    ['useInvestment', '/api/investments/guid', queries.getInvestment],
-  ])('calls useSWRImmutable with expected params for %s', (name, key, f) => {
-    // @ts-ignore
-    renderHook(() => API[name]('guid'));
-
-    expect(swrImmutable.default).toBeCalledWith(
-      key,
-      expect.any(Function),
-    );
-
-    expect(f).toBeCalledTimes(1);
-    expect(f).toBeCalledWith('guid');
-  });
-
-  it.each([
-    'useInvestment',
-    'useInvestments',
-  ])('propagates error for %s', (name) => {
-    jest.spyOn(swrImmutable, 'default').mockReturnValue({ error: 'error' } as SWRResponse);
-    // @ts-ignore
-    renderHook(() => expect(() => API[name]()).toThrow('error'));
   });
 
   describe('useStartDate', () => {
@@ -166,33 +125,6 @@ describe('API', () => {
         expect.any(Function),
       );
       expect(queries.getMonthlyTotals).toBeCalledWith(accounts, todayPrices);
-    });
-  });
-
-  describe('useInvestments', () => {
-    it('mutates detail keys', () => {
-      jest.spyOn(swrImmutable, 'default').mockReturnValue({
-        data: [
-          { account: { guid: '1' } } as InvestmentAccount,
-          { account: { guid: '2' } } as InvestmentAccount,
-        ],
-      } as SWRResponse);
-      renderHook(() => API.useInvestments());
-
-      expect(swrImmutable.default).toBeCalledWith(
-        '/api/investments',
-        expect.any(Function),
-      );
-      expect(swr.mutate).toBeCalledWith(
-        '/api/investments/1',
-        { account: { guid: '1' } },
-        { revalidate: false },
-      );
-      expect(swr.mutate).toBeCalledWith(
-        '/api/investments/2',
-        { account: { guid: '2' } },
-        { revalidate: false },
-      );
     });
   });
 });

--- a/src/__tests__/hooks/api/useInvestments.test.tsx
+++ b/src/__tests__/hooks/api/useInvestments.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react';
+import * as query from '@tanstack/react-query';
+
+import { useInvestment, useInvestments } from '@/hooks/api';
+import { InvestmentAccount } from '@/book/models';
+import * as queries from '@/lib/queries';
+import type { Account } from '@/book/entities';
+
+jest.mock('@tanstack/react-query');
+jest.mock('@/lib/queries');
+
+describe('useInvestment', () => {
+  let investment: InvestmentAccount;
+
+  beforeEach(() => {
+    investment = {
+      account: {
+        guid: 'guid',
+      } as Account,
+    } as InvestmentAccount;
+    // @ts-ignore
+    jest.spyOn(queries, 'getInvestment').mockResolvedValue(investment);
+    jest.spyOn(query, 'useQuery');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls query as expected', async () => {
+    renderHook(() => useInvestment('guid'));
+
+    expect(query.useQuery).toBeCalledWith({
+      queryKey: ['/api/investments', { guid: 'guid' }],
+      queryFn: expect.any(Function),
+    });
+
+    const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+    callArgs.queryFn();
+    expect(queries.getInvestment).toBeCalledWith('guid');
+  });
+});
+
+describe('useInvestments', () => {
+  let investment1: InvestmentAccount;
+  let investment2: InvestmentAccount;
+
+  beforeEach(() => {
+    investment1 = {
+      account: {
+        guid: 'guid1',
+      } as Account,
+    } as InvestmentAccount;
+    investment2 = {
+      account: {
+        guid: 'guid2',
+      } as Account,
+    } as InvestmentAccount;
+    jest.spyOn(queries, 'getInvestments').mockResolvedValue([investment1, investment2]);
+    jest.spyOn(query, 'useQuery');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls query as expected', async () => {
+    renderHook(() => useInvestments());
+
+    expect(query.useQuery).toBeCalledWith({
+      queryKey: ['/api/investments'],
+      queryFn: expect.any(Function),
+    });
+
+    const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+    callArgs.queryFn();
+    expect(queries.getInvestments).toBeCalledWith();
+  });
+});

--- a/src/__tests__/hooks/api/useInvestments.test.tsx
+++ b/src/__tests__/hooks/api/useInvestments.test.tsx
@@ -1,13 +1,19 @@
 import { renderHook } from '@testing-library/react';
 import * as query from '@tanstack/react-query';
 
-import { useInvestment, useInvestments } from '@/hooks/api';
+import { useInvestment, useInvestments } from '@/hooks/api/useInvestments';
 import { InvestmentAccount } from '@/book/models';
-import * as queries from '@/lib/queries';
-import type { Account } from '@/book/entities';
+import * as queries from '@/lib/queries/getInvestments';
+import * as useAccountsHook from '@/hooks/api/useAccounts';
+import * as useSplitsHook from '@/hooks/api/useSplits';
+import * as useMainCurrencyHook from '@/hooks/api/useMainCurrency';
+import type { Account, Commodity, Split } from '@/book/entities';
 
 jest.mock('@tanstack/react-query');
-jest.mock('@/lib/queries');
+jest.mock('@/lib/queries/getInvestments');
+jest.mock('@/hooks/api/useAccounts');
+jest.mock('@/hooks/api/useSplits');
+jest.mock('@/hooks/api/useMainCurrency');
 
 describe('useInvestment', () => {
   let investment: InvestmentAccount;
@@ -18,62 +24,232 @@ describe('useInvestment', () => {
         guid: 'guid',
       } as Account,
     } as InvestmentAccount;
-    // @ts-ignore
-    jest.spyOn(queries, 'getInvestment').mockResolvedValue(investment);
-    jest.spyOn(query, 'useQuery');
+
+    jest.spyOn(queries, 'initInvestment').mockResolvedValue(investment);
+    jest.spyOn(query, 'useQuery').mockReturnValue({
+      data: { account: { guid: '1' } } as InvestmentAccount,
+      dataUpdatedAt: 123,
+    } as query.UseQueryResult<InvestmentAccount>);
+
+    jest.spyOn(useAccountsHook, 'useAccount').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<Account>);
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<Split[]>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<Commodity>);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('calls query as expected', async () => {
+  it('calls query with enabled false when no account', async () => {
+    const mainCurrency = { guid: 'c_guid' };
+    const splits = [{ guid: 'sp_guid' }];
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: splits,
+    } as query.UseQueryResult<Split[]>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: mainCurrency,
+    } as query.UseQueryResult<Commodity>);
+
     renderHook(() => useInvestment('guid'));
 
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query with enabled false when no splits', async () => {
+    const account = { guid: 'guid' };
+    const mainCurrency = { guid: 'c_guid' };
+    jest.spyOn(useAccountsHook, 'useAccount').mockReturnValue({
+      data: account,
+    } as query.UseQueryResult<Account>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: mainCurrency,
+    } as query.UseQueryResult<Commodity>);
+
+    renderHook(() => useInvestment('guid'));
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query with enabled false when no mainCurrency', async () => {
+    const account = { guid: 'guid' };
+    const splits = [{ guid: 'sp_guid' }];
+    jest.spyOn(useAccountsHook, 'useAccount').mockReturnValue({
+      data: account,
+    } as query.UseQueryResult<Account>);
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: splits,
+    } as query.UseQueryResult<Split[]>);
+
+    renderHook(() => useInvestment('guid'));
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query as expected', async () => {
+    const account = { guid: 'guid' };
+    const mainCurrency = { guid: 'c_guid' };
+    const splits = [{ guid: 'sp_guid' }];
+    jest.spyOn(useAccountsHook, 'useAccount').mockReturnValue({
+      data: account,
+      dataUpdatedAt: 1,
+    } as query.UseQueryResult<Account>);
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: splits,
+      dataUpdatedAt: 2,
+    } as query.UseQueryResult<Split[]>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: mainCurrency,
+      dataUpdatedAt: 3,
+    } as query.UseQueryResult<Commodity>);
+    jest.spyOn(query, 'useQueryClient').mockReturnValue({
+      setQueryData: jest.fn() as query.QueryClient['setQueryData'],
+    } as query.QueryClient);
+
+    renderHook(() => useInvestment('guid'));
+
+    expect(useAccountsHook.useAccount).toBeCalledWith('guid');
+    expect(useSplitsHook.useSplits).toBeCalledWith({ guid: 'guid' });
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/investments', { guid: 'guid' }],
+      queryKey: [
+        '/api/investments',
+        {
+          account: 'guid',
+          accountUpdatedAt: 1,
+          splitsUpdatedAt: 2,
+          currencyUpdatedAt: 3,
+        },
+      ],
       queryFn: expect.any(Function),
+      enabled: true,
+      placeholderData: expect.any(Function),
     });
 
     const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
     callArgs.queryFn();
-    expect(queries.getInvestment).toBeCalledWith('guid');
+    expect(queries.initInvestment).toBeCalledWith(account, mainCurrency, splits);
   });
 });
 
 describe('useInvestments', () => {
-  let investment1: InvestmentAccount;
-  let investment2: InvestmentAccount;
+  let investment: InvestmentAccount;
 
   beforeEach(() => {
-    investment1 = {
+    investment = {
       account: {
-        guid: 'guid1',
+        guid: 'guid',
       } as Account,
     } as InvestmentAccount;
-    investment2 = {
-      account: {
-        guid: 'guid2',
-      } as Account,
-    } as InvestmentAccount;
-    jest.spyOn(queries, 'getInvestments').mockResolvedValue([investment1, investment2]);
-    jest.spyOn(query, 'useQuery');
+
+    jest.spyOn(queries, 'initInvestment').mockResolvedValue(investment);
+    jest.spyOn(query, 'useQuery').mockReturnValue({
+      data: { account: { guid: '1' } } as InvestmentAccount,
+    } as query.UseQueryResult<InvestmentAccount>);
+
+    jest.spyOn(useAccountsHook, 'useAccounts').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<Account[]>);
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<Split[]>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<Commodity>);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('calls query as expected', async () => {
+  it('calls query with enabled false when no accounts', async () => {
+    const mainCurrency = { guid: 'c_guid' };
+    const splits = [{ guid: 'sp_guid' }];
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: splits,
+    } as query.UseQueryResult<Split[]>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: mainCurrency,
+    } as query.UseQueryResult<Commodity>);
+
     renderHook(() => useInvestments());
 
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query with enabled false when no splits', async () => {
+    const account = { guid: 'guid' };
+    const mainCurrency = { guid: 'c_guid' };
+    jest.spyOn(useAccountsHook, 'useAccounts').mockReturnValue({
+      data: [account],
+    } as query.UseQueryResult<Account[]>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: mainCurrency,
+    } as query.UseQueryResult<Commodity>);
+
+    renderHook(() => useInvestments());
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query with enabled false when no mainCurrency', async () => {
+    const account = { guid: 'guid' };
+    const splits = [{ guid: 'sp_guid' }];
+    jest.spyOn(useAccountsHook, 'useAccounts').mockReturnValue({
+      data: [account],
+    } as query.UseQueryResult<Account[]>);
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: splits,
+    } as query.UseQueryResult<Split[]>);
+
+    renderHook(() => useInvestments());
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query as expected', async () => {
+    const account1 = { guid: 'guid', type: 'INVESTMENT' };
+    const account2 = { guid: 'guid', type: 'ASSET' };
+    const mainCurrency = { guid: 'c_guid' };
+    const splits = [{ guid: 'sp_guid' }];
+    jest.spyOn(useAccountsHook, 'useAccounts').mockReturnValue({
+      data: [account1, account2],
+    } as query.UseQueryResult<Account[]>);
+    jest.spyOn(useSplitsHook, 'useSplits').mockReturnValue({
+      data: splits,
+    } as query.UseQueryResult<Split[]>);
+    jest.spyOn(useMainCurrencyHook, 'useMainCurrency').mockReturnValue({
+      data: mainCurrency,
+    } as query.UseQueryResult<Commodity>);
+
+    renderHook(() => useInvestments());
+
+    expect(useAccountsHook.useAccounts).toBeCalledWith();
+    expect(useSplitsHook.useSplits).toBeCalledWith({ type: 'INVESTMENT' });
     expect(query.useQuery).toBeCalledWith({
       queryKey: ['/api/investments'],
       queryFn: expect.any(Function),
+      enabled: true,
     });
 
     const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
     callArgs.queryFn();
-    expect(queries.getInvestments).toBeCalledWith();
+    expect(queries.getInvestments).toBeCalledWith([account1], mainCurrency, splits);
   });
 });

--- a/src/__tests__/hooks/api/useMainCurrency.test.ts
+++ b/src/__tests__/hooks/api/useMainCurrency.test.ts
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react';
+import * as query from '@tanstack/react-query';
+
+import { useMainCurrency } from '@/hooks/api';
+import * as queries from '@/lib/queries';
+
+jest.mock('@tanstack/react-query');
+jest.mock('@/lib/queries');
+
+describe('useMainCurrency', () => {
+  it('calls query as expected', async () => {
+    renderHook(() => useMainCurrency());
+
+    expect(query.useQuery).toBeCalledWith({
+      queryKey: ['/api/commodities', { guid: 'main' }],
+      queryFn: expect.any(Function),
+    });
+
+    const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+    callArgs.queryFn();
+    expect(queries.getMainCurrency).toBeCalled();
+  });
+});

--- a/src/__tests__/hooks/api/usePrices.test.ts
+++ b/src/__tests__/hooks/api/usePrices.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react';
+import * as query from '@tanstack/react-query';
+
+import { usePrices } from '@/hooks/api';
+import * as queries from '@/lib/queries';
+import type { Commodity } from '@/book/entities';
+
+jest.mock('@tanstack/react-query');
+jest.mock('@/lib/queries');
+
+describe('usePrices', () => {
+  it('calls query as expected', async () => {
+    renderHook(() => usePrices({ guid: 'guid' } as Commodity));
+
+    expect(query.useQuery).toBeCalledWith({
+      queryKey: ['/api/prices', { commodity: 'guid' }],
+      queryFn: expect.any(Function),
+      enabled: true,
+    });
+
+    const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+    callArgs.queryFn();
+    expect(queries.getPrices).toBeCalledWith({ from: { guid: 'guid' } });
+  });
+});

--- a/src/__tests__/hooks/api/useSplits.test.ts
+++ b/src/__tests__/hooks/api/useSplits.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import * as query from '@tanstack/react-query';
+
+import { useSplits } from '@/hooks/api';
+import { Split } from '@/book/entities';
+import * as queries from '@/lib/queries';
+
+jest.mock('@tanstack/react-query');
+jest.mock('@/lib/queries');
+
+describe('useSplits', () => {
+  let split1: Split;
+  let split2: Split;
+
+  beforeEach(() => {
+    split1 = {
+      guid: 'guid1',
+    } as Split;
+    split2 = {
+      guid: 'guid2',
+    } as Split;
+    jest.spyOn(queries, 'getSplits').mockResolvedValue([split1, split2]);
+    jest.spyOn(query, 'useQuery');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls query as expected', async () => {
+    renderHook(() => useSplits({ guid: 'guid' }));
+
+    expect(query.useQuery).toBeCalledWith({
+      queryKey: ['/api/splits', { guid: 'guid' }],
+      queryFn: expect.any(Function),
+    });
+
+    const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+    callArgs.queryFn();
+    expect(queries.getSplits).toBeCalledWith(
+      { guid: 'guid' },
+      {
+        fk_transaction: {
+          splits: {
+            fk_account: true,
+          },
+        },
+        fk_account: true,
+      },
+    );
+  });
+});

--- a/src/__tests__/lib/queries/getSplits.test.ts
+++ b/src/__tests__/lib/queries/getSplits.test.ts
@@ -61,7 +61,7 @@ describe('getSplits', () => {
   });
 
   it('returns empty when no transactions', async () => {
-    const splits = await getSplits(assetAccount.guid);
+    const splits = await getSplits({ guid: assetAccount.guid });
     expect(splits).toEqual([]);
   });
 
@@ -130,7 +130,17 @@ describe('getSplits', () => {
       ],
     }).save();
 
-    const splits = await getSplits(assetAccount.guid);
+    const splits = await getSplits(
+      { guid: assetAccount.guid },
+      {
+        fk_transaction: {
+          splits: {
+            fk_account: true,
+          },
+        },
+        fk_account: true,
+      },
+    );
 
     expect(splits[0].transaction.date.year).toEqual(2023);
     expect(splits[1].transaction.date.year).toEqual(2022);

--- a/src/app/dashboard/investments/page.tsx
+++ b/src/app/dashboard/investments/page.tsx
@@ -15,11 +15,11 @@ import Money from '@/book/Money';
 import * as API from '@/hooks/api';
 
 export default function InvestmentsPage(): JSX.Element {
-  const { data: investments, isLoading } = API.useInvestments();
+  const { data: investments, isPending } = API.useInvestments();
   const { data: currency } = API.useMainCurrency();
   const mainCurrency = currency?.mnemonic || 'EUR';
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <div className="h-screen">
         <div className="flex text-sm h-3/4 place-content-center place-items-center">

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -20,7 +20,7 @@ const queryClient = new QueryClient({
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
-      gcTime: 3600000,
+      gcTime: 300000,
     },
   },
 });

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -292,15 +292,15 @@ describe('caching', () => {
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/txs', { name: 'latest' }],
+      queryKey: ['/api/txs', { name: 'start' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { account: '1' }],
+      queryKey: ['/api/splits', { guid: '1' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { account: '2' }],
+      queryKey: ['/api/splits', { guid: '2' }],
       refetchType: 'all',
     });
   });
@@ -324,15 +324,15 @@ describe('caching', () => {
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/txs', { name: 'latest' }],
+      queryKey: ['/api/txs', { name: 'start' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { account: '1' }],
+      queryKey: ['/api/splits', { guid: '1' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { account: '2' }],
+      queryKey: ['/api/splits', { guid: '2' }],
       refetchType: 'all',
     });
   });

--- a/src/book/__tests__/models/InvestmentAccount.test.ts
+++ b/src/book/__tests__/models/InvestmentAccount.test.ts
@@ -88,10 +88,10 @@ describe('InvestmentAccount', () => {
           splits: true,
         },
       });
-      const investment = new InvestmentAccount(account, 'EUR', priceMap);
+      const investment = new InvestmentAccount(account, account.splits, 'EUR', priceMap);
 
       expect(investment.account).toEqual(account);
-      expect(investment.account.splits).toEqual([]);
+      expect(investment.splits).toEqual([]);
 
       expect(investment.mainCurrency).toEqual('EUR');
       expect(investment.currency).toEqual('EUR');
@@ -141,10 +141,10 @@ describe('InvestmentAccount', () => {
           splits: true,
         },
       });
-      const investment = new InvestmentAccount(account, 'EUR', priceMap);
+      const investment = new InvestmentAccount(account, account.splits, 'EUR', priceMap);
 
       expect(investment.account).toEqual(account);
-      expect(investment.account.splits).toEqual([]);
+      expect(investment.splits).toEqual([]);
 
       expect(investment.mainCurrency).toEqual('EUR');
       expect(investment.currency).toEqual('USD');
@@ -189,7 +189,7 @@ describe('InvestmentAccount', () => {
           splits: true,
         },
       });
-      const investment = new InvestmentAccount(account, 'EUR', priceMap);
+      const investment = new InvestmentAccount(account, account.splits, 'EUR', priceMap);
 
       investment.setTodayQuoteInfo({
         price: 1000,
@@ -225,7 +225,7 @@ describe('InvestmentAccount', () => {
         },
       });
       expect(
-        () => new InvestmentAccount(account, 'EUR', priceMap),
+        () => new InvestmentAccount(account, account.splits, 'EUR', priceMap),
       ).toThrow('No price found for TICKER');
     });
   });
@@ -355,6 +355,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice, todayCurrencyPrice]),
         );
@@ -412,6 +413,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice, currencyPrice2, todayCurrencyPrice]),
         );
@@ -467,6 +469,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice]),
         );
@@ -516,6 +519,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice]),
         );
@@ -570,6 +574,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice]),
         );
@@ -624,6 +629,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice, todayCurrencyPrice]),
         );
@@ -677,6 +683,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice, todayCurrencyPrice]),
         );
@@ -728,6 +735,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice, todayCurrencyPrice]),
         );
@@ -779,6 +787,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice, todayCurrencyPrice]),
         );
@@ -853,6 +862,7 @@ describe('InvestmentAccount', () => {
 
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice]),
         );
@@ -940,6 +950,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice]),
         );
@@ -971,6 +982,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           'EUR',
           new PriceDBMap([stockPrice, currencyPrice]),
         );
@@ -1005,6 +1017,7 @@ describe('InvestmentAccount', () => {
         });
         const instance = new InvestmentAccount(
           account,
+          account.splits,
           'EUR',
           new PriceDBMap([stockPrice, currencyPrice]),
         );
@@ -1047,6 +1060,7 @@ describe('InvestmentAccount', () => {
       expect(
         () => new InvestmentAccount(
           account,
+          account.splits,
           mainCurrency,
           new PriceDBMap([stockPrice, currencyPrice]),
         ),

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -126,7 +126,7 @@ export async function updateCache(
 
   entity.splits.forEach(split => {
     queryClient.invalidateQueries({
-      queryKey: [Split.CACHE_KEY, { account: split.fk_account.guid }],
+      queryKey: [Split.CACHE_KEY, { guid: split.fk_account.guid }],
       refetchType: 'all',
     });
   });

--- a/src/book/models/InvestmentAccount.ts
+++ b/src/book/models/InvestmentAccount.ts
@@ -7,6 +7,8 @@ import { PriceDBMap } from '../prices';
 import type { QuoteInfo } from '../types';
 
 export default class InvestmentAccount {
+  static CACHE_KEY = '/api/investments';
+
   readonly account: Account;
   quantity: Money;
   realizedProfit: Money;

--- a/src/book/models/InvestmentAccount.ts
+++ b/src/book/models/InvestmentAccount.ts
@@ -10,6 +10,7 @@ export default class InvestmentAccount {
   static CACHE_KEY = '/api/investments';
 
   readonly account: Account;
+  readonly splits: Split[];
   quantity: Money;
   realizedProfit: Money;
   realizedProfitInCurrency: Money;
@@ -25,8 +26,14 @@ export default class InvestmentAccount {
   private _avgPriceInCurrency = 0;
   private _priceDBMap: PriceDBMap;
 
-  constructor(account: Account, mainCurrency: string, priceDBMap: PriceDBMap) {
+  constructor(
+    account: Account,
+    splits: Split[],
+    mainCurrency: string,
+    priceDBMap: PriceDBMap,
+  ) {
     this.account = account;
+    this.splits = splits;
     this.mainCurrency = mainCurrency;
 
     this._priceDBMap = priceDBMap;
@@ -154,11 +161,7 @@ export default class InvestmentAccount {
     this.realizedProfit = new Money(0, this.currency);
     this.dividends.splice(0, this.dividends.length);
 
-    const sortedSplits = this.account.splits.sort(
-      (a, b) => a.transaction.date.toMillis() - b.transaction.date.toMillis(),
-    );
-
-    sortedSplits.filter(
+    this.splits.filter(
       split => split.transaction.date <= (date || DateTime.now()),
     ).forEach((split) => {
       const numSplits = split.transaction.splits.length;

--- a/src/components/forms/transaction/TransactionForm.tsx
+++ b/src/components/forms/transaction/TransactionForm.tsx
@@ -148,13 +148,6 @@ async function onSubmit(data: FormValues, action: 'add' | 'update' | 'delete', o
     await transaction.remove();
   }
 
-  transaction.splits.forEach(split => {
-    if (split.account.commodity.namespace !== 'CURRENCY') {
-      mutate('/api/investments', undefined);
-      mutate(`/api/investments/${split.account.guid}`);
-    }
-  });
-
   mutate('/api/monthly-totals', undefined);
   onSave();
 }

--- a/src/components/pages/account/AccountInfo.tsx
+++ b/src/components/pages/account/AccountInfo.tsx
@@ -15,7 +15,7 @@ export type AccountInfoProps = {
 export default function AccountInfo({
   account,
 }: AccountInfoProps): JSX.Element {
-  let { data: splits } = useSplits(account.guid);
+  let { data: splits } = useSplits({ guid: account.guid });
   splits = splits || [];
 
   const total = new Money(splits.reduce(

--- a/src/components/pages/account/Header.tsx
+++ b/src/components/pages/account/Header.tsx
@@ -24,7 +24,7 @@ export default function Header({
   account,
 }: HeaderProps): JSX.Element {
   const { data: parent } = useAccount(account.parentId);
-  const { data: splits } = useSplits(account.guid);
+  const { data: splits } = useSplits({ guid: account.guid });
   const router = useRouter();
 
   const latestDate = splits?.[0]?.transaction?.date;

--- a/src/components/pages/account/InvestmentChart.tsx
+++ b/src/components/pages/account/InvestmentChart.tsx
@@ -25,7 +25,7 @@ export default function InvestmentChart({
     return <Loading />;
   }
 
-  if (!investment.account.splits.length) {
+  if (!investment.splits.length) {
     return (
       <div className="flex h-full text-sm place-content-center place-items-center">
         <span>You don&apos;t have any transactions for this investment yet!</span>
@@ -33,7 +33,7 @@ export default function InvestmentChart({
     );
   }
 
-  const startDate = investment.account.splits[0].transaction.date;
+  const startDate = investment.splits[investment.splits.length - 1].transaction.date;
   const prices = pricesMap.prices || [];
   const currency = (prices.length && prices[0].currency.mnemonic) || '';
 

--- a/src/components/pages/account/SplitsHistogram.tsx
+++ b/src/components/pages/account/SplitsHistogram.tsx
@@ -14,7 +14,7 @@ export type SplitsHistogramProps = {
 export default function SplitsHistogram({
   account,
 }: SplitsHistogramProps): JSX.Element {
-  let { data: splits } = API.useSplits(account.guid);
+  let { data: splits } = API.useSplits({ guid: account.guid });
   splits = splits || [];
 
   let datasets: ChartDataset<'bar'>[] = [];

--- a/src/components/pages/account/TotalLineChart.tsx
+++ b/src/components/pages/account/TotalLineChart.tsx
@@ -12,7 +12,7 @@ export type TotalLineChartProps = {
 export default function TotalLineChart({
   account,
 }: TotalLineChartProps): JSX.Element {
-  let { data: splits } = API.useSplits(account.guid);
+  let { data: splits } = API.useSplits({ guid: account.guid });
   splits = splits || [];
 
   let totalAggregate = 0;

--- a/src/components/pages/account/TransactionsTable.tsx
+++ b/src/components/pages/account/TransactionsTable.tsx
@@ -29,7 +29,7 @@ export default function TransactionsTable({
   account,
 }: TransactionsTableProps): JSX.Element {
   const { data } = API.useAccounts();
-  let { data: splits } = API.useSplits(account.guid);
+  let { data: splits } = API.useSplits({ guid: account.guid });
 
   const accounts = mapAccounts(data);
   splits = splits || [];

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -1,19 +1,13 @@
 import { DateTime } from 'luxon';
 import { SWRResponse } from 'swr';
 import useSWRImmutable from 'swr/immutable';
-import {
-  useQuery,
-  UseQueryResult,
-} from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import {
-  Commodity,
-  Price,
-  Split,
   Transaction,
 } from '@/book/entities';
 import * as queries from '@/lib/queries';
-import type { PriceDBMap } from '@/book/prices';
 import type { Account } from '@/book/entities';
 import { useAccounts } from './useAccounts';
 import fetcher from './fetcher';
@@ -21,25 +15,14 @@ import fetcher from './fetcher';
 export { useAccount, useAccounts } from '@/hooks/api/useAccounts';
 export { useCommodity, useCommodities } from '@/hooks/api/useCommodities';
 export { useInvestment, useInvestments } from '@/hooks/api/useInvestments';
-
-export function useSplits(guid: string): UseQueryResult<Split[]> {
-  return useQuery({
-    queryKey: [Split.CACHE_KEY, { account: guid }],
-    queryFn: fetcher(() => queries.getSplits(guid), `${Split.CACHE_KEY}/${guid}`),
-  });
-}
+export { useSplits } from '@/hooks/api/useSplits';
+export { usePrices } from '@/hooks/api/usePrices';
+export { useMainCurrency } from '@/hooks/api/useMainCurrency';
 
 export function useStartDate(): UseQueryResult<DateTime> {
   return useQuery({
     queryKey: [Transaction.CACHE_KEY, { name: 'start' }],
     queryFn: fetcher(queries.getEarliestDate, `${Transaction.CACHE_KEY}/start`),
-  });
-}
-
-export function useMainCurrency(): UseQueryResult<Commodity> {
-  return useQuery({
-    queryKey: [Commodity.CACHE_KEY, { guid: 'main' }],
-    queryFn: fetcher(queries.getMainCurrency, `${Commodity.CACHE_KEY}/main`),
   });
 }
 
@@ -67,14 +50,4 @@ export function useAccountsMonthlyTotals(): SWRResponse<queries.MonthlyTotals> {
   );
 
   return result;
-}
-
-/**
- * Returns prices for a given commodity
- */
-export function usePrices(c: Commodity | undefined): UseQueryResult<PriceDBMap> {
-  return useQuery({
-    queryKey: [Price.CACHE_KEY, { commodity: c?.guid }],
-    queryFn: fetcher(() => queries.getPrices({ from: c }), `${Price.CACHE_KEY}/${c?.guid}`),
-  });
 }

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { mutate, SWRResponse } from 'swr';
+import { SWRResponse } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 import {
   useQuery,
@@ -12,7 +12,6 @@ import {
   Split,
   Transaction,
 } from '@/book/entities';
-import { InvestmentAccount } from '@/book/models';
 import * as queries from '@/lib/queries';
 import type { PriceDBMap } from '@/book/prices';
 import type { Account } from '@/book/entities';
@@ -21,6 +20,7 @@ import fetcher from './fetcher';
 
 export { useAccount, useAccounts } from '@/hooks/api/useAccounts';
 export { useCommodity, useCommodities } from '@/hooks/api/useCommodities';
+export { useInvestment, useInvestments } from '@/hooks/api/useInvestments';
 
 export function useSplits(guid: string): UseQueryResult<Split[]> {
   return useQuery({
@@ -65,46 +65,6 @@ export function useAccountsMonthlyTotals(): SWRResponse<queries.MonthlyTotals> {
       key,
     ),
   );
-
-  return result;
-}
-
-export function useInvestment(guid: string): SWRResponse<InvestmentAccount> {
-  const key = `/api/investments/${guid}`;
-
-  const result = useSWRImmutable(
-    key,
-    fetcher(() => queries.getInvestment(guid), key),
-  );
-
-  if (result.error) {
-    throw new Error(result.error);
-  }
-
-  return result;
-}
-
-export function useInvestments(): SWRResponse<InvestmentAccount[]> {
-  const key = '/api/investments';
-
-  const result = useSWRImmutable(
-    key,
-    fetcher(() => queries.getInvestments(), key),
-  );
-
-  if (result.error) {
-    throw new Error(result.error);
-  }
-
-  if (result.data) {
-    result.data.forEach(
-      (investment: InvestmentAccount) => mutate(
-        `/api/investments/${investment.account.guid}`,
-        investment,
-        { revalidate: false },
-      ),
-    );
-  }
 
   return result;
 }

--- a/src/hooks/api/useInvestments.ts
+++ b/src/hooks/api/useInvestments.ts
@@ -1,0 +1,26 @@
+import {
+  useQuery,
+  UseQueryResult,
+} from '@tanstack/react-query';
+
+import { InvestmentAccount } from '@/book/models';
+import { getInvestment, getInvestments } from '@/lib/queries';
+import fetcher from './fetcher';
+
+export function useInvestment(guid: string): UseQueryResult<InvestmentAccount> {
+  const result = useQuery({
+    queryKey: [InvestmentAccount.CACHE_KEY, { guid }],
+    queryFn: fetcher(() => getInvestment(guid), `${InvestmentAccount.CACHE_KEY}/${guid}`),
+  });
+
+  return result;
+}
+
+export function useInvestments(): UseQueryResult<InvestmentAccount[]> {
+  const result = useQuery({
+    queryKey: [InvestmentAccount.CACHE_KEY],
+    queryFn: fetcher(getInvestments, InvestmentAccount.CACHE_KEY),
+  });
+
+  return result;
+}

--- a/src/hooks/api/useInvestments.ts
+++ b/src/hooks/api/useInvestments.ts
@@ -1,26 +1,115 @@
 import {
+  keepPreviousData,
   useQuery,
+  useQueryClient,
   UseQueryResult,
 } from '@tanstack/react-query';
 
 import { InvestmentAccount } from '@/book/models';
-import { getInvestment, getInvestments } from '@/lib/queries';
+import { getInvestments, initInvestment } from '@/lib/queries/getInvestments';
+import {
+  Account,
+  Commodity,
+  Split,
+} from '@/book/entities';
 import fetcher from './fetcher';
+import { useAccount, useAccounts } from './useAccounts';
+import { useSplits } from './useSplits';
+import { useMainCurrency } from './useMainCurrency';
 
+/**
+ * This hook creates an Investment account for a given account. It depends on other
+ * data like:
+ *
+ * - The specific account
+ * - The splits for that account
+ * - The main currency
+ *
+ * When all those dependencies are loaded, the investment is created and set under a key
+ * containing the guid of the account and a variable number that accumulates data it
+ * depends on so it gets updated when it changes.
+ *
+ * Other than creating the investment, it also modifies the list key /api/investments
+ * so it updates with the added/updated investment.
+ */
 export function useInvestment(guid: string): UseQueryResult<InvestmentAccount> {
+  const queryClient = useQueryClient();
+  const { data: account, dataUpdatedAt: accountUpdatedAt } = useAccount(guid);
+  const { data: splits, dataUpdatedAt: splitsUpdatedAt } = useSplits({ guid });
+  const { data: mainCurrency, dataUpdatedAt: currencyUpdatedAt } = useMainCurrency();
+
   const result = useQuery({
-    queryKey: [InvestmentAccount.CACHE_KEY, { guid }],
-    queryFn: fetcher(() => getInvestment(guid), `${InvestmentAccount.CACHE_KEY}/${guid}`),
+    queryKey: [
+      InvestmentAccount.CACHE_KEY,
+      {
+        account: guid,
+        accountUpdatedAt,
+        splitsUpdatedAt,
+        currencyUpdatedAt,
+      },
+    ],
+    queryFn: fetcher(
+      async () => {
+        const investment = await initInvestment(
+          account as Account,
+          mainCurrency as Commodity,
+          splits as Split[],
+        );
+        queryClient.setQueryData(
+          [InvestmentAccount.CACHE_KEY],
+          (entities: InvestmentAccount[]) => {
+            if (!entities) {
+              return undefined;
+            }
+
+            const newEntities = [...entities];
+
+            const index = entities.findIndex(e => e.account.guid === investment.account.guid);
+            if (index === -1) { // New entity added
+              newEntities.push(investment);
+            } else { // Entity updated
+              newEntities[index] = investment;
+            }
+
+            return newEntities;
+          },
+        );
+
+        return investment;
+      },
+      `${InvestmentAccount.CACHE_KEY}/${guid}`,
+    ),
+    enabled: !!account && !!splits && !!mainCurrency,
+    placeholderData: keepPreviousData,
   });
 
+  if (result.error) {
+    throw result.error;
+  }
   return result;
 }
 
 export function useInvestments(): UseQueryResult<InvestmentAccount[]> {
+  const { data: accounts } = useAccounts();
+  const { data: mainCurrency } = useMainCurrency();
+  const { data: splits } = useSplits({ type: 'INVESTMENT' });
+
   const result = useQuery({
     queryKey: [InvestmentAccount.CACHE_KEY],
-    queryFn: fetcher(getInvestments, InvestmentAccount.CACHE_KEY),
+    queryFn: fetcher(
+      () => getInvestments(
+        (accounts as Account[]).filter(a => a.type === 'INVESTMENT'),
+        mainCurrency as Commodity,
+        splits as Split[],
+      ),
+      InvestmentAccount.CACHE_KEY,
+    ),
+    enabled: !!accounts && !!splits && !!mainCurrency,
   });
+
+  if (result.error) {
+    throw result.error;
+  }
 
   return result;
 }

--- a/src/hooks/api/useMainCurrency.ts
+++ b/src/hooks/api/useMainCurrency.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import { Commodity } from '@/book/entities';
+import { getMainCurrency } from '@/lib/queries';
+import fetcher from './fetcher';
+
+export function useMainCurrency(): UseQueryResult<Commodity> {
+  return useQuery({
+    queryKey: [Commodity.CACHE_KEY, { guid: 'main' }],
+    queryFn: fetcher(getMainCurrency, `${Commodity.CACHE_KEY}/main`),
+  });
+}

--- a/src/hooks/api/usePrices.ts
+++ b/src/hooks/api/usePrices.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import { Price } from '@/book/entities';
+import { getPrices } from '@/lib/queries';
+import type { PriceDBMap } from '@/book/prices';
+import type { Commodity } from '@/book/entities';
+import fetcher from './fetcher';
+
+/**
+ * Returns prices for a given commodity
+ */
+export function usePrices(c: Commodity | undefined): UseQueryResult<PriceDBMap> {
+  return useQuery({
+    queryKey: [Price.CACHE_KEY, { commodity: c?.guid }],
+    queryFn: fetcher(() => getPrices({ from: c }), `${Price.CACHE_KEY}/${c?.guid}`),
+    enabled: !!c,
+  });
+}

--- a/src/hooks/api/useSplits.ts
+++ b/src/hooks/api/useSplits.ts
@@ -1,0 +1,34 @@
+import {
+  useQuery,
+  UseQueryResult,
+} from '@tanstack/react-query';
+import type { FindOptionsWhere } from 'typeorm';
+
+import { Split } from '@/book/entities';
+import type { Account } from '@/book/entities';
+import { getSplits } from '@/lib/queries';
+import fetcher from './fetcher';
+
+/**
+ * This query is mainly used for when we want to retrieve splits for a specific account
+ * so we display them
+ */
+export function useSplits(findOptions: FindOptionsWhere<Account>): UseQueryResult<Split[]> {
+  return useQuery({
+    queryKey: [Split.CACHE_KEY, findOptions],
+    queryFn: fetcher(
+      () => getSplits(
+        findOptions,
+        {
+          fk_transaction: {
+            splits: {
+              fk_account: true,
+            },
+          },
+          fk_account: true,
+        },
+      ),
+      `${Split.CACHE_KEY}/${JSON.stringify(findOptions)}`,
+    ),
+  });
+}

--- a/src/lib/queries/getSplits.ts
+++ b/src/lib/queries/getSplits.ts
@@ -1,4 +1,9 @@
-import { Split } from '@/book/entities';
+import type {
+  FindOptionsWhere,
+  FindOptionsRelations,
+} from 'typeorm';
+
+import { Account, Split } from '@/book/entities';
 
 /**
  * Returns splits associated to the received account
@@ -6,20 +11,18 @@ import { Split } from '@/book/entities';
  * The splits are ordered by transaction date and quantity. This is so it's
  * easy to display the splits as the account ledger.
  */
-export default async function getSplits(account: string): Promise<Split[]> {
+export default async function getSplits(
+  account: FindOptionsWhere<Account>,
+  relations?: FindOptionsRelations<Split>,
+): Promise<Split[]> {
   const splits = await Split.find({
     where: {
       fk_account: {
-        guid: account,
+        ...account,
       },
     },
     relations: {
-      fk_transaction: {
-        splits: {
-          fk_account: true,
-        },
-      },
-      fk_account: true,
+      ...relations,
     },
     order: {
       fk_transaction: {

--- a/src/lib/queries/index.ts
+++ b/src/lib/queries/index.ts
@@ -1,7 +1,5 @@
 export { default as getPrices } from './getPrices';
 
-export { getInvestments, getInvestment } from './getInvestments';
-
 export { default as getSplits } from './getSplits';
 export { default as getMonthlyTotals } from './getMonthlyTotals';
 export { default as getMainCurrency } from './getMainCurrency';


### PR DESCRIPTION
This one was a bit more complex compared to the previous ones as we've modified the current hook to make use of dependant data so whenever there are updates, the investment gets updated accordingly too.