### PR TITLE
Move monthly totals to query

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@fontsource/inter": "^5.0.16",
     "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.20.5",
+    "@tanstack/react-query-devtools": "^5.20.5",
     "@tanstack/react-table": "^8.12.0",
     "@testing-library/jest-dom": "^6.4.2",
     "aws-amplify": "^5.3.12",

--- a/src/__tests__/components/forms/account/AccountForm.test.tsx
+++ b/src/__tests__/components/forms/account/AccountForm.test.tsx
@@ -7,7 +7,6 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DataSource } from 'typeorm';
-import * as swr from 'swr';
 import * as navigation from 'next/navigation';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -23,10 +22,7 @@ import {
 import AccountForm from '@/components/forms/account/AccountForm';
 import * as apiHook from '@/hooks/api';
 
-jest.mock('swr');
-
 jest.mock('next/navigation');
-
 jest.mock('@/hooks/api', () => ({
   __esModule: true,
   ...jest.requireActual('@/hooks/api'),
@@ -419,8 +415,6 @@ describe('AccountForm', () => {
         valueNum: -10001,
       },
     ]);
-
-    expect(swr.mutate).toBeCalledWith('/api/monthly-totals', undefined);
   });
 
   it.each([

--- a/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
+++ b/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
@@ -7,7 +7,6 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DataSource, IsNull } from 'typeorm';
-import * as swr from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import {
@@ -21,8 +20,6 @@ import TransactionForm from '@/components/forms/transaction/TransactionForm';
 import * as queries from '@/lib/queries';
 import * as apiHook from '@/hooks/api';
 import { PriceDBMap } from '@/book/prices';
-
-jest.mock('swr');
 
 jest.mock('@/lib/queries', () => ({
   __esModule: true,
@@ -273,8 +270,6 @@ describe('TransactionForm', () => {
       });
       expect(tx.guid.length).toEqual(31);
       expect(mockSave).toHaveBeenCalledTimes(1);
-      expect(swr.mutate).toBeCalledTimes(1);
-      expect(swr.mutate).toHaveBeenNthCalledWith(1, '/api/monthly-totals', undefined);
     });
   });
 
@@ -1236,9 +1231,6 @@ describe('TransactionForm', () => {
 
     expect(screen.getByText('add')).toBeEnabled();
     await user.click(screen.getByText('add'));
-
-    expect(swr.mutate).toBeCalledTimes(1);
-    expect(swr.mutate).toHaveBeenNthCalledWith(1, '/api/monthly-totals', undefined);
   });
 
   describe('actions', () => {

--- a/src/__tests__/components/pages/accounts/AccountsTable.test.tsx
+++ b/src/__tests__/components/pages/accounts/AccountsTable.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { DateTime } from 'luxon';
-import type { SWRResponse } from 'swr';
 import { UseQueryResult } from '@tanstack/react-query';
 
 import { AccountsTable } from '@/components/pages/accounts';
@@ -9,6 +8,7 @@ import Table from '@/components/Table';
 import { Account } from '@/book/entities';
 import Money from '@/book/Money';
 import * as apiHook from '@/hooks/api';
+import type { MonthlyTotals } from '@/lib/queries';
 
 jest.mock('@/components/Table', () => jest.fn(
   () => <div data-testid="Table" />,
@@ -24,7 +24,7 @@ describe('AccountsTable', () => {
   beforeEach(() => {
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-01') as DateTime<true>);
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<MonthlyTotals>);
   });
 
   afterEach(() => {
@@ -104,7 +104,7 @@ describe('AccountsTable', () => {
         ] as Account[],
       } as UseQueryResult<Account[]>,
     );
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           a1: {
@@ -114,8 +114,8 @@ describe('AccountsTable', () => {
           a2: {
             '01/2023': new Money(-100, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(<AccountsTable />);
@@ -189,7 +189,7 @@ describe('AccountsTable', () => {
         ] as Account[],
       } as UseQueryResult<Account[]>,
     );
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           a1: {
@@ -197,8 +197,8 @@ describe('AccountsTable', () => {
             '01/2023': new Money(100, 'EUR'),
             '02/2023': new Money(100, 'EUR'), // will be ignored
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(<AccountsTable />);

--- a/src/__tests__/components/pages/accounts/IncomeExpenseHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/IncomeExpenseHistogram.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DateTime } from 'luxon';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import Money from '@/book/Money';
@@ -9,6 +8,7 @@ import Bar from '@/components/charts/Bar';
 import IncomeExpenseHistogram from '@/components/pages/accounts/IncomeExpenseHistogram';
 import * as apiHook from '@/hooks/api';
 import type { Commodity } from '@/book/entities';
+import type { MonthlyTotals } from '@/lib/queries';
 
 jest.mock('@/components/charts/Bar', () => jest.fn(
   () => <div data-testid="Bar" />,
@@ -22,7 +22,7 @@ jest.mock('@/hooks/api', () => ({
 describe('IncomeExpenseHistogram', () => {
   beforeEach(() => {
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-02') as DateTime<true>);
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<MonthlyTotals>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
   });
 
@@ -167,7 +167,7 @@ describe('IncomeExpenseHistogram', () => {
   });
 
   it('generates datasets as expected', () => {
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           income: {
@@ -178,8 +178,8 @@ describe('IncomeExpenseHistogram', () => {
             '11/2022': new Money(400, 'EUR'),
             '12/2022': new Money(500, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(

--- a/src/__tests__/components/pages/accounts/MonthlyTotalHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/MonthlyTotalHistogram.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DateTime } from 'luxon';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import Money from '@/book/Money';
@@ -9,6 +8,7 @@ import { Account, Commodity } from '@/book/entities';
 import Bar from '@/components/charts/Bar';
 import { MonthlyTotalHistogram } from '@/components/pages/accounts';
 import * as apiHook from '@/hooks/api';
+import type { MonthlyTotals } from '@/lib/queries';
 
 jest.mock('@/components/charts/Bar', () => jest.fn(
   () => <div data-testid="Bar" />,
@@ -25,7 +25,7 @@ describe('MonthlyTotalHistogram', () => {
   beforeEach(() => {
     jest.spyOn(DateTime, 'now').mockReturnValue(now);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<MonthlyTotals>);
   });
 
   afterEach(() => {
@@ -133,15 +133,15 @@ describe('MonthlyTotalHistogram', () => {
     undefined,
     now.minus({ months: 3 }),
   ])('selects default date now - 9 months', (date) => {
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           salary: {
             '11/2022': new Money(-1000, 'EUR'),
             '12/2022': new Money(-1000, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(
@@ -180,15 +180,15 @@ describe('MonthlyTotalHistogram', () => {
   });
 
   it('selects date range of 9 months in the past', () => {
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           salary: {
             '11/2021': new Money(-1000, 'EUR'),
             '12/2021': new Money(-1000, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     const selectedDate = now.minus({ years: 1 });
@@ -228,7 +228,7 @@ describe('MonthlyTotalHistogram', () => {
   });
 
   it('generates data as expected', () => {
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           salary: {
@@ -239,8 +239,8 @@ describe('MonthlyTotalHistogram', () => {
             '11/2022': new Money(-150, 'EUR'),
             '12/2022': new Money(-50, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(

--- a/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthHistogram.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DateTime } from 'luxon';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import Money from '@/book/Money';
@@ -9,6 +8,7 @@ import Bar from '@/components/charts/Bar';
 import NetWorthHistogram from '@/components/pages/accounts/NetWorthHistogram';
 import * as apiHook from '@/hooks/api';
 import type { Commodity } from '@/book/entities';
+import type { MonthlyTotals } from '@/lib/queries';
 
 jest.mock('@/components/charts/Bar', () => jest.fn(
   () => <div data-testid="Bar" />,
@@ -22,7 +22,7 @@ jest.mock('@/hooks/api', () => ({
 describe('NetWorthHistogram', () => {
   beforeEach(() => {
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-02') as DateTime<true>);
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<MonthlyTotals>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
   });
 
@@ -153,7 +153,7 @@ describe('NetWorthHistogram', () => {
   });
 
   it('generates datasets as expected', () => {
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           asset: {
@@ -166,8 +166,8 @@ describe('NetWorthHistogram', () => {
             '12/2022': new Money(-200, 'EUR'),
             '01/2023': new Money(-200, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(

--- a/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DateTime } from 'luxon';
-import type { SWRResponse } from 'swr';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import Money from '@/book/Money';
@@ -9,6 +8,7 @@ import Pie from '@/components/charts/Pie';
 import { NetWorthPie } from '@/components/pages/accounts';
 import * as apiHook from '@/hooks/api';
 import type { Commodity } from '@/book/entities';
+import type { MonthlyTotals } from '@/lib/queries';
 
 jest.mock('@/components/charts/Pie', () => jest.fn(
   () => <div data-testid="Pie" />,
@@ -22,7 +22,7 @@ jest.mock('@/hooks/api', () => ({
 describe('NetWorthPie', () => {
   beforeEach(() => {
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue({ data: undefined } as SWRResponse);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<MonthlyTotals>);
   });
 
   afterEach(() => {
@@ -72,7 +72,7 @@ describe('NetWorthPie', () => {
 
   it('shows net worth as expected', () => {
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-02-20') as DateTime<true>);
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           asset: {
@@ -83,8 +83,8 @@ describe('NetWorthPie', () => {
             '01/2023': new Money(-50, 'EUR'),
             '02/2023': new Money(-100, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(<NetWorthPie />);
@@ -106,15 +106,15 @@ describe('NetWorthPie', () => {
   });
 
   it('shows net worth when no liabilities', () => {
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           asset: {
             '01/2023': new Money(500, 'EUR'),
             '02/2023': new Money(1000, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(<NetWorthPie />);
@@ -136,7 +136,7 @@ describe('NetWorthPie', () => {
   });
 
   it('filters by selected date', () => {
-    jest.spyOn(apiHook, 'useAccountsMonthlyTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
       {
         data: {
           asset: {
@@ -147,8 +147,8 @@ describe('NetWorthPie', () => {
             '01/2023': new Money(-50, 'EUR'),
             '02/2023': new Money(-100, 'EUR'),
           },
-        },
-      } as SWRResponse,
+        } as MonthlyTotals,
+      } as UseQueryResult<MonthlyTotals>,
     );
 
     render(

--- a/src/__tests__/hooks/api.test.tsx
+++ b/src/__tests__/hooks/api.test.tsx
@@ -4,15 +4,11 @@ import * as query from '@tanstack/react-query';
 import { BareFetcher, SWRResponse } from 'swr';
 
 import { Commodity } from '@/book/entities';
-import { PriceDBMap } from '@/book/prices';
 import * as API from '@/hooks/api';
 import * as queries from '@/lib/queries';
-import { AccountsMap } from '@/types/book';
 
 jest.mock('swr');
-
 jest.mock('@tanstack/react-query');
-
 jest.mock('@/lib/queries');
 
 jest.mock('@/book/prices', () => ({
@@ -76,25 +72,6 @@ describe('API', () => {
       const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
       callArgs.queryFn();
       expect(queries.getLatestTxs).toBeCalled();
-    });
-  });
-
-  describe('useAccountsMonthlyTotals', () => {
-    it('calls useSWRImmutable with expected params for useAccountsMonthlyTotals', () => {
-      const accounts = { a: { guid: 'a' } } as AccountsMap;
-      const todayPrices = new PriceDBMap();
-      jest.spyOn(query, 'useQuery')
-        .mockReturnValueOnce({ data: accounts } as query.UseQueryResult<AccountsMap>);
-      jest.spyOn(swrImmutable, 'default')
-        .mockReturnValueOnce({ data: todayPrices } as SWRResponse);
-      renderHook(() => API.useAccountsMonthlyTotals());
-
-      expect(swrImmutable.default).toHaveBeenNthCalledWith(
-        2,
-        '/api/monthly-totals',
-        expect.any(Function),
-      );
-      expect(queries.getMonthlyTotals).toBeCalledWith(accounts, todayPrices);
     });
   });
 });

--- a/src/__tests__/hooks/api/useAccountsTotals.test.tsx
+++ b/src/__tests__/hooks/api/useAccountsTotals.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook } from '@testing-library/react';
+import * as query from '@tanstack/react-query';
+
+import * as useAccountsHook from '@/hooks/api/useAccounts';
+import * as usePricesHook from '@/hooks/api/usePrices';
+import { useAccountsTotals } from '@/hooks/api';
+import { Account } from '@/book/entities';
+import * as queries from '@/lib/queries/getMonthlyTotals';
+import type { PriceDBMap } from '@/book/prices';
+
+jest.mock('@tanstack/react-query');
+jest.mock('@/lib/queries/getMonthlyTotals');
+jest.mock('@/hooks/api/useAccounts');
+jest.mock('@/hooks/api/usePrices');
+
+describe('useAccount', () => {
+  let account: Account;
+
+  beforeEach(() => {
+    account = {
+      guid: 'guid',
+    } as Account;
+    // @ts-ignore
+    jest.spyOn(Account, 'findOneBy').mockResolvedValue(account);
+
+    jest.spyOn(useAccountsHook, 'useAccounts').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<Account[]>);
+    jest.spyOn(usePricesHook, 'usePrices').mockReturnValue({
+      data: undefined,
+    } as query.UseQueryResult<PriceDBMap>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls query with enabled false when no accounts', async () => {
+    jest.spyOn(usePricesHook, 'usePrices').mockReturnValue({
+      data: {} as PriceDBMap,
+    } as query.UseQueryResult<PriceDBMap>);
+
+    renderHook(() => useAccountsTotals());
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query with enabled false when no prices', async () => {
+    jest.spyOn(useAccountsHook, 'useAccounts').mockReturnValue({
+      data: [] as Account[],
+    } as query.UseQueryResult<Account[]>);
+
+    renderHook(() => useAccountsTotals());
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('calls query as expected', async () => {
+    jest.spyOn(useAccountsHook, 'useAccounts').mockReturnValue({
+      data: [] as Account[],
+      dataUpdatedAt: 1,
+    } as query.UseQueryResult<Account[]>);
+    jest.spyOn(usePricesHook, 'usePrices').mockReturnValue({
+      data: {} as PriceDBMap,
+      dataUpdatedAt: 2,
+    } as query.UseQueryResult<PriceDBMap>);
+    renderHook(() => useAccountsTotals());
+
+    expect(query.useQuery).toBeCalledWith({
+      queryKey: [
+        '/api/aggregations/accounts/totals',
+        {
+          accountsUpdatedAt: 1,
+          pricesUpdatedAt: 2,
+        },
+      ],
+      queryFn: expect.any(Function),
+      enabled: true,
+    });
+
+    const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+    callArgs.queryFn();
+    expect(queries.default).toBeCalledWith([], {});
+  });
+});

--- a/src/__tests__/hooks/api/usePrices.test.ts
+++ b/src/__tests__/hooks/api/usePrices.test.ts
@@ -9,11 +9,15 @@ jest.mock('@tanstack/react-query');
 jest.mock('@/lib/queries');
 
 describe('usePrices', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('calls query as expected', async () => {
-    renderHook(() => usePrices({ guid: 'guid' } as Commodity));
+    renderHook(() => usePrices({ from: { guid: 'guid' } as Commodity }));
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/prices', { commodity: 'guid' }],
+      queryKey: ['/api/prices', { from: 'guid' }],
       queryFn: expect.any(Function),
       enabled: true,
     });
@@ -21,5 +25,45 @@ describe('usePrices', () => {
     const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
     callArgs.queryFn();
     expect(queries.getPrices).toBeCalledWith({ from: { guid: 'guid' } });
+  });
+
+  it('calls query as expected with from and to', async () => {
+    renderHook(() => usePrices({
+      from: { guid: 'guid' } as Commodity,
+      to: { guid: 'to' } as Commodity,
+    }));
+
+    expect(query.useQuery).toBeCalledWith({
+      queryKey: ['/api/prices', { from: 'guid', to: 'to' }],
+      queryFn: expect.any(Function),
+      enabled: true,
+    });
+
+    const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];
+    callArgs.queryFn();
+    expect(queries.getPrices).toBeCalledWith({
+      from: { guid: 'guid' },
+      to: { guid: 'to' },
+    });
+  });
+
+  /**
+   * If we explicitly pass from and the value is undefined, it means the value
+   * has not been loaded yet so we disable the query until it has a value
+   */
+  it('call is disabled if from passed with undefined', async () => {
+    renderHook(() => usePrices({ from: undefined }));
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+  });
+
+  it('call is disabled if to passed with undefined', async () => {
+    renderHook(() => usePrices({ to: undefined }));
+
+    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
   });
 });

--- a/src/app/dashboard/commodities/[guid]/page.tsx
+++ b/src/app/dashboard/commodities/[guid]/page.tsx
@@ -20,7 +20,7 @@ export type CommodityPageProps = {
 
 export default function CommodityPage({ params }: CommodityPageProps): JSX.Element {
   const { data: commodity, isLoading } = useCommodity(params.guid);
-  const { data: prices } = usePrices(commodity);
+  const { data: prices } = usePrices({ from: commodity });
 
   if (isLoading) {
     return (

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Modal from 'react-modal';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import Footer from '@/layout/Footer';
 import LeftSidebar from '@/layout/LeftSidebar';
@@ -51,6 +52,7 @@ export default function DashboardLayout({
       <LeftSidebar />
       <div className="mt-20 ml-20 p-3 pb-7">
         <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtools initialIsOpen={false} />
           <DashboardPage>
             {children}
           </DashboardPage>

--- a/src/book/__tests__/entities/Price.test.ts
+++ b/src/book/__tests__/entities/Price.test.ts
@@ -158,7 +158,7 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(1);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { commodity: 'ticker' }],
+      queryKey: ['/api/prices', { from: 'ticker' }],
       refetchType: 'all',
     });
     expect(Price.upsert).toBeCalledWith(
@@ -183,11 +183,11 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(2);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { commodity: 'eur' }],
+      queryKey: ['/api/prices', { from: 'eur' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { commodity: 'usd' }],
+      queryKey: ['/api/prices', { from: 'usd' }],
       refetchType: 'all',
     });
   });
@@ -203,7 +203,7 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(1);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { commodity: 'ticker' }],
+      queryKey: ['/api/prices', { from: 'ticker' }],
       refetchType: 'all',
     });
   });

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -286,7 +286,7 @@ describe('caching', () => {
 
     await tx.save();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(4);
+    expect(mockInvalidateQueries).toBeCalledTimes(5);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['/api/txs', { name: 'latest' }],
       refetchType: 'all',
@@ -301,6 +301,10 @@ describe('caching', () => {
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['/api/splits', { guid: '2' }],
+      refetchType: 'all',
+    });
+    expect(mockInvalidateQueries).toBeCalledWith({
+      queryKey: ['/api/aggregations/accounts/totals'],
       refetchType: 'all',
     });
   });
@@ -318,7 +322,7 @@ describe('caching', () => {
 
     await tx.remove();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(4);
+    expect(mockInvalidateQueries).toBeCalledTimes(5);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['/api/txs', { name: 'latest' }],
       refetchType: 'all',
@@ -333,6 +337,10 @@ describe('caching', () => {
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['/api/splits', { guid: '2' }],
+      refetchType: 'all',
+    });
+    expect(mockInvalidateQueries).toBeCalledWith({
+      queryKey: ['/api/aggregations/accounts/totals'],
       refetchType: 'all',
     });
   });

--- a/src/book/entities/Price.ts
+++ b/src/book/entities/Price.ts
@@ -146,13 +146,13 @@ export async function updateCache(
   },
 ) {
   queryClient.invalidateQueries({
-    queryKey: [Price.CACHE_KEY, { commodity: (entity.fk_commodity as Commodity).guid }],
+    queryKey: [Price.CACHE_KEY, { from: (entity.fk_commodity as Commodity).guid }],
     refetchType: 'all',
   });
 
   if ((entity.fk_commodity as Commodity).namespace === 'CURRENCY') {
     queryClient.invalidateQueries({
-      queryKey: [Price.CACHE_KEY, { commodity: (entity.fk_currency as Commodity).guid }],
+      queryKey: [Price.CACHE_KEY, { from: (entity.fk_currency as Commodity).guid }],
       refetchType: 'all',
     });
   }

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -130,6 +130,11 @@ export async function updateCache(
       refetchType: 'all',
     });
   });
+
+  queryClient.invalidateQueries({
+    queryKey: ['/api/aggregations/accounts/totals'],
+    refetchType: 'all',
+  });
 }
 
 // https://github.com/typeorm/typeorm/issues/4714

--- a/src/components/forms/account/AccountForm.tsx
+++ b/src/components/forms/account/AccountForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';
 import { DateTime } from 'luxon';
-import { mutate } from 'swr';
 import classNames from 'classnames';
 
 import {
@@ -354,6 +353,4 @@ async function createBalance(
     ],
     date: data.balanceDate ? DateTime.fromISO(data.balanceDate as string) : DateTime.now(),
   }).save();
-
-  mutate('/api/monthly-totals', undefined);
 }

--- a/src/components/forms/transaction/MainSplit.tsx
+++ b/src/components/forms/transaction/MainSplit.tsx
@@ -26,7 +26,7 @@ export default function MainSplit({
   const date = form.watch('date');
   const txCurrency = form.watch('fk_currency');
   const quantity = form.watch('splits.0.quantity');
-  const { data: prices } = usePrices(account?.commodity);
+  const { data: prices } = usePrices({ from: account?.commodity });
   const [exchangeRate, setExchangeRate] = React.useState(
     Price.create({ valueNum: 1, valueDenom: 1, fk_currency: txCurrency }),
   );

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -27,7 +27,7 @@ export default function SplitField({
   const account = form.watch(`splits.${index}.fk_account`) as Account;
   const txCurrency = form.watch('fk_currency');
   const date = form.watch('date');
-  const { data: prices } = usePrices(account?.commodity);
+  const { data: prices } = usePrices({ from: account?.commodity });
   const [exchangeRate, setExchangeRate] = React.useState(
     Price.create({ valueNum: 1, valueDenom: 1, fk_currency: txCurrency }),
   );

--- a/src/components/forms/transaction/TransactionForm.tsx
+++ b/src/components/forms/transaction/TransactionForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { DateTime } from 'luxon';
 import { useForm } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';
-import { mutate } from 'swr';
 import { IsNull } from 'typeorm';
 import { Tooltip } from 'react-tooltip';
 import classNames from 'classnames';
@@ -148,6 +147,5 @@ async function onSubmit(data: FormValues, action: 'add' | 'update' | 'delete', o
     await transaction.remove();
   }
 
-  mutate('/api/monthly-totals', undefined);
   onSave();
 }

--- a/src/components/pages/account/InvestmentChart.tsx
+++ b/src/components/pages/account/InvestmentChart.tsx
@@ -19,7 +19,7 @@ export default function InvestmentChart({
   account,
 }: InvestmentChartProps): JSX.Element {
   const { data: investment } = useInvestment(account.guid);
-  const { data: pricesMap } = usePrices(account.commodity);
+  const { data: pricesMap } = usePrices({ from: account.commodity });
 
   if (!investment || !pricesMap) {
     return <Loading />;

--- a/src/components/pages/account/InvestmentInfo.tsx
+++ b/src/components/pages/account/InvestmentInfo.tsx
@@ -17,7 +17,7 @@ export default function InvestmentInfo({
   account,
 }: InvestmentInfoProps): JSX.Element {
   const { data: investment } = useInvestment(account.guid);
-  let { data: prices } = usePrices(account.commodity);
+  let { data: prices } = usePrices({ from: account.commodity });
 
   if (!investment || !prices) {
     return <Loading />;

--- a/src/components/pages/accounts/AccountsTable.tsx
+++ b/src/components/pages/accounts/AccountsTable.tsx
@@ -16,7 +16,7 @@ import {
   isAsset,
   isLiability,
 } from '@/book/helpers/accountType';
-import * as API from '@/hooks/api';
+import { useAccountsTotals, useAccounts } from '@/hooks/api';
 import mapAccounts from '@/helpers/mapAccounts';
 
 export type AccountsTableProps = {
@@ -36,8 +36,8 @@ export default function AccountsTable(
     isExpanded = false,
   }: AccountsTableProps,
 ): JSX.Element {
-  const { data } = API.useAccounts();
-  const { data: monthlyTotals } = API.useAccountsMonthlyTotals();
+  const { data } = useAccounts();
+  const { data: monthlyTotals } = useAccountsTotals();
 
   const accounts = mapAccounts(data);
   const tree = getTreeTotals(accounts.type_root, accounts, monthlyTotals || {}, selectedDate);

--- a/src/components/pages/accounts/IncomeExpenseHistogram.tsx
+++ b/src/components/pages/accounts/IncomeExpenseHistogram.tsx
@@ -6,7 +6,7 @@ import zoomPlugin from 'chartjs-plugin-zoom';
 
 import Bar from '@/components/charts/Bar';
 import { moneyToString } from '@/helpers/number';
-import * as API from '@/hooks/api';
+import { useAccountsTotals, useMainCurrency } from '@/hooks/api';
 
 export type IncomeExpenseHistogramProps = {
   startDate?: DateTime,
@@ -21,11 +21,11 @@ export default function IncomeExpenseHistogram({
   startDate,
   selectedDate = DateTime.now().minus({ months: 3 }),
 }: IncomeExpenseHistogramProps): JSX.Element {
-  const { data: monthlyTotals } = API.useAccountsMonthlyTotals();
+  const { data: monthlyTotals } = useAccountsTotals();
   const incomeSeries = monthlyTotals?.income;
   const expenseSeries = monthlyTotals?.expense;
 
-  const { data: currency } = API.useMainCurrency();
+  const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
   const now = DateTime.now();

--- a/src/components/pages/accounts/MonthlyTotalHistogram.tsx
+++ b/src/components/pages/accounts/MonthlyTotalHistogram.tsx
@@ -4,7 +4,7 @@ import type { ChartDataset } from 'chart.js';
 
 import Bar from '@/components/charts/Bar';
 import type { Account } from '@/book/entities';
-import * as API from '@/hooks/api';
+import { useAccountsTotals, useMainCurrency } from '@/hooks/api';
 import { moneyToString } from '@/helpers/number';
 
 export type MonthlyTotalHistogramProps = {
@@ -18,10 +18,10 @@ export default function MonthlyTotalHistogram({
   selectedDate = DateTime.now().minus({ months: 4 }),
   accounts = [],
 }: MonthlyTotalHistogramProps): JSX.Element {
-  const { data: monthlyTotals } = API.useAccountsMonthlyTotals();
+  const { data: monthlyTotals } = useAccountsTotals();
   const now = DateTime.now();
 
-  const { data: currency } = API.useMainCurrency();
+  const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
   if (now.diff(selectedDate, ['months']).months < 4) {

--- a/src/components/pages/accounts/NetWorthHistogram.tsx
+++ b/src/components/pages/accounts/NetWorthHistogram.tsx
@@ -10,7 +10,7 @@ import zoomPlugin from 'chartjs-plugin-zoom';
 
 import Bar from '@/components/charts/Bar';
 import { moneyToString } from '@/helpers/number';
-import * as API from '@/hooks/api';
+import { useAccountsTotals, useMainCurrency } from '@/hooks/api';
 
 // We are using Bar chart here but one of the axis uses Line so
 // we have to register here or otherwise we get an error.
@@ -30,11 +30,11 @@ export default function NetWorthHistogram({
   startDate,
   selectedDate = DateTime.now().minus({ months: 3 }),
 }: NetWorthHistogramProps): JSX.Element {
-  const { data: monthlyTotals } = API.useAccountsMonthlyTotals();
+  const { data: monthlyTotals } = useAccountsTotals();
   const assetSeries = monthlyTotals?.asset;
   const liabilitiesSeries = monthlyTotals?.liability;
 
-  const { data: currency } = API.useMainCurrency();
+  const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
   const now = DateTime.now();

--- a/src/components/pages/accounts/NetWorthPie.tsx
+++ b/src/components/pages/accounts/NetWorthPie.tsx
@@ -3,8 +3,8 @@ import { DateTime } from 'luxon';
 
 import Money from '@/book/Money';
 import Pie from '@/components/charts/Pie';
-import * as API from '@/hooks/api';
 import { moneyToString } from '@/helpers/number';
+import { useAccountsTotals, useMainCurrency } from '@/hooks/api';
 
 export type NetWorthPieProps = {
   selectedDate?: DateTime,
@@ -13,11 +13,11 @@ export type NetWorthPieProps = {
 export default function NetWorthPie({
   selectedDate = DateTime.now(),
 }: NetWorthPieProps): JSX.Element {
-  const { data: monthlyTotals } = API.useAccountsMonthlyTotals();
+  const { data: monthlyTotals } = useAccountsTotals();
   const assetsSeries = monthlyTotals?.asset;
   const liabilitiesSeries = monthlyTotals?.liability;
 
-  const { data: currency } = API.useMainCurrency();
+  const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
   const assetsTotal = assetsSeries?.[selectedDate.toFormat('MM/yyyy')] || new Money(0, unit);

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -1,6 +1,4 @@
 import { DateTime } from 'luxon';
-import { SWRResponse } from 'swr';
-import useSWRImmutable from 'swr/immutable';
 import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 
@@ -8,8 +6,6 @@ import {
   Transaction,
 } from '@/book/entities';
 import * as queries from '@/lib/queries';
-import type { Account } from '@/book/entities';
-import { useAccounts } from './useAccounts';
 import fetcher from './fetcher';
 
 export { useAccount, useAccounts } from '@/hooks/api/useAccounts';
@@ -18,6 +14,7 @@ export { useInvestment, useInvestments } from '@/hooks/api/useInvestments';
 export { useSplits } from '@/hooks/api/useSplits';
 export { usePrices } from '@/hooks/api/usePrices';
 export { useMainCurrency } from '@/hooks/api/useMainCurrency';
+export { useAccountsTotals } from '@/hooks/api/useAccountsTotals';
 
 export function useStartDate(): UseQueryResult<DateTime> {
   return useQuery({
@@ -31,23 +28,4 @@ export function useLatestTxs(): UseQueryResult<Transaction[]> {
     queryKey: [Transaction.CACHE_KEY, { name: 'latest' }],
     queryFn: fetcher(queries.getLatestTxs, `${Transaction.CACHE_KEY}/latest`),
   });
-}
-
-export function useAccountsMonthlyTotals(): SWRResponse<queries.MonthlyTotals> {
-  const { data: accounts } = useAccounts();
-  const { data: prices } = useSWRImmutable(
-    '/api/prices',
-    fetcher(() => queries.getPrices({}), '/api/prices'),
-  );
-
-  const key = '/api/monthly-totals';
-  const result = useSWRImmutable(
-    (accounts && prices) ? key : null,
-    fetcher(
-      () => queries.getMonthlyTotals(accounts as Account[], prices),
-      key,
-    ),
-  );
-
-  return result;
 }

--- a/src/hooks/api/useAccountsTotals.ts
+++ b/src/hooks/api/useAccountsTotals.ts
@@ -1,0 +1,40 @@
+import {
+  useQuery,
+  UseQueryResult,
+} from '@tanstack/react-query';
+
+import { getMonthlyTotals } from '@/lib/queries';
+import { Account } from '@/book/entities';
+import type { MonthlyTotals } from '@/lib/queries';
+import type { PriceDBMap } from '@/book/prices';
+import { useAccounts } from './useAccounts';
+import { usePrices } from './usePrices';
+import fetcher from './fetcher';
+
+/**
+ * Returns monthly aggregations for all accounts that are. Note that
+ * if there are changes to `/api/accounts/` or any of the other dependencies the
+ * data here WILL NOT be refetched because we don't change the key.
+ *
+ * The data in this key is refreshed via the useAccountTotals hook as it updates for
+ * each account that changes. This hook is only for the initial load.
+ */
+export function useAccountsTotals(): UseQueryResult<MonthlyTotals> {
+  const { data: accounts, dataUpdatedAt: accountsUpdatedAt } = useAccounts();
+  const { data: prices, dataUpdatedAt: pricesUpdatedAt } = usePrices({});
+
+  const key = '/api/aggregations/accounts/totals';
+  const result = useQuery({
+    queryKey: [key, { accountsUpdatedAt, pricesUpdatedAt }],
+    queryFn: fetcher(
+      () => getMonthlyTotals(
+        accounts as Account[],
+        prices as PriceDBMap,
+      ),
+      key,
+    ),
+    enabled: !!accounts && !!prices,
+  });
+
+  return result;
+}

--- a/src/hooks/api/useInvestments.ts
+++ b/src/hooks/api/useInvestments.ts
@@ -89,6 +89,14 @@ export function useInvestment(guid: string): UseQueryResult<InvestmentAccount> {
   return result;
 }
 
+/**
+ * Returns all InvestmentAccount for accounts that are INVESTMENT. Note that
+ * if there are changes to `/api/accounts/` or any of the other dependencies the
+ * data here WILL NOT be refetched because we don't change the key.
+ *
+ * The data in this key is refreshed via the useInvestment hook as it updates for
+ * each account that changes. This hook is only for the initial load.
+ */
 export function useInvestments(): UseQueryResult<InvestmentAccount[]> {
   const { data: accounts } = useAccounts();
   const { data: mainCurrency } = useMainCurrency();

--- a/src/hooks/api/usePrices.ts
+++ b/src/hooks/api/usePrices.ts
@@ -10,10 +10,20 @@ import fetcher from './fetcher';
 /**
  * Returns prices for a given commodity
  */
-export function usePrices(c: Commodity | undefined): UseQueryResult<PriceDBMap> {
+export function usePrices(params: {
+  from?: Commodity,
+  to?: Commodity,
+}): UseQueryResult<PriceDBMap> {
   return useQuery({
-    queryKey: [Price.CACHE_KEY, { commodity: c?.guid }],
-    queryFn: fetcher(() => getPrices({ from: c }), `${Price.CACHE_KEY}/${c?.guid}`),
-    enabled: !!c,
+    queryKey: [Price.CACHE_KEY, { from: params.from?.guid, to: params.to?.guid }],
+    queryFn: fetcher(
+      () => getPrices(params),
+      `${Price.CACHE_KEY}/${params.from?.guid}.${params.to?.guid}`,
+    ),
+    enabled: (
+      !!('from' in params && params.from)
+      || !!('to' in params && params.to)
+      || (!('from' in params) && !('to' in params))
+    ),
   });
 }

--- a/src/lib/Stocker.ts
+++ b/src/lib/Stocker.ts
@@ -83,7 +83,7 @@ export async function insertTodayPrices(): Promise<void> {
   );
 
   const end = performance.now();
-  console.log(`/api/prices: ${end - start}ms`);
+  console.log(`/stocker/api/prices: ${end - start}ms`);
 }
 
 export type LiveSummary = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4164,6 +4164,18 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.20.5.tgz#12bb02a937cc8f4f158b1428c0ddef5a1f48479b"
   integrity sha512-T1W28gGgWn0A++tH3lxj3ZuUVZZorsiKcv+R50RwmPYz62YoDEkG4/aXHZELGkRp4DfrW07dyq2K5dvJ4Wl1aA==
 
+"@tanstack/query-devtools@5.20.2":
+  version "5.20.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.20.2.tgz#33780ea54529fecb9e572bd21a731b8f5efb765f"
+  integrity sha512-BZfSjhk/NGPbqte5E3Vc1Zbj28uWt///4I0DgzAdWrOtMVvdl0WlUXK23K2daLsbcyfoDR4jRI4f2Z5z/mMzuw==
+
+"@tanstack/react-query-devtools@^5.20.5":
+  version "5.20.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.20.5.tgz#1c60908835a346a86ca12035208a8a7fa624b660"
+  integrity sha512-Wl7IzNuKCb4h41a5iH/YXNwalHItqJPCAr4r8+0iUYOLHNOf3E9P0G4kzZ9sqDoWKxY04qst6Vrij9bwPzLQRQ==
+  dependencies:
+    "@tanstack/query-devtools" "5.20.2"
+
 "@tanstack/react-query@^5.20.5":
   version "5.20.5"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.20.5.tgz#ebf57b6d3344478d505ad8db09a8b29262a35dab"


### PR DESCRIPTION
This is the final migration from SWR to react-query for data. Only the state is missing which should be quite quick.

Note we've removed the `preloading` of some data we had in the datasource hook so things would load faster because with react-query it doesn't affect. Overall though, first load is a bit slower. I'll be working on this by adding some pagination and moving queries to more granular components. Right now the monthly-totals is way too fat as we load all the history. Some ideas to improve:

- We only need global totals for accounts tree, not per month. This should depend on the date the user selects and the query should be easy to do. The problem comes a bit for nested accounts as we have to accumulate those totals
- For graphs, we only need to show latest 6 months rather than ALL. We could load the rest dynamically whenever the user pans (or disable it and see a better way)