### PR TITLE
Fix investment splits ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@fontsource/inter": "^5.0.16",
     "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.20.5",
-    "@tanstack/react-table": "^8.11.8",
+    "@tanstack/react-table": "^8.12.0",
     "@testing-library/jest-dom": "^6.4.2",
     "aws-amplify": "^5.3.12",
     "chart.js": "^4.4.1",

--- a/src/book/__tests__/models/InvestmentAccount.test.ts
+++ b/src/book/__tests__/models/InvestmentAccount.test.ts
@@ -352,6 +352,14 @@ describe('InvestmentAccount', () => {
               },
             },
           },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
+              },
+            },
+          },
         });
         const instance = new InvestmentAccount(
           account,
@@ -407,6 +415,14 @@ describe('InvestmentAccount', () => {
             splits: {
               fk_transaction: {
                 splits: true,
+              },
+            },
+          },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
               },
             },
           },
@@ -466,6 +482,14 @@ describe('InvestmentAccount', () => {
               },
             },
           },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
+              },
+            },
+          },
         });
         const instance = new InvestmentAccount(
           account,
@@ -513,6 +537,14 @@ describe('InvestmentAccount', () => {
             splits: {
               fk_transaction: {
                 splits: true,
+              },
+            },
+          },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
               },
             },
           },
@@ -571,6 +603,14 @@ describe('InvestmentAccount', () => {
               },
             },
           },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
+              },
+            },
+          },
         });
         const instance = new InvestmentAccount(
           account,
@@ -623,6 +663,14 @@ describe('InvestmentAccount', () => {
             splits: {
               fk_transaction: {
                 splits: true,
+              },
+            },
+          },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
               },
             },
           },
@@ -680,6 +728,14 @@ describe('InvestmentAccount', () => {
               },
             },
           },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
+              },
+            },
+          },
         });
         const instance = new InvestmentAccount(
           account,
@@ -732,6 +788,14 @@ describe('InvestmentAccount', () => {
               },
             },
           },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
+              },
+            },
+          },
         });
         const instance = new InvestmentAccount(
           account,
@@ -781,6 +845,14 @@ describe('InvestmentAccount', () => {
             splits: {
               fk_transaction: {
                 splits: true,
+              },
+            },
+          },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
               },
             },
           },
@@ -855,6 +927,14 @@ describe('InvestmentAccount', () => {
                 splits: {
                   fk_account: true,
                 },
+              },
+            },
+          },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
               },
             },
           },
@@ -947,6 +1027,14 @@ describe('InvestmentAccount', () => {
               },
             },
           },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
+              },
+            },
+          },
         });
         const instance = new InvestmentAccount(
           account,
@@ -976,6 +1064,14 @@ describe('InvestmentAccount', () => {
                 splits: {
                   fk_account: true,
                 },
+              },
+            },
+          },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
               },
             },
           },
@@ -1011,6 +1107,14 @@ describe('InvestmentAccount', () => {
                 splits: {
                   fk_account: true,
                 },
+              },
+            },
+          },
+          order: {
+            splits: {
+              fk_transaction: {
+                date: 'DESC',
+                enterDate: 'DESC',
               },
             },
           },
@@ -1053,6 +1157,14 @@ describe('InvestmentAccount', () => {
           splits: {
             fk_transaction: {
               splits: true,
+            },
+          },
+        },
+        order: {
+          splits: {
+            fk_transaction: {
+              date: 'DESC',
+              enterDate: 'DESC',
             },
           },
         },

--- a/src/book/models/InvestmentAccount.ts
+++ b/src/book/models/InvestmentAccount.ts
@@ -161,7 +161,7 @@ export default class InvestmentAccount {
     this.realizedProfit = new Money(0, this.currency);
     this.dividends.splice(0, this.dividends.length);
 
-    this.splits.filter(
+    this.splits.reverse().filter(
       split => split.transaction.date <= (date || DateTime.now()),
     ).forEach((split) => {
       const numSplits = split.transaction.splits.length;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,17 +4171,17 @@
   dependencies:
     "@tanstack/query-core" "5.20.5"
 
-"@tanstack/react-table@^8.11.8":
-  version "8.11.8"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.11.8.tgz#4eef4a2d91116ca51c8c9b2f00b455d8d99886c7"
-  integrity sha512-NEwvIq4iSiDQozEyvbdiSdCOiLa+g5xHmdEnvwDb98FObcK6YkBOkRrs/CNqrKdDy+/lqoIllIWHk+M80GW6+g==
+"@tanstack/react-table@^8.12.0":
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.12.0.tgz#069210657f9f6c6c17584cc955a8ebb25b8642f8"
+  integrity sha512-LlEQ1Gpz4bfpiET+qmle4BhKDgKN3Y/sssc+O/wLqX8HRtjV+nhusYbllZlutZfMR8oeef83whKTj/VhaV8EeA==
   dependencies:
-    "@tanstack/table-core" "8.11.8"
+    "@tanstack/table-core" "8.12.0"
 
-"@tanstack/table-core@8.11.8":
-  version "8.11.8"
-  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.11.8.tgz#7f46c31894249dbb57e43ad95c80e891236a895f"
-  integrity sha512-DECHvtq4YW4U/gqg6etup7ydt/RB1Bi1pJaMpHUXl65ooW1d71Nv7BzD66rUdHrBSNdyiW3PLTPUQlpXjAgDeA==
+"@tanstack/table-core@8.12.0":
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.12.0.tgz#ada34e17ca761fed99353b48e8cb7deacc971025"
+  integrity sha512-cq/ylWVrOwixmwNXQjgZaQw1Izf7+nPxjczum7paAnMtwPg1S2qRAJU+Jb8rEBUWm69voC/zcChmePlk2hc6ug==
 
 "@testing-library/dom@^9.0.0":
   version "9.2.0"


### PR DESCRIPTION
We changed the ordering of the splits and didn't reflect as expected in `InvestmentAccount` which caused errors for stocks that had Sell operations. This fixes it.