### PR TITLE
Dont block on stocker price

### DIFF
--- a/src/__tests__/hooks/api.test.tsx
+++ b/src/__tests__/hooks/api.test.tsx
@@ -50,7 +50,7 @@ describe('API', () => {
       renderHook(() => API.useStartDate());
 
       expect(query.useQuery).toBeCalledWith({
-        queryKey: ['/api/txs', { name: 'start' }],
+        queryKey: ['api', 'txs', { name: 'start' }],
         queryFn: expect.any(Function),
       });
 
@@ -65,7 +65,7 @@ describe('API', () => {
       renderHook(() => API.useLatestTxs());
 
       expect(query.useQuery).toBeCalledWith({
-        queryKey: ['/api/txs', { name: 'latest' }],
+        queryKey: ['api', 'txs', { name: 'latest' }],
         queryFn: expect.any(Function),
       });
 

--- a/src/__tests__/hooks/api/useAccounts.test.tsx
+++ b/src/__tests__/hooks/api/useAccounts.test.tsx
@@ -26,7 +26,7 @@ describe('useAccount', () => {
     renderHook(() => useAccount('guid'));
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/accounts', { guid: 'guid' }],
+      queryKey: ['api', 'accounts', { guid: 'guid' }],
       queryFn: expect.any(Function),
     });
 
@@ -59,7 +59,7 @@ describe('useAccounts', () => {
     renderHook(() => useAccounts());
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/accounts'],
+      queryKey: ['api', 'accounts'],
       queryFn: expect.any(Function),
     });
 

--- a/src/__tests__/hooks/api/useAccountsTotals.test.tsx
+++ b/src/__tests__/hooks/api/useAccountsTotals.test.tsx
@@ -72,7 +72,7 @@ describe('useAccount', () => {
 
     expect(query.useQuery).toBeCalledWith({
       queryKey: [
-        '/api/aggregations/accounts/totals',
+        'api', 'aggregations', 'accounts', 'totals',
         {
           accountsUpdatedAt: 1,
           pricesUpdatedAt: 2,

--- a/src/__tests__/hooks/api/useCommodities.test.ts
+++ b/src/__tests__/hooks/api/useCommodities.test.ts
@@ -26,7 +26,7 @@ describe('useCommodity', () => {
     renderHook(() => useCommodity('guid'));
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/commodities', { guid: 'guid' }],
+      queryKey: ['api', 'commodities', { guid: 'guid' }],
       queryFn: expect.any(Function),
     });
 
@@ -59,7 +59,7 @@ describe('useCommodities', () => {
     renderHook(() => useCommodities());
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/commodities'],
+      queryKey: ['api', 'commodities'],
       queryFn: expect.any(Function),
     });
 

--- a/src/__tests__/hooks/api/useInvestments.test.tsx
+++ b/src/__tests__/hooks/api/useInvestments.test.tsx
@@ -123,7 +123,7 @@ describe('useInvestment', () => {
     expect(useSplitsHook.useSplits).toBeCalledWith({ guid: 'guid' });
     expect(query.useQuery).toBeCalledWith({
       queryKey: [
-        '/api/investments',
+        'api', 'investments',
         {
           account: 'guid',
           accountUpdatedAt: 1,
@@ -243,7 +243,7 @@ describe('useInvestments', () => {
     expect(useAccountsHook.useAccounts).toBeCalledWith();
     expect(useSplitsHook.useSplits).toBeCalledWith({ type: 'INVESTMENT' });
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/investments'],
+      queryKey: ['api', 'investments'],
       queryFn: expect.any(Function),
       enabled: true,
     });

--- a/src/__tests__/hooks/api/useMainCurrency.test.ts
+++ b/src/__tests__/hooks/api/useMainCurrency.test.ts
@@ -12,7 +12,7 @@ describe('useMainCurrency', () => {
     renderHook(() => useMainCurrency());
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/commodities', { guid: 'main' }],
+      queryKey: ['api', 'commodities', { guid: 'main' }],
       queryFn: expect.any(Function),
     });
 

--- a/src/__tests__/hooks/api/usePrices.test.ts
+++ b/src/__tests__/hooks/api/usePrices.test.ts
@@ -17,7 +17,7 @@ describe('usePrices', () => {
     renderHook(() => usePrices({ from: { guid: 'guid' } as Commodity }));
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/prices', { from: 'guid' }],
+      queryKey: ['api', 'prices', { from: 'guid' }],
       queryFn: expect.any(Function),
       enabled: true,
     });
@@ -34,7 +34,7 @@ describe('usePrices', () => {
     }));
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/prices', { from: 'guid', to: 'to' }],
+      queryKey: ['api', 'prices', { from: 'guid', to: 'to' }],
       queryFn: expect.any(Function),
       enabled: true,
     });

--- a/src/__tests__/hooks/api/useSplits.test.ts
+++ b/src/__tests__/hooks/api/useSplits.test.ts
@@ -31,7 +31,7 @@ describe('useSplits', () => {
     renderHook(() => useSplits({ guid: 'guid' }));
 
     expect(query.useQuery).toBeCalledWith({
-      queryKey: ['/api/splits', { guid: 'guid' }],
+      queryKey: ['api', 'splits', { guid: 'guid' }],
       queryFn: expect.any(Function),
     });
 

--- a/src/__tests__/hooks/useDataSource.test.ts
+++ b/src/__tests__/hooks/useDataSource.test.ts
@@ -294,6 +294,7 @@ describe('useDataSource', () => {
         expect(datasource.sqljsManager.loadDatabase).toBeCalledWith(new Uint8Array([44, 55]));
 
         expect(datasource.options.extra.queryClient.refetchQueries).toBeCalledWith({
+          queryKey: ['api'],
           type: 'all',
         });
 

--- a/src/book/__tests__/entities/BaseEntity.test.ts
+++ b/src/book/__tests__/entities/BaseEntity.test.ts
@@ -38,7 +38,7 @@ describe('BaseEntity', () => {
   describe('caching', () => {
     let mockSetQueryData: jest.Mock;
     class Account extends BaseEntity {
-      static CACHE_KEY = '/api/accounts';
+      static CACHE_KEY = ['api', 'accounts'];
     }
 
     beforeEach(() => {
@@ -76,12 +76,12 @@ describe('BaseEntity', () => {
       expect(BE.prototype.save).toBeCalledWith(undefined);
       expect(mockSetQueryData).toHaveBeenNthCalledWith(
         1,
-        ['/api/accounts'],
+        ['api', 'accounts'],
         expect.any(Function),
       );
       expect(mockSetQueryData).toHaveBeenNthCalledWith(
         2,
-        ['/api/accounts', { guid: instance.guid }],
+        ['api', 'accounts', { guid: instance.guid }],
         instance,
       );
     });
@@ -114,13 +114,7 @@ describe('BaseEntity', () => {
 
     it('updates existing account in /api/accounts', async () => {
       jest.spyOn(BE.prototype, 'save')
-        .mockResolvedValueOnce(instance)
-        .mockResolvedValueOnce({
-          ...instance,
-          // @ts-ignore
-          name: 'updated', // Fake attribute to show we update
-        });
-
+        .mockResolvedValueOnce(instance);
       await instance.save();
       mockSetQueryData
         .mockImplementation((_: string, callback: Account | Function): Account[] | Account => {
@@ -130,6 +124,11 @@ describe('BaseEntity', () => {
 
           return instance;
         });
+
+      // @ts-ignore fake attribute to prove we update
+      instance.name = 'updated';
+      jest.spyOn(BE.prototype, 'save')
+        .mockResolvedValueOnce(instance);
       await instance.save();
 
       await waitFor(() => expect(mockSetQueryData.mock.results).toHaveLength(4));
@@ -163,7 +162,7 @@ describe('BaseEntity', () => {
 
       expect(mockSetQueryData).toHaveBeenNthCalledWith(
         4,
-        ['/api/accounts', { guid: instance.guid }],
+        ['api', 'accounts', { guid: instance.guid }],
         null,
       );
     });

--- a/src/book/__tests__/entities/Price.test.ts
+++ b/src/book/__tests__/entities/Price.test.ts
@@ -158,7 +158,7 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(1);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { from: 'ticker' }],
+      queryKey: ['api', 'prices', { from: 'ticker' }],
       refetchType: 'all',
     });
     expect(Price.upsert).toBeCalledWith(
@@ -183,11 +183,11 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(2);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { from: 'eur' }],
+      queryKey: ['api', 'prices', { from: 'eur' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { from: 'usd' }],
+      queryKey: ['api', 'prices', { from: 'usd' }],
       refetchType: 'all',
     });
   });
@@ -203,7 +203,7 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(1);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/prices', { from: 'ticker' }],
+      queryKey: ['api', 'prices', { from: 'ticker' }],
       refetchType: 'all',
     });
   });

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -288,23 +288,23 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(5);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/txs', { name: 'latest' }],
+      queryKey: ['api', 'txs', { name: 'latest' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/txs', { name: 'start' }],
+      queryKey: ['api', 'txs', { name: 'start' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { guid: '1' }],
+      queryKey: ['api', 'splits', { guid: '1' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { guid: '2' }],
+      queryKey: ['api', 'splits', { guid: '2' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/aggregations/accounts/totals'],
+      queryKey: ['api', 'aggregations', 'accounts', 'totals'],
       refetchType: 'all',
     });
   });
@@ -324,23 +324,23 @@ describe('caching', () => {
 
     expect(mockInvalidateQueries).toBeCalledTimes(5);
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/txs', { name: 'latest' }],
+      queryKey: ['api', 'txs', { name: 'latest' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/txs', { name: 'start' }],
+      queryKey: ['api', 'txs', { name: 'start' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { guid: '1' }],
+      queryKey: ['api', 'splits', { guid: '1' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/splits', { guid: '2' }],
+      queryKey: ['api', 'splits', { guid: '2' }],
       refetchType: 'all',
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['/api/aggregations/accounts/totals'],
+      queryKey: ['api', 'aggregations', 'accounts', 'totals'],
       refetchType: 'all',
     });
   });

--- a/src/book/entities/Account.ts
+++ b/src/book/entities/Account.ts
@@ -43,7 +43,7 @@ import BaseEntity from './BaseEntity';
 @Entity('accounts')
 @Tree('nested-set')
 export default class Account extends BaseEntity {
-  static CACHE_KEY = '/api/accounts';
+  static CACHE_KEY = ['api', 'accounts'];
   static TYPES = [
     'ROOT',
     'EQUITY',
@@ -183,7 +183,7 @@ export async function updateCache(
   await entity.reload();
 
   queryClient.setQueryData(
-    [Account.CACHE_KEY],
+    [...Account.CACHE_KEY],
     (entities: Account[] | undefined) => {
       if (!entities) {
         return undefined;

--- a/src/book/entities/BaseEntity.ts
+++ b/src/book/entities/BaseEntity.ts
@@ -13,7 +13,7 @@ import { QueryClient } from '@tanstack/react-query';
  * we want and adds validation before saving or updating entities
  */
 export default class BaseEntity extends BE {
-  static CACHE_KEY = '';
+  static CACHE_KEY: string[] = [];
 
   @BeforeInsert()
   @BeforeUpdate()
@@ -80,7 +80,7 @@ export async function updateCache(
   const key = entity.constructor.CACHE_KEY;
 
   queryClient.setQueryData(
-    [key],
+    [...key],
     (entities: BaseEntity[] | undefined) => {
       if (!entities) {
         return undefined;
@@ -102,7 +102,7 @@ export async function updateCache(
   );
 
   queryClient.setQueryData(
-    [key, { guid: entity.guid }],
+    [...key, { guid: entity.guid }],
     !isDelete ? entity : null,
   );
 }

--- a/src/book/entities/Commodity.ts
+++ b/src/book/entities/Commodity.ts
@@ -26,7 +26,7 @@ import BaseEntity from './BaseEntity';
 @Entity('commodities')
 @Index(['mnemonic', 'namespace'], { unique: true })
 export default class Commodity extends BaseEntity {
-  static CACHE_KEY = '/api/commodities';
+  static CACHE_KEY = ['api', 'commodities'];
 
   @Column({
     type: 'text',

--- a/src/book/entities/Price.ts
+++ b/src/book/entities/Price.ts
@@ -32,7 +32,7 @@ import { toAmountWithScale } from '../../helpers/number';
 @Entity('prices')
 @Index(['fk_commodity', 'fk_currency', 'date'], { unique: true })
 export default class Price extends BaseEntity {
-  static CACHE_KEY = '/api/prices';
+  static CACHE_KEY = ['api', 'prices'];
 
   @ManyToOne('Commodity', { eager: true })
   @JoinColumn({ name: 'commodity_guid' })
@@ -146,13 +146,13 @@ export async function updateCache(
   },
 ) {
   queryClient.invalidateQueries({
-    queryKey: [Price.CACHE_KEY, { from: (entity.fk_commodity as Commodity).guid }],
+    queryKey: [...Price.CACHE_KEY, { from: (entity.fk_commodity as Commodity).guid }],
     refetchType: 'all',
   });
 
   if ((entity.fk_commodity as Commodity).namespace === 'CURRENCY') {
     queryClient.invalidateQueries({
-      queryKey: [Price.CACHE_KEY, { from: (entity.fk_currency as Commodity).guid }],
+      queryKey: [...Price.CACHE_KEY, { from: (entity.fk_currency as Commodity).guid }],
       refetchType: 'all',
     });
   }

--- a/src/book/entities/Split.ts
+++ b/src/book/entities/Split.ts
@@ -34,7 +34,7 @@ import { toAmountWithScale } from '../../helpers/number';
 */
 @Entity('splits')
 export default class Split extends BaseEntity {
-  static CACHE_KEY = '/api/splits';
+  static CACHE_KEY = ['api', 'splits'];
 
   @ManyToOne('Transaction')
   @JoinColumn({ name: 'tx_guid' })

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -34,7 +34,7 @@ import { DateTimeTransformer } from './transformers';
 
 @Entity('transactions')
 export default class Transaction extends BaseEntity {
-  static CACHE_KEY = '/api/txs';
+  static CACHE_KEY = ['api', 'txs'];
 
   @ManyToOne('Commodity', { eager: true })
   @JoinColumn({ name: 'currency_guid' })
@@ -116,23 +116,23 @@ export async function updateCache(
   },
 ) {
   queryClient.invalidateQueries({
-    queryKey: [Transaction.CACHE_KEY, { name: 'latest' }],
+    queryKey: [...Transaction.CACHE_KEY, { name: 'latest' }],
     refetchType: 'all',
   });
   queryClient.invalidateQueries({
-    queryKey: [Transaction.CACHE_KEY, { name: 'start' }],
+    queryKey: [...Transaction.CACHE_KEY, { name: 'start' }],
     refetchType: 'all',
   });
 
   entity.splits.forEach(split => {
     queryClient.invalidateQueries({
-      queryKey: [Split.CACHE_KEY, { guid: split.fk_account.guid }],
+      queryKey: [...Split.CACHE_KEY, { guid: split.fk_account.guid }],
       refetchType: 'all',
     });
   });
 
   queryClient.invalidateQueries({
-    queryKey: ['/api/aggregations/accounts/totals'],
+    queryKey: ['api', 'aggregations', 'accounts', 'totals'],
     refetchType: 'all',
   });
 }

--- a/src/book/models/InvestmentAccount.ts
+++ b/src/book/models/InvestmentAccount.ts
@@ -7,7 +7,7 @@ import { PriceDBMap } from '../prices';
 import type { QuoteInfo } from '../types';
 
 export default class InvestmentAccount {
-  static CACHE_KEY = '/api/investments';
+  static CACHE_KEY = ['api', 'investments'];
 
   readonly account: Account;
   readonly splits: Split[];

--- a/src/components/forms/currency/CurrencyForm.tsx
+++ b/src/components/forms/currency/CurrencyForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';
 import { SingleValue } from 'react-select';
-import { mutate } from 'swr';
 
 import { Commodity } from '@/book/entities';
 import Selector from '@/components/selectors/Selector';
@@ -75,6 +74,5 @@ async function onSubmit(data: Commodity, onSave: Function) {
   const mainCommodity = await Commodity.create({
     ...data,
   }).save();
-  mutate('/api/commodities');
   await onSave(mainCommodity);
 }

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -60,7 +60,7 @@ export default function Onboarding({
                 <CurrencyForm
                   onSave={async (currency: Commodity) => {
                     datasource?.options.extra?.queryClient.setQueryData(
-                      [Commodity.CACHE_KEY, { guid: 'main' }],
+                      [...Commodity.CACHE_KEY, { guid: 'main' }],
                       currency,
                     );
                     await createInitialAccounts(setAccounts, currency);

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -18,14 +18,14 @@ export { useAccountsTotals } from '@/hooks/api/useAccountsTotals';
 
 export function useStartDate(): UseQueryResult<DateTime> {
   return useQuery({
-    queryKey: [Transaction.CACHE_KEY, { name: 'start' }],
-    queryFn: fetcher(queries.getEarliestDate, `${Transaction.CACHE_KEY}/start`),
+    queryKey: [...Transaction.CACHE_KEY, { name: 'start' }],
+    queryFn: fetcher(queries.getEarliestDate, `/${Transaction.CACHE_KEY.join('/')}/start`),
   });
 }
 
 export function useLatestTxs(): UseQueryResult<Transaction[]> {
   return useQuery({
-    queryKey: [Transaction.CACHE_KEY, { name: 'latest' }],
-    queryFn: fetcher(queries.getLatestTxs, `${Transaction.CACHE_KEY}/latest`),
+    queryKey: [...Transaction.CACHE_KEY, { name: 'latest' }],
+    queryFn: fetcher(queries.getLatestTxs, `/${Transaction.CACHE_KEY.join('/')}/latest`),
   });
 }

--- a/src/hooks/api/useAccounts.ts
+++ b/src/hooks/api/useAccounts.ts
@@ -8,8 +8,8 @@ import fetcher from './fetcher';
 
 export function useAccount(guid: string): UseQueryResult<Account> {
   const result = useQuery({
-    queryKey: [Account.CACHE_KEY, { guid }],
-    queryFn: fetcher(() => Account.findOneBy({ guid }), `${Account.CACHE_KEY}/${guid}`),
+    queryKey: [...Account.CACHE_KEY, { guid }],
+    queryFn: fetcher(() => Account.findOneBy({ guid }), `/${Account.CACHE_KEY.join('/')}/${guid}`),
   });
 
   return result;
@@ -17,8 +17,8 @@ export function useAccount(guid: string): UseQueryResult<Account> {
 
 export function useAccounts(): UseQueryResult<Account[]> {
   const result = useQuery({
-    queryKey: [Account.CACHE_KEY],
-    queryFn: fetcher(() => Account.find(), Account.CACHE_KEY),
+    queryKey: [...Account.CACHE_KEY],
+    queryFn: fetcher(() => Account.find(), `/${Account.CACHE_KEY.join('/')}`),
   });
 
   return result;

--- a/src/hooks/api/useAccountsTotals.ts
+++ b/src/hooks/api/useAccountsTotals.ts
@@ -23,15 +23,15 @@ export function useAccountsTotals(): UseQueryResult<MonthlyTotals> {
   const { data: accounts, dataUpdatedAt: accountsUpdatedAt } = useAccounts();
   const { data: prices, dataUpdatedAt: pricesUpdatedAt } = usePrices({});
 
-  const key = '/api/aggregations/accounts/totals';
+  const key = ['api', 'aggregations', 'accounts', 'totals'];
   const result = useQuery({
-    queryKey: [key, { accountsUpdatedAt, pricesUpdatedAt }],
+    queryKey: [...key, { accountsUpdatedAt, pricesUpdatedAt }],
     queryFn: fetcher(
       () => getMonthlyTotals(
         accounts as Account[],
         prices as PriceDBMap,
       ),
-      key,
+      `/${key.join('/')}`,
     ),
     enabled: !!accounts && !!prices,
   });

--- a/src/hooks/api/useCommodities.ts
+++ b/src/hooks/api/useCommodities.ts
@@ -8,8 +8,8 @@ import fetcher from './fetcher';
 
 export function useCommodity(guid: string): UseQueryResult<Commodity> {
   const result = useQuery({
-    queryKey: [Commodity.CACHE_KEY, { guid }],
-    queryFn: fetcher(() => Commodity.findOneBy({ guid }), `${Commodity.CACHE_KEY}/${guid}`),
+    queryKey: [...Commodity.CACHE_KEY, { guid }],
+    queryFn: fetcher(() => Commodity.findOneBy({ guid }), `/${Commodity.CACHE_KEY.join('/')}/${guid}`),
   });
 
   return result;
@@ -17,8 +17,8 @@ export function useCommodity(guid: string): UseQueryResult<Commodity> {
 
 export function useCommodities(): UseQueryResult<Commodity[]> {
   const result = useQuery({
-    queryKey: [Commodity.CACHE_KEY],
-    queryFn: fetcher(() => Commodity.find(), Commodity.CACHE_KEY),
+    queryKey: [...Commodity.CACHE_KEY],
+    queryFn: fetcher(() => Commodity.find(), `/${Commodity.CACHE_KEY.join('/')}`),
   });
 
   return result;

--- a/src/hooks/api/useInvestments.ts
+++ b/src/hooks/api/useInvestments.ts
@@ -40,7 +40,7 @@ export function useInvestment(guid: string): UseQueryResult<InvestmentAccount> {
 
   const result = useQuery({
     queryKey: [
-      InvestmentAccount.CACHE_KEY,
+      ...InvestmentAccount.CACHE_KEY,
       {
         account: guid,
         accountUpdatedAt,
@@ -56,7 +56,7 @@ export function useInvestment(guid: string): UseQueryResult<InvestmentAccount> {
           splits as Split[],
         );
         queryClient.setQueryData(
-          [InvestmentAccount.CACHE_KEY],
+          [...InvestmentAccount.CACHE_KEY],
           (entities: InvestmentAccount[]) => {
             if (!entities) {
               return undefined;
@@ -77,7 +77,7 @@ export function useInvestment(guid: string): UseQueryResult<InvestmentAccount> {
 
         return investment;
       },
-      `${InvestmentAccount.CACHE_KEY}/${guid}`,
+      `/${InvestmentAccount.CACHE_KEY.join('/')}/${guid}`,
     ),
     enabled: !!account && !!splits && !!mainCurrency,
     placeholderData: keepPreviousData,
@@ -103,14 +103,14 @@ export function useInvestments(): UseQueryResult<InvestmentAccount[]> {
   const { data: splits } = useSplits({ type: 'INVESTMENT' });
 
   const result = useQuery({
-    queryKey: [InvestmentAccount.CACHE_KEY],
+    queryKey: [...InvestmentAccount.CACHE_KEY],
     queryFn: fetcher(
       () => getInvestments(
         (accounts as Account[]).filter(a => a.type === 'INVESTMENT'),
         mainCurrency as Commodity,
         splits as Split[],
       ),
-      InvestmentAccount.CACHE_KEY,
+      `/${InvestmentAccount.CACHE_KEY.join('/')}`,
     ),
     enabled: !!accounts && !!splits && !!mainCurrency,
   });

--- a/src/hooks/api/useMainCurrency.ts
+++ b/src/hooks/api/useMainCurrency.ts
@@ -7,7 +7,7 @@ import fetcher from './fetcher';
 
 export function useMainCurrency(): UseQueryResult<Commodity> {
   return useQuery({
-    queryKey: [Commodity.CACHE_KEY, { guid: 'main' }],
-    queryFn: fetcher(getMainCurrency, `${Commodity.CACHE_KEY}/main`),
+    queryKey: [...Commodity.CACHE_KEY, { guid: 'main' }],
+    queryFn: fetcher(getMainCurrency, `/${Commodity.CACHE_KEY.join('/')}/main`),
   });
 }

--- a/src/hooks/api/usePrices.ts
+++ b/src/hooks/api/usePrices.ts
@@ -15,10 +15,10 @@ export function usePrices(params: {
   to?: Commodity,
 }): UseQueryResult<PriceDBMap> {
   return useQuery({
-    queryKey: [Price.CACHE_KEY, { from: params.from?.guid, to: params.to?.guid }],
+    queryKey: [...Price.CACHE_KEY, { from: params.from?.guid, to: params.to?.guid }],
     queryFn: fetcher(
       () => getPrices(params),
-      `${Price.CACHE_KEY}/${params.from?.guid}.${params.to?.guid}`,
+      `/${Price.CACHE_KEY.join('/')}/${params.from?.guid}.${params.to?.guid}`,
     ),
     enabled: (
       !!('from' in params && params.from)

--- a/src/hooks/api/useSplits.ts
+++ b/src/hooks/api/useSplits.ts
@@ -15,7 +15,7 @@ import fetcher from './fetcher';
  */
 export function useSplits(findOptions: FindOptionsWhere<Account>): UseQueryResult<Split[]> {
   return useQuery({
-    queryKey: [Split.CACHE_KEY, findOptions],
+    queryKey: [...Split.CACHE_KEY, findOptions],
     queryFn: fetcher(
       () => getSplits(
         findOptions,
@@ -28,7 +28,7 @@ export function useSplits(findOptions: FindOptionsWhere<Account>): UseQueryResul
           fk_account: true,
         },
       ),
-      `${Split.CACHE_KEY}/${JSON.stringify(findOptions)}`,
+      `/${Split.CACHE_KEY.join('/')}/${JSON.stringify(findOptions)}`,
     ),
   });
 }

--- a/src/hooks/useDataSource.ts
+++ b/src/hooks/useDataSource.ts
@@ -125,10 +125,11 @@ async function importBook(storage: BookStorage, rawData: Uint8Array) {
   await DATASOURCE.sqljsManager.loadDatabase(rawBook);
 
   DATASOURCE.options.extra.queryClient.refetchQueries({
+    queryKey: ['api'],
     type: 'all',
   });
 
-  await loadStockerPrices();
+  loadStockerPrices();
   await save(storage);
 }
 

--- a/src/lib/Stocker.ts
+++ b/src/lib/Stocker.ts
@@ -82,6 +82,13 @@ export async function insertTodayPrices(): Promise<void> {
     },
   );
 
+  if (prices.length) {
+    prices[0]?.queryClient?.invalidateQueries({
+      queryKey: ['api', 'prices'],
+      refetchType: 'all',
+    });
+  }
+
   const end = performance.now();
   console.log(`/stocker/api/prices: ${end - start}ms`);
 }


### PR DESCRIPTION
Avoid blocking on stocker prices by invalidating prices key once we've inserted prices.

Also, refactored the way we define the keys so we can invalidate/refetch groups of keys accordingly. More in https://stackoverflow.com/questions/74770055/react-query-invalidatequeries-partial-match-not-working