### PR TITLE
Income/Expense account mainCurrency only

### DIFF
--- a/src/__tests__/components/forms/account/AccountForm.test.tsx
+++ b/src/__tests__/components/forms/account/AccountForm.test.tsx
@@ -166,6 +166,25 @@ describe('AccountForm', () => {
     await screen.findByText('USD');
   });
 
+  it.each([
+    'INCOME', 'EXPENSE',
+  ])('hides commodity field when %s', async (type) => {
+    jest.spyOn(apiHook, 'useMainCurrency')
+      .mockReturnValue({ data: eur } as UseQueryResult<Commodity>);
+    render(
+      <AccountForm
+        action="add"
+        defaultValues={{
+          type,
+        }}
+        onSave={() => {}}
+      />,
+    );
+
+    const fieldsets = screen.getAllByRole('group');
+    expect(fieldsets[5]).toHaveClass('hidden');
+  });
+
   it('renders with defaults as expected', async () => {
     render(
       <AccountForm

--- a/src/__tests__/components/forms/account/__snapshots__/AccountForm.test.tsx.snap
+++ b/src/__tests__/components/forms/account/__snapshots__/AccountForm.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`AccountForm renders as expected with add 1`] = `
       </div>
     </fieldset>
     <fieldset
-      class="text-sm my-5"
+      class="text-sm my-5 hidden"
     >
       <label
         class="inline-block mb-2"
@@ -772,7 +772,7 @@ exports[`AccountForm renders as expected with delete 1`] = `
       </div>
     </fieldset>
     <fieldset
-      class="text-sm my-5"
+      class="text-sm my-5 hidden"
     >
       <label
         class="inline-block mb-2"
@@ -1219,7 +1219,7 @@ exports[`AccountForm renders as expected with update 1`] = `
       </div>
     </fieldset>
     <fieldset
-      class="text-sm my-5"
+      class="text-sm my-5 hidden"
     >
       <label
         class="inline-block mb-2"

--- a/src/book/__tests__/entities/Account.test.ts
+++ b/src/book/__tests__/entities/Account.test.ts
@@ -175,7 +175,32 @@ describe('Account', () => {
         fk_commodity: eur,
       });
 
-      await expect(account.save()).rejects.toThrow('checkCommodity');
+      await expect(account.save()).rejects.toThrow('checkInvestmentCommodity');
+    });
+
+    it.each([
+      'INCOME',
+      'EXPENSE',
+    ])('fails if different commodity than parent for %s', async (type) => {
+      account2 = await Account.create({
+        name: 'Name',
+        type,
+        parent: root,
+        fk_commodity: eur,
+      }).save();
+
+      const usd = await Commodity.create({
+        namespace: 'CURRENCY',
+        mnemonic: 'USD',
+      }).save();
+      account = Account.create({
+        name: 'name',
+        type,
+        parent: account2,
+        fk_commodity: usd,
+      });
+
+      await expect(account.save()).rejects.toThrow('checkIECommodity');
     });
   });
 });

--- a/src/components/forms/account/AccountForm.tsx
+++ b/src/components/forms/account/AccountForm.tsx
@@ -245,7 +245,9 @@ export default function AccountForm({
         className={classNames(
           'text-sm my-5',
           {
-            hidden: hideDefaults && defaultValues?.fk_commodity,
+            hidden: (hideDefaults && defaultValues?.fk_commodity)
+                      || type === undefined
+                      || ['INCOME', 'EXPENSE'].includes(type),
           },
         )}
       >

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -10,7 +10,6 @@ import '@/css/globals.css';
 import { Auth0Provider } from '@/lib/auth0-provider';
 import { isProd, isStaging } from '@/helpers/env';
 
-Settings.throwOnInvalid = true;
 if (isStaging()) {
   Settings.now = () => 1704067200000; // 2023-01-01
 }


### PR DESCRIPTION
Sooo this PR can be a bit controversial, I'm removing the feature of being able to have income/expense accounts in a commodity different than mainCurrency. Some reasoning here:

- When you check income/expense reports you want to see them in your main currency.
- With the current feature, it creates a bit of duality where some accounts that already existed are in EUR but some new accounts I created in SGD after I moved there. However, it's weird to have one of each and for consistency, I prefer all of them to be in EUR.

There is one use case where I think this would make sense and would be when you permanently move to another country. For this case (although not implemented yet) the recommendation anyway is to close and open a new book.