### PR TITLE
Refactor monthly aggregations

### DIFF
--- a/src/__tests__/app/dashboard/accounts/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/page.test.tsx
@@ -163,7 +163,6 @@ describe('AccountsPage', () => {
     expect(IncomeExpenseHistogram).toHaveBeenLastCalledWith(
       {
         selectedDate: DateTime.fromISO('2023-01-02'),
-        startDate: DateTime.fromISO('2022-01-01'),
       },
       {},
     );
@@ -285,7 +284,6 @@ describe('AccountsPage', () => {
     }, {});
     expect(IncomeExpenseHistogram).toHaveBeenLastCalledWith(
       {
-        startDate: date,
         selectedDate: DateTime.fromISO('2023-01-02'),
       },
       {},

--- a/src/__tests__/components/pages/accounts/AccountsTable.test.tsx
+++ b/src/__tests__/components/pages/accounts/AccountsTable.test.tsx
@@ -8,7 +8,7 @@ import Table from '@/components/Table';
 import { Account } from '@/book/entities';
 import Money from '@/book/Money';
 import * as apiHook from '@/hooks/api';
-import type { AccountsTotals } from '@/lib/queries/getAccountsTotals';
+import type { AccountsTotals } from '@/types/book';
 
 jest.mock('@/components/Table', () => jest.fn(
   () => <div data-testid="Table" />,

--- a/src/__tests__/components/pages/accounts/IncomeExpenseHistogram.test.tsx
+++ b/src/__tests__/components/pages/accounts/IncomeExpenseHistogram.test.tsx
@@ -8,7 +8,7 @@ import Bar from '@/components/charts/Bar';
 import IncomeExpenseHistogram from '@/components/pages/accounts/IncomeExpenseHistogram';
 import * as apiHook from '@/hooks/api';
 import type { Commodity } from '@/book/entities';
-import type { MonthlyTotals } from '@/lib/queries';
+import type { AccountsMonthlyTotals } from '@/types/book';
 
 jest.mock('@/components/charts/Bar', () => jest.fn(
   () => <div data-testid="Bar" />,
@@ -21,8 +21,7 @@ jest.mock('@/hooks/api', () => ({
 
 describe('IncomeExpenseHistogram', () => {
   beforeEach(() => {
-    jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-02') as DateTime<true>);
-    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<MonthlyTotals>);
+    jest.spyOn(apiHook, 'useAccountsMonthlyTotal').mockReturnValue({ data: undefined } as UseQueryResult<AccountsMonthlyTotals>);
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
   });
 
@@ -43,17 +42,17 @@ describe('IncomeExpenseHistogram', () => {
           datasets: [
             {
               backgroundColor: '#22C55E',
-              data: [],
+              data: [0, 0, 0, 0, 0, 0, 0],
               label: 'Income',
             },
             {
               backgroundColor: '#EF4444',
-              data: [],
+              data: [0, 0, 0, 0, 0, 0, 0],
               label: 'Expenses',
             },
             {
               backgroundColor: '#06B6D4',
-              data: [],
+              data: [0, 0, 0, 0, 0, 0, 0],
               label: 'Savings',
               datalabels: {
                 anchor: 'end',
@@ -66,7 +65,15 @@ describe('IncomeExpenseHistogram', () => {
               },
             },
           ],
-          labels: [],
+          labels: [
+            DateTime.now().minus({ month: 6 }),
+            expect.any(DateTime),
+            expect.any(DateTime),
+            expect.any(DateTime),
+            expect.any(DateTime),
+            expect.any(DateTime),
+            DateTime.now(),
+          ],
         },
         options: {
           layout: {
@@ -89,26 +96,6 @@ describe('IncomeExpenseHistogram', () => {
               padding: {
                 bottom: 30,
                 top: 0,
-              },
-            },
-            zoom: {
-              limits: {
-                x: {
-                  min: undefined,
-                  max: 1672617600000,
-                  minRange: 21168000000,
-                },
-              },
-              pan: {
-                mode: 'x',
-                enabled: true,
-              },
-              zoom: {
-                mode: 'x',
-                wheel: {
-                  enabled: true,
-                  modifierKey: 'meta',
-                },
               },
             },
             legend: {
@@ -134,8 +121,6 @@ describe('IncomeExpenseHistogram', () => {
               grid: {
                 display: false,
               },
-              max: DateTime.now().startOf('month').toMillis(),
-              min: DateTime.now().minus({ months: 8 }).startOf('month').toMillis(),
               ticks: {
                 align: 'center',
               },
@@ -167,7 +152,7 @@ describe('IncomeExpenseHistogram', () => {
   });
 
   it('generates datasets as expected', () => {
-    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue(
+    jest.spyOn(apiHook, 'useAccountsMonthlyTotal').mockReturnValue(
       {
         data: {
           income: {
@@ -178,13 +163,13 @@ describe('IncomeExpenseHistogram', () => {
             '11/2022': new Money(400, 'EUR'),
             '12/2022': new Money(500, 'EUR'),
           },
-        } as MonthlyTotals,
-      } as UseQueryResult<MonthlyTotals>,
+        } as AccountsMonthlyTotals,
+      } as UseQueryResult<AccountsMonthlyTotals>,
     );
 
     render(
       <IncomeExpenseHistogram
-        startDate={DateTime.fromISO('2022-09-01')}
+        selectedDate={DateTime.fromISO('2022-12-01')}
       />,
     );
 
@@ -193,24 +178,26 @@ describe('IncomeExpenseHistogram', () => {
         data: {
           datasets: [
             expect.objectContaining({
-              data: [-0, -0, 600, 400, -0],
+              data: [0, 0, 0, 0, 0, 600, 400],
               label: 'Income',
             }),
             expect.objectContaining({
-              data: [-0, -0, -400, -500, -0],
+              data: [0, 0, 0, 0, 0, -400, -500],
               label: 'Expenses',
             }),
             expect.objectContaining({
-              data: [0, 0, 200, -100, 0],
+              data: [0, 0, 0, 0, 0, 200, -100],
               label: 'Savings',
             }),
           ],
           labels: [
-            DateTime.fromISO('2022-09-01'),
-            DateTime.fromISO('2022-10-01'),
-            DateTime.fromISO('2022-11-01'),
+            DateTime.fromISO('2022-06-01'),
+            expect.any(DateTime),
+            expect.any(DateTime),
+            expect.any(DateTime),
+            expect.any(DateTime),
+            expect.any(DateTime),
             DateTime.fromISO('2022-12-01'),
-            DateTime.fromISO('2023-01-01'),
           ],
         },
       }),

--- a/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
@@ -8,7 +8,7 @@ import Pie from '@/components/charts/Pie';
 import { NetWorthPie } from '@/components/pages/accounts';
 import * as apiHook from '@/hooks/api';
 import type { Commodity } from '@/book/entities';
-import type { AccountsTotals } from '@/lib/queries/getAccountsTotals';
+import type { AccountsTotals } from '@/types/book';
 
 jest.mock('@/components/charts/Pie', () => jest.fn(
   () => <div data-testid="Pie" />,

--- a/src/__tests__/lib/queries/getAccountsTotals.test.ts
+++ b/src/__tests__/lib/queries/getAccountsTotals.test.ts
@@ -12,7 +12,7 @@ import { getAccountsTotals } from '@/lib/queries';
 import { PriceDBMap } from '@/book/prices';
 import Money from '@/book/Money';
 
-describe('getMonthlyTotals', () => {
+describe('getAccountsTotals', () => {
   let datasource: DataSource;
   let eur: Commodity;
   let root: Account;
@@ -88,7 +88,7 @@ describe('getMonthlyTotals', () => {
   it('aggregates with same currency', async () => {
     await Transaction.create({
       description: 'description',
-      date: DateTime.fromISO('2023-01-01'),
+      date: DateTime.fromISO('2022-01-01'),
       fk_currency: eur,
       splits: [
         Split.create({
@@ -109,7 +109,7 @@ describe('getMonthlyTotals', () => {
     }).save();
     await Transaction.create({
       description: 'description',
-      date: DateTime.fromISO('2023-02-01'),
+      date: DateTime.fromISO('2022-02-01'),
       fk_currency: eur,
       splits: [
         Split.create({
@@ -219,7 +219,7 @@ describe('getMonthlyTotals', () => {
 
     await Transaction.create({
       description: 'description',
-      date: DateTime.fromISO('2023-01-01'),
+      date: DateTime.fromISO('2022-01-01'),
       fk_currency: eur,
       splits: [
         Split.create({
@@ -240,7 +240,7 @@ describe('getMonthlyTotals', () => {
     }).save();
     await Transaction.create({
       description: 'description',
-      date: DateTime.fromISO('2023-02-01'),
+      date: DateTime.fromISO('2022-02-01'),
       fk_currency: eur,
       splits: [
         Split.create({

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -124,7 +124,6 @@ export default function AccountsPage(): JSX.Element {
           </div>
           <div className="card col-span-8">
             <IncomeExpenseHistogram
-              startDate={earliestDate}
               selectedDate={selectedDate}
             />
           </div>

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -286,7 +286,7 @@ describe('caching', () => {
 
     await tx.save();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(6);
+    expect(mockInvalidateQueries).toBeCalledTimes(7);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', { name: 'latest' }],
     });
@@ -304,6 +304,9 @@ describe('caching', () => {
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'splits', { aggregation: 'total' }],
+    });
+    expect(mockInvalidateQueries).toBeCalledWith({
+      queryKey: ['api', 'splits', { aggregation: 'monthlyTotal' }],
     });
   });
 
@@ -320,7 +323,7 @@ describe('caching', () => {
 
     await tx.remove();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(6);
+    expect(mockInvalidateQueries).toBeCalledTimes(7);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', { name: 'latest' }],
     });
@@ -338,6 +341,9 @@ describe('caching', () => {
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'splits', { aggregation: 'total' }],
+    });
+    expect(mockInvalidateQueries).toBeCalledWith({
+      queryKey: ['api', 'splits', { aggregation: 'monthlyTotal' }],
     });
   });
 });

--- a/src/book/__tests__/models/InvestmentAccount.test.ts
+++ b/src/book/__tests__/models/InvestmentAccount.test.ts
@@ -293,7 +293,7 @@ describe('InvestmentAccount', () => {
       await Transaction.create({
         description: 'description',
         fk_currency: stockCurrency,
-        date: DateTime.fromISO('2023-01-01'),
+        date: DateTime.fromISO('2022-01-01'),
         splits: [
           // Purchase 122.85 stocks for 1000EUR
           {
@@ -316,7 +316,7 @@ describe('InvestmentAccount', () => {
       currencyPrice = await Price.create({
         fk_commodity: stockCurrency,
         fk_currency: mainCommodity,
-        date: DateTime.fromISO('2023-01-01'),
+        date: DateTime.fromISO('2022-01-01'),
         source: `maffin::{"price":${txExchangeRate},"changePct":-1,"changeAbs":-1,"currency":"${currency}"}`,
         valueNum: txExchangeRate * 10000,
         valueDenom: 10000,
@@ -381,7 +381,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-10'),
+          date: DateTime.fromISO('2022-01-10'),
           splits: [
             {
               valueNum: 1700,
@@ -403,7 +403,7 @@ describe('InvestmentAccount', () => {
         const currencyPrice2 = await Price.create({
           fk_commodity: stockCurrency,
           fk_currency: mainCommodity,
-          date: DateTime.fromISO('2023-01-10'),
+          date: DateTime.fromISO('2022-01-10'),
           source: `maffin::{"price":0.9056,"changePct":-1,"changeAbs":-1,"currency":"${currency}"}`,
           valueNum: currency === mainCurrency ? 10000 : 9056,
           valueDenom: 10000,
@@ -454,7 +454,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               valueNum: -1000,
@@ -511,7 +511,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               guid: 'split_guid_3',
@@ -575,7 +575,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               valueNum: -500,
@@ -638,7 +638,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               valueNum: -1000,
@@ -700,7 +700,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               valueNum: -250,
@@ -767,7 +767,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               valueNum: 0,
@@ -820,7 +820,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               valueNum: 0,
@@ -890,7 +890,7 @@ describe('InvestmentAccount', () => {
         tx = await Transaction.create({
           description: 'description',
           fk_currency: stockCurrency,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             // This split is used to associate the STOCK it comes from
             {
@@ -955,7 +955,7 @@ describe('InvestmentAccount', () => {
 
         expect(instance.dividends[0].amount.toString()).toEqual(`89.67 ${currency}`);
         expect(instance.dividends[0].amountInCurrency.toString()).toEqual(expected.toString());
-        expect(instance.dividends[0].when.toISODate()).toEqual('2023-01-02');
+        expect(instance.dividends[0].when.toISODate()).toEqual('2022-01-02');
       });
 
       /**
@@ -990,7 +990,7 @@ describe('InvestmentAccount', () => {
         await Transaction.create({
           description: 'description',
           fk_currency: eur,
-          date: DateTime.fromISO('2023-01-02'),
+          date: DateTime.fromISO('2022-01-02'),
           splits: [
             {
               valueNum: 0,
@@ -1139,7 +1139,7 @@ describe('InvestmentAccount', () => {
       await Transaction.create({
         description: 'description',
         fk_currency: stockCommodity,
-        date: DateTime.fromISO('2023-01-02'),
+        date: DateTime.fromISO('2022-01-02'),
         splits: [
           {
             valueNum: 10,

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -135,6 +135,10 @@ export async function updateCache(
   queryClient.invalidateQueries({
     queryKey: [...Split.CACHE_KEY, { aggregation: 'total' }],
   });
+
+  queryClient.invalidateQueries({
+    queryKey: [...Split.CACHE_KEY, { aggregation: 'monthlyTotal' }],
+  });
 }
 
 // https://github.com/typeorm/typeorm/issues/4714

--- a/src/components/pages/accounts/MonthlyTotalHistogram.tsx
+++ b/src/components/pages/accounts/MonthlyTotalHistogram.tsx
@@ -4,7 +4,7 @@ import type { ChartDataset } from 'chart.js';
 
 import Bar from '@/components/charts/Bar';
 import type { Account } from '@/book/entities';
-import { useAccountsTotals, useMainCurrency } from '@/hooks/api';
+import { useAccountsMonthlyTotal, useMainCurrency } from '@/hooks/api';
 import { moneyToString } from '@/helpers/number';
 
 export type MonthlyTotalHistogramProps = {
@@ -15,24 +15,19 @@ export type MonthlyTotalHistogramProps = {
 
 export default function MonthlyTotalHistogram({
   title,
-  selectedDate = DateTime.now().minus({ months: 4 }),
+  selectedDate = DateTime.now(),
   accounts = [],
 }: MonthlyTotalHistogramProps): JSX.Element {
-  const { data: monthlyTotals } = useAccountsTotals();
-  const now = DateTime.now();
+  const interval = Interval.fromDateTimes(
+    selectedDate.minus({ months: 6 }).startOf('month'),
+    selectedDate.endOf('month'),
+  );
+  const { data: monthlyTotals } = useAccountsMonthlyTotal(interval);
 
   const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
-  if (now.diff(selectedDate, ['months']).months < 4) {
-    selectedDate = now.minus({ months: 4 });
-  }
-  const interval = Interval.fromDateTimes(
-    selectedDate.minus({ months: 5 }),
-    selectedDate.plus({ months: 4 }),
-  );
-
-  const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).plus({ month: 1 }).startOf('month'));
+  const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).startOf('month'));
 
   const datasets: ChartDataset<'bar'>[] = [];
 

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -17,6 +17,7 @@ export {
   useSplitsCount,
   useAccountTotal,
   useAccountsTotal,
+  useAccountsMonthlyTotal,
 } from '@/hooks/api/useSplits';
 export { usePrices } from '@/hooks/api/usePrices';
 export { useMainCurrency } from '@/hooks/api/useMainCurrency';

--- a/src/lib/queries/getAccountsTotals.ts
+++ b/src/lib/queries/getAccountsTotals.ts
@@ -4,12 +4,8 @@ import Money from '@/book/Money';
 import { Commodity, Split } from '@/book/entities';
 import type { Account } from '@/book/entities';
 import mapAccounts from '@/helpers/mapAccounts';
-import type { AccountsMap } from '@/types/book';
+import type { AccountsMap, AccountsTotals } from '@/types/book';
 import type { PriceDBMap } from '@/book/prices';
-
-export type AccountsTotals = {
-  [guid: string]: Money;
-};
 
 export default async function getAccountsTotals(
   accounts: Account[],

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -38,4 +38,4 @@ window.matchMedia = jest.fn().mockReturnValue({ matches: true });
 
 Settings.defaultZone = 'utc';
 Settings.throwOnInvalid = true;
-Settings.now = () => 1704067200000; // 2023-01-01
+Settings.now = () => 1672531200000; // 2023-01-01

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -6,3 +6,13 @@ export type AccountsTree = {
   account: Account,
   leaves: AccountsTree[],
 };
+
+export type AccountsTotals = {
+  [guid: string]: Money;
+};
+
+export type AccountsMonthlyTotals = {
+  [guid: string]: {
+    [yearMonth: string]: Money,
+  },
+};


### PR DESCRIPTION
Move to a more granular/paginated approach for calculating totals for accounts (either absolute total or monthly aggregation).

This covers most of the home aggregations except the networth histogram which is a bit more complicating and will be doing in subsequent PRs. So far I've been mixing concepts a bit. When saying monthly aggregation it's actually two different things:

- For Income/Expense account it's usually a histogram that shows monthly splits
- For Assets though, what we want to show is the net worth on that specific month and its progression. We don't have many cases to show monthly splits for an Asset account except for maybe in the account detail page