### PR TITLE
Minor updates

### DIFF
--- a/amplify/backend/function/stockerlambda/package.json
+++ b/amplify/backend/function/stockerlambda/package.json
@@ -69,7 +69,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.6",
-    "@types/node": "^20.11.17",
+    "@types/node": "^20.11.19",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "jest": "^27.4.6",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@types/google.accounts": "^0.0.14",
     "@types/jest": "^29.5.5",
     "@types/luxon": "^3.4.2",
-    "@types/node": "^20.11.17",
+    "@types/node": "^20.11.19",
     "@types/pako": "^2.0.3",
     "@types/react": "18.2.55",
     "@types/react-dom": "^18.2.19",

--- a/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
@@ -124,7 +124,7 @@ describe('InvestmentInfo', () => {
       {
         className: 'col-span-6',
         title: 'Latest known price',
-        statsTextClass: 'table-caption badge',
+        statsTextClass: 'table-caption badge default',
         stats: '€15.00',
         description: 'on 2/1/2023',
       },
@@ -157,7 +157,7 @@ describe('InvestmentInfo', () => {
       {
         className: 'col-span-5',
         title: 'Total Dividends',
-        statsTextClass: 'badge',
+        statsTextClass: 'badge default',
         stats: '€20.00',
         description: '',
       },
@@ -200,7 +200,7 @@ describe('InvestmentInfo', () => {
         currency: 'EUR',
         realizedDividends: new Money(20, 'USD'),
       },
-    } as SWRResponse);
+    } as UseQueryResult<InvestmentAccount>);
 
     render(
       <InvestmentInfo account={account} />,
@@ -211,7 +211,7 @@ describe('InvestmentInfo', () => {
       {
         className: 'col-span-5',
         title: 'Total Dividends',
-        statsTextClass: 'badge',
+        statsTextClass: 'badge default',
         stats: '$20.00',
         description: '',
       },

--- a/src/__tests__/components/pages/account/__snapshots__/InvestmentInfo.test.tsx.snap
+++ b/src/__tests__/components/pages/account/__snapshots__/InvestmentInfo.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`InvestmentInfo renders as expected with data 1`] = `
           You currently owe
         </span>
         <span
-          class="badge text-xl font-semibold mx-1"
+          class="badge default text-xl font-semibold mx-1"
         >
           10 titles
         </span>
@@ -23,7 +23,7 @@ exports[`InvestmentInfo renders as expected with data 1`] = `
           at an average price of
         </span>
         <span
-          class="badge text-xl font-semibold mx-1"
+          class="badge default text-xl font-semibold mx-1"
         >
           €10.00
         </span>

--- a/src/__tests__/components/selectors/AccountSelector.test.tsx
+++ b/src/__tests__/components/selectors/AccountSelector.test.tsx
@@ -36,6 +36,9 @@ describe('AccountSelector', () => {
         placeholder: 'Choose account',
         getOptionLabel: expect.any(Function),
         getOptionValue: expect.any(Function),
+        classNames: {
+          option: expect.any(Function),
+        },
       },
       {},
     );

--- a/src/__tests__/hooks/api/useMainCurrency.test.ts
+++ b/src/__tests__/hooks/api/useMainCurrency.test.ts
@@ -14,6 +14,7 @@ describe('useMainCurrency', () => {
     expect(query.useQuery).toBeCalledWith({
       queryKey: ['api', 'commodities', { guid: 'main' }],
       queryFn: expect.any(Function),
+      gcTime: Infinity,
     });
 
     const callArgs = (query.useQuery as jest.Mock).mock.calls[0][0];

--- a/src/__tests__/hooks/state/useTheme.test.tsx
+++ b/src/__tests__/hooks/state/useTheme.test.tsx
@@ -23,6 +23,7 @@ describe('useMainCurrency', () => {
     const queryCache = queryClient.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(['state', 'theme']);
+    expect(queryCache[0].gcTime).toEqual(Infinity);
   });
 
   it('returns whatever is set in localstorage', async () => {
@@ -33,6 +34,6 @@ describe('useMainCurrency', () => {
     await waitFor(() => expect(result.current.data).toEqual('light'));
     const queryCache = queryClient.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
-    expect(queryCache[0].queryKey).toEqual(['state', 'theme']);
+    expect(queryCache[0].gcTime).toEqual(Infinity);
   });
 });

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -22,7 +22,6 @@ const queryClient = new QueryClient({
       refetchOnMount: true,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
-      gcTime: 300000,
       placeholderData: keepPreviousData,
     },
   },

--- a/src/book/models/InvestmentAccount.ts
+++ b/src/book/models/InvestmentAccount.ts
@@ -161,7 +161,7 @@ export default class InvestmentAccount {
     this.realizedProfit = new Money(0, this.currency);
     this.dividends.splice(0, this.dividends.length);
 
-    this.splits.reverse().filter(
+    [...this.splits].reverse().filter(
       split => split.transaction.date <= (date || DateTime.now()),
     ).forEach((split) => {
       const numSplits = split.transaction.splits.length;

--- a/src/components/forms/account/AccountForm.tsx
+++ b/src/components/forms/account/AccountForm.tsx
@@ -15,6 +15,7 @@ import {
   CommoditySelector,
   AccountTypeSelector,
 } from '@/components/selectors';
+import { useMainCurrency } from '@/hooks/api';
 import { getAllowedSubAccounts } from '@/book/helpers/accountType';
 import { toAmountWithScale } from '@/helpers/number';
 import createEquityAccount from '@/lib/createEquityAccount';
@@ -38,10 +39,12 @@ export type SplitFieldData = {
 
 export default function AccountForm({
   action = 'add',
-  defaultValues,
+  defaultValues = {},
   onSave = () => {},
   hideDefaults = false,
 }: AccountFormProps): JSX.Element {
+  const { data: mainCurrency } = useMainCurrency();
+  defaultValues.fk_commodity = defaultValues?.fk_commodity || mainCurrency;
   const form = useForm<FormValues>({
     defaultValues,
     mode: 'onChange',
@@ -123,7 +126,6 @@ export default function AccountForm({
             <>
               <AccountSelector
                 id="parentInput"
-                showRoot
                 isDisabled={disabled}
                 isClearable={false}
                 ignoreAccounts={['INVESTMENT']}

--- a/src/components/pages/account/InvestmentInfo.tsx
+++ b/src/components/pages/account/InvestmentInfo.tsx
@@ -31,15 +31,15 @@ export default function InvestmentInfo({
       <div className="col-span-4">
         <div className="card text-lg">
           <span>You currently owe</span>
-          <span className="badge text-xl font-semibold mx-1">{`${investment.quantity.toNumber()} titles`}</span>
+          <span className="badge default text-xl font-semibold mx-1">{`${investment.quantity.toNumber()} titles`}</span>
           <span>at an average price of</span>
-          <span className="badge text-xl font-semibold mx-1">{new Money(investment.avgPrice, investment.currency).format()}</span>
+          <span className="badge default text-xl font-semibold mx-1">{new Money(investment.avgPrice, investment.currency).format()}</span>
         </div>
         <div className="grid grid-cols-12">
           <StatisticsWidget
             className="col-span-6"
             title="Latest known price"
-            statsTextClass="table-caption badge"
+            statsTextClass="table-caption badge default"
             stats={new Money(latestPrice.value, investment.currency).format()}
             description={
               `on ${latestPrice.date.toLocaleString()}`
@@ -71,7 +71,7 @@ export default function InvestmentInfo({
             className="col-span-5"
             title="Total Dividends"
             stats={investment.realizedDividends.format()}
-            statsTextClass="badge"
+            statsTextClass="badge default"
             description=""
           />
         </div>

--- a/src/components/pages/account/TransactionsTable.tsx
+++ b/src/components/pages/account/TransactionsTable.tsx
@@ -22,8 +22,7 @@ import {
 } from '@/book/entities';
 import { useSplitsCount, useSplitsPagination } from '@/hooks/api';
 import type { Commodity } from '@/book/entities';
-import { isAsset } from '@/book/helpers';
-import { isLiability } from '@/book/helpers/accountType';
+import { accountColorCode } from '@/helpers/classNames';
 import fetcher from '@/hooks/api/fetcher';
 
 export type TransactionsTableProps = {
@@ -154,13 +153,7 @@ function FromToAccountCell({ row }: CellContext<Split, unknown>): JSX.Element {
           <li key={split.guid}>
             <Link
               href={`/dashboard/accounts/${split.accountId}`}
-              className={classNames('badge mb-0.5 hover:text-slate-300', {
-                success: account.type === 'INCOME',
-                danger: account.type === 'EXPENSE',
-                misc: ['INVESTMENT'].includes(account.type),
-                info: isAsset(account),
-                warning: isLiability(account),
-              })}
+              className={accountColorCode(account, 'badge mb-0.5 hover:text-slate-300')}
             >
               { account?.path }
             </Link>

--- a/src/components/pages/accounts/AccountsTable.tsx
+++ b/src/components/pages/accounts/AccountsTable.tsx
@@ -3,7 +3,6 @@ import { DateTime } from 'luxon';
 import { ColumnDef } from '@tanstack/react-table';
 import Link from 'next/link';
 import { BiCircle, BiSolidRightArrow, BiSolidDownArrow } from 'react-icons/bi';
-import classNames from 'classnames';
 import { Tooltip } from 'react-tooltip';
 
 import Money from '@/book/Money';
@@ -12,12 +11,12 @@ import type { AccountsMap } from '@/types/book';
 import { MonthlyTotals } from '@/lib/queries';
 import { Account } from '@/book/entities';
 import {
-  isInvestment,
   isAsset,
   isLiability,
 } from '@/book/helpers/accountType';
 import { useAccountsTotals, useAccounts } from '@/hooks/api';
 import mapAccounts from '@/helpers/mapAccounts';
+import { accountColorCode } from '@/helpers/classNames';
 
 export type AccountsTableProps = {
   selectedDate?: DateTime,
@@ -128,13 +127,7 @@ const columns: ColumnDef<AccountsTableRow>[] = [
             && (
               <span
                 data-tooltip-id={row.original.account.guid}
-                className={classNames('badge cursor-default', {
-                  success: row.original.account.type === 'INCOME',
-                  danger: row.original.account.type === 'EXPENSE',
-                  info: isAsset(row.original.account),
-                  warning: isLiability(row.original.account),
-                  misc: isInvestment(row.original.account),
-                })}
+                className={accountColorCode(row.original.account, 'badge cursor-default')}
               >
                 {row.original.account.name}
               </span>
@@ -142,13 +135,7 @@ const columns: ColumnDef<AccountsTableRow>[] = [
           ) || (
             <Link
               data-tooltip-id={row.original.account.guid}
-              className={classNames('badge hover:text-slate-300', {
-                success: row.original.account.type === 'INCOME',
-                danger: row.original.account.type === 'EXPENSE',
-                info: isAsset(row.original.account),
-                warning: isLiability(row.original.account),
-                misc: isInvestment(row.original.account),
-              })}
+              className={accountColorCode(row.original.account, 'badge hover:text-slate-300')}
               href={`/dashboard/accounts/${row.original.account.guid}`}
             >
               {row.original.account.name}

--- a/src/components/pages/accounts/LatestTransactions.tsx
+++ b/src/components/pages/accounts/LatestTransactions.tsx
@@ -11,6 +11,7 @@ import { useLatestTxs } from '@/hooks/api';
 import { isAsset, isInvestment, isLiability } from '@/book/helpers/accountType';
 import type { Split, Transaction } from '@/book/entities';
 import { moneyToString } from '@/helpers/number';
+import { accountColorCode } from '@/helpers/classNames';
 
 export default function LatestTransactions(): JSX.Element {
   let { data: txs } = useLatestTxs();
@@ -56,10 +57,12 @@ export default function LatestTransactions(): JSX.Element {
                         )}
                       </span>
                       <Link
-                        className={classNames('ml-auto text-xs badge hover:text-slate-300', {
-                          info: selectedSplit?.account && isAsset(selectedSplit.account),
-                          warning: selectedSplit?.account && isLiability(selectedSplit?.account),
-                        })}
+                        className={
+                          accountColorCode(
+                            selectedSplit?.account,
+                            'ml-auto text-xs badge hover:text-slate-300',
+                          )
+                        }
                         href={`/dashboard/accounts/${selectedSplit?.account?.guid}`}
                       >
                         {selectedSplit?.account?.name || '???'}

--- a/src/components/pages/investments/InvestmentsTable.tsx
+++ b/src/components/pages/investments/InvestmentsTable.tsx
@@ -45,7 +45,7 @@ const columns: ColumnDef<InvestmentAccount>[] = [
       <p className="m-0 d-inline-block align-middle font-18">
         <Link
           href={`/dashboard/accounts/${row.original.account.guid}`}
-          className="badge hover:text-slate-300 bg-light"
+          className="badge misc hover:text-slate-300 bg-light"
         >
           {getValue<string>()}
         </Link>

--- a/src/components/selectors/AccountSelector.tsx
+++ b/src/components/selectors/AccountSelector.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { Props as SelectProps, GroupBase } from 'react-select';
+import classNames from 'classnames';
 
 import Selector from '@/components/selectors/Selector';
 import { useAccounts } from '@/hooks/api';
 import { Account } from '@/book/entities';
+import { isAsset, isLiability } from '@/book/helpers/accountType';
+import { accountColorCode } from '@/helpers/classNames';
 
 export interface AccountSelectorProps extends SelectProps<Account, false, GroupBase<Account>> {
   ignoreAccounts?: string[],
@@ -46,8 +49,24 @@ export default function AccountSelector(
       id={id}
       getOptionLabel={(option: Account) => option.path}
       getOptionValue={(option: Account) => option.path}
-      options={options}
+      options={options.sort((a, b) => a.path.localeCompare(b.path))}
       placeholder={placeholder || 'Choose account'}
+      classNames={{
+        option: (option) => {
+          if (option.isFocused || option.isSelected) {
+            return accountColorCode(option.data, 'bg-opacity-70 text-white');
+          }
+
+          return classNames('', {
+            'text-green-600': option.data.type === 'INCOME',
+            'text-red-600/80': option.data.type === 'EXPENSE',
+            'text-violet-600': ['INVESTMENT'].includes(option.data.type),
+            'text-cyan-600': isAsset(option.data),
+            'text-orange-600': isLiability(option.data),
+            'text-cyan-700': option.data.type === 'EQUITY',
+          });
+        },
+      }}
     />
   );
 }

--- a/src/components/selectors/Selector.tsx
+++ b/src/components/selectors/Selector.tsx
@@ -64,6 +64,11 @@ export default function Selector<T extends object = {}>(
         indicatorSeparator: () => 'hidden',
         singleValue: () => '!text-inherit',
         input: () => '!text-inherit',
+        option: () => {
+          const backgroundClasses = 'bg-light-100 dark:bg-dark-800 hover:bg-white/60 dark:hover:bg-dark-700';
+          return `w-full cursor-default px-4 py-2 ${backgroundClasses}`;
+        },
+        ...props.classNames,
       }}
     />
   );

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -78,26 +78,30 @@
   }
 
   .badge {
-    @apply text-white bg-cyan-700 dark:bg-cyan-700/70 inline-block py-0.5 px-2 text-xs text-center rounded-md;
+    @apply text-white inline-block py-0.5 px-2 text-xs text-center rounded-md;
   }
 
-  .badge.success {
+  .default {
+    @apply bg-cyan-700 dark:bg-cyan-700/70;
+  }
+
+  .success {
     @apply bg-green-600;
   }
 
-  .badge.warning {
+  .warning {
     @apply bg-orange-600/70;
   }
 
-  .badge.danger {
+  .danger {
     @apply bg-red-600/70;
   }
 
-  .badge.info {
+  .info {
     @apply bg-cyan-600;
   }
 
-  .badge.misc {
+  .misc {
     @apply bg-violet-600;
   }
 
@@ -118,11 +122,7 @@
   }
 
   .selector .selector__option {
-    @apply w-full cursor-default bg-light-100 hover:bg-white/60 dark:bg-dark-800 dark:hover:bg-dark-700 px-4 py-2;
-  }
-
-  .selector .selector__option--is-selected {
-    @apply bg-white dark:bg-dark-700;
+    @apply w-full cursor-default px-4 py-2;
   }
 
   .amount-positive {

--- a/src/helpers/classNames.ts
+++ b/src/helpers/classNames.ts
@@ -1,0 +1,15 @@
+import classNames from 'classnames';
+
+import { isAsset, isInvestment, isLiability } from '@/book/helpers/accountType';
+import type { Account } from '@/book/entities';
+
+export function accountColorCode(account?: Account, defaults?: string) {
+  return classNames(defaults, {
+    misc: account && isInvestment(account),
+    default: account?.type === 'EQUITY',
+    success: account?.type === 'INCOME',
+    danger: account?.type === 'EXPENSE',
+    warning: account && isLiability(account),
+    info: account && isAsset(account),
+  });
+}

--- a/src/hooks/api/useMainCurrency.ts
+++ b/src/hooks/api/useMainCurrency.ts
@@ -9,5 +9,6 @@ export function useMainCurrency(): UseQueryResult<Commodity> {
   return useQuery({
     queryKey: [...Commodity.CACHE_KEY, { guid: 'main' }],
     queryFn: fetcher(getMainCurrency, `/${Commodity.CACHE_KEY.join('/')}/main`),
+    gcTime: Infinity,
   });
 }

--- a/src/hooks/state/useTheme.ts
+++ b/src/hooks/state/useTheme.ts
@@ -13,5 +13,6 @@ export function useTheme(): UseQueryResult<'dark' | 'light'> {
       return selectedTheme || preferredTheme;
     },
     enabled: typeof window !== 'undefined',
+    gcTime: Infinity,
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4558,10 +4558,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.3.tgz#6bda7819aae6ea0b386ebc5b24bdf602f1b42b01"
   integrity sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==
 
-"@types/node@^20.11.17":
-  version "20.11.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.17.tgz#cdd642d0e62ef3a861f88ddbc2b61e32578a9292"
-  integrity sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==
+"@types/node@^20.11.19":
+  version "20.11.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.19.tgz#b466de054e9cb5b3831bee38938de64ac7f81195"
+  integrity sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
Some minor changes including:

- Fix bug where startDate for investment charts is wrongly calculated (due to `reverse` mutation of splits)
- Change account selector to display color code according to account type
- Sort accounts in account selector
- Show focused/active element in account selector (some css priority issue was avoiding that so even though you could select with arrows, you didn't have any visual feedback).
- Now main currency is selected by default in AccountForm when no default `fk_commodity` is passed.
- mainCurrency and theme keys have now an Infinity gcTime as they never change (unless user acts on it which we manually change then in the case of theme)
- Remove Root account from account selector. We want users creating accounts within the standard Assets/L/I/E accounts