### PR TITLE
Extract aggregate children totals

### DIFF
--- a/src/__tests__/components/pages/accounts/AccountsTable.test.tsx
+++ b/src/__tests__/components/pages/accounts/AccountsTable.test.tsx
@@ -107,7 +107,7 @@ describe('AccountsTable', () => {
       {
         data: {
           a1: new Money(300, 'EUR'),
-          a2: new Money(-100, 'EUR'),
+          a2: new Money(100, 'EUR'),
         } as AccountsTotals,
       } as UseQueryResult<AccountsTotals>,
     );

--- a/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
+++ b/src/__tests__/components/pages/accounts/NetWorthPie.test.tsx
@@ -76,7 +76,7 @@ describe('NetWorthPie', () => {
       {
         data: {
           type_asset: new Money(1500, 'EUR'),
-          type_liability: new Money(-150, 'EUR'),
+          type_liability: new Money(150, 'EUR'),
         } as AccountsTotals,
       } as UseQueryResult<AccountsTotals>,
     );

--- a/src/__tests__/helpers/aggregateChildrenTotals.test.ts
+++ b/src/__tests__/helpers/aggregateChildrenTotals.test.ts
@@ -1,0 +1,324 @@
+import { DateTime } from 'luxon';
+
+import aggregateChildrenTotals from '@/helpers/aggregateChildrenTotals';
+import Money from '@/book/Money';
+import { PriceDBMap } from '@/book/prices';
+import { Price } from '@/book/entities';
+import type { Account, Commodity } from '@/book/entities';
+
+describe('aggregateChildrenTotals', () => {
+  let eur: Commodity;
+  let accounts: Account[];
+
+  beforeEach(() => {
+    jest.spyOn(Price, 'create').mockReturnValue({ guid: 'missing_price' } as Price);
+    eur = {
+      guid: 'eur',
+      namespace: 'CURRENCY',
+      mnemonic: 'EUR',
+    } as Commodity;
+
+    accounts = [
+      {
+        guid: 'root',
+        name: 'Root',
+        type: 'ROOT',
+        childrenIds: ['a1', 'a2', 'a3', 'a4'],
+      } as Account,
+      {
+        guid: 'a1',
+        type: 'ASSET',
+        commodity: eur,
+        parentId: 'root',
+        childrenIds: [] as string[],
+      } as Account,
+      {
+        guid: 'a2',
+        type: 'LIABILITY',
+        commodity: eur,
+        parentId: 'root',
+        childrenIds: [] as string[],
+      } as Account,
+      {
+        guid: 'a3',
+        type: 'INCOME',
+        commodity: eur,
+        parentId: 'root',
+        childrenIds: [] as string[],
+      } as Account,
+      {
+        guid: 'a4',
+        type: 'EXPENSE',
+        commodity: eur,
+        parentId: 'root',
+        childrenIds: [] as string[],
+      } as Account,
+    ];
+  });
+
+  it('creates default account type entries', () => {
+    const totals = aggregateChildrenTotals(
+      'root',
+      accounts,
+      {} as PriceDBMap,
+      DateTime.now(),
+      {},
+    );
+
+    expect(totals.type_asset.toString()).toEqual('0.00 EUR');
+    expect(totals.type_liability.toString()).toEqual('0.00 EUR');
+    expect(totals.type_income.toString()).toEqual('0.00 EUR');
+    expect(totals.type_expense.toString()).toEqual('0.00 EUR');
+  });
+
+  it('aggregates children with same currency', () => {
+    accounts[4].childrenIds = ['a5', 'a6'];
+    accounts = [
+      ...accounts,
+      {
+        guid: 'a5',
+        type: 'EXPENSE',
+        commodity: eur,
+        parentId: 'a4',
+        childrenIds: [] as string[],
+      } as Account,
+      {
+        guid: 'a6',
+        type: 'EXPENSE',
+        commodity: eur,
+        parentId: 'a4',
+        childrenIds: [] as string[],
+      } as Account,
+    ];
+
+    const totals = {
+      a5: new Money(500, 'EUR'),
+      a6: new Money(200, 'EUR'),
+    };
+    const aggregatedTotals = aggregateChildrenTotals(
+      'root',
+      accounts,
+      {} as PriceDBMap,
+      DateTime.now(),
+      totals,
+    );
+
+    expect(aggregatedTotals.type_expense.toString()).toEqual('700.00 EUR');
+    expect(aggregatedTotals.a5.toString()).toEqual('500.00 EUR');
+    expect(aggregatedTotals.a6.toString()).toEqual('200.00 EUR');
+
+    // Check that we don't modify original totals
+    expect(Object.keys(totals)).toHaveLength(2);
+  });
+
+  it('aggregates children with different currency', () => {
+    const usd = {
+      guid: 'usd',
+      mnemonic: 'USD',
+      namespace: 'CURRENCY',
+    };
+
+    accounts[4].childrenIds = ['a5', 'a6'];
+    accounts = [
+      ...accounts,
+      {
+        guid: 'a5',
+        type: 'EXPENSE',
+        commodity: eur,
+        parentId: 'a4',
+        childrenIds: [] as string[],
+      } as Account,
+      {
+        guid: 'a6',
+        type: 'EXPENSE',
+        commodity: usd,
+        parentId: 'a4',
+        childrenIds: [] as string[],
+      } as Account,
+    ];
+
+    const prices = [
+      {
+        date: DateTime.now(),
+        value: 0.9,
+        commodity: usd,
+        currency: eur,
+      },
+    ] as Price[];
+
+    const totals = aggregateChildrenTotals(
+      'root',
+      accounts,
+      new PriceDBMap(prices),
+      DateTime.now(),
+      {
+        a5: new Money(500, 'EUR'),
+        a6: new Money(200, 'USD'),
+      },
+    );
+
+    // 500 + 200 * 0.8
+    expect(totals.type_expense.toString()).toEqual('680.00 EUR');
+    expect(totals.a5.toString()).toEqual('500.00 EUR');
+    expect(totals.a6.toString()).toEqual('200.00 USD');
+  });
+
+  it('aggregates children with different currency and specific date', () => {
+    const usd = {
+      guid: 'usd',
+      mnemonic: 'USD',
+      namespace: 'CURRENCY',
+    };
+
+    accounts[4].childrenIds = ['a5', 'a6'];
+    accounts = [
+      ...accounts,
+      {
+        guid: 'a5',
+        type: 'EXPENSE',
+        commodity: eur,
+        parentId: 'a4',
+        childrenIds: [] as string[],
+      } as Account,
+      {
+        guid: 'a6',
+        type: 'EXPENSE',
+        commodity: usd,
+        parentId: 'a4',
+        childrenIds: [] as string[],
+      } as Account,
+    ];
+
+    const prices = [
+      {
+        date: DateTime.now().minus({ month: 1 }),
+        value: 0.8,
+        commodity: usd,
+        currency: eur,
+      },
+      {
+        date: DateTime.now(),
+        value: 0.9,
+        commodity: usd,
+        currency: eur,
+      },
+    ] as Price[];
+
+    const totals = aggregateChildrenTotals(
+      'root',
+      accounts,
+      new PriceDBMap(prices),
+      DateTime.now().minus({ month: 1 }),
+      {
+        a5: new Money(500, 'EUR'),
+        a6: new Money(200, 'USD'),
+      },
+    );
+
+    // 500 + 200 * 0.8
+    expect(totals.type_expense.toString()).toEqual('660.00 EUR');
+    expect(totals.a5.toString()).toEqual('500.00 EUR');
+    expect(totals.a6.toString()).toEqual('200.00 USD');
+  });
+
+  it('aggregates children that are stocks', () => {
+    const usd = {
+      guid: 'usd',
+      mnemonic: 'USD',
+      namespace: 'CURRENCY',
+    };
+
+    const ticker1 = {
+      guid: 'ticker1',
+      mnemonic: 'TICKER1',
+      namespace: 'CUSTOM',
+    };
+
+    const ticker2 = {
+      guid: 'ticker2',
+      mnemonic: 'TICKER2',
+      namespace: 'STOCK',
+    };
+
+    accounts[1].childrenIds = ['a5', 'a6'];
+    accounts = [
+      ...accounts,
+      {
+        guid: 'a5',
+        type: 'INVESTMENT',
+        commodity: ticker1,
+        parentId: 'a1',
+        childrenIds: [] as string[],
+      } as Account,
+      {
+        guid: 'a6',
+        type: 'INVESTMENT',
+        commodity: ticker2,
+        parentId: 'a1',
+        childrenIds: [] as string[],
+      } as Account,
+    ];
+
+    const prices = [
+      {
+        date: DateTime.now(),
+        value: 100,
+        commodity: ticker1,
+        currency: eur,
+      },
+      {
+        date: DateTime.now(),
+        value: 50,
+        commodity: ticker2,
+        currency: usd,
+      },
+      {
+        date: DateTime.now(),
+        value: 0.9,
+        commodity: usd,
+        currency: eur,
+      },
+    ] as Price[];
+
+    const totals = aggregateChildrenTotals(
+      'root',
+      accounts,
+      new PriceDBMap(prices),
+      DateTime.now(),
+      {
+        a5: new Money(2, 'TICKER1'),
+        a6: new Money(5, 'TICKER2'),
+      },
+    );
+
+    // 2 * 100 + 5 * 50 * 0.9
+    expect(totals.type_asset.toString()).toEqual('425.00 EUR');
+    expect(totals.a5.toString()).toEqual('2.00 TICKER1');
+    expect(totals.a6.toString()).toEqual('5.00 TICKER2');
+  });
+
+  it('works with children without totals', () => {
+    accounts[4].childrenIds = ['a5'];
+    accounts = [
+      ...accounts,
+      {
+        guid: 'a5',
+        type: 'INVESTMENT',
+        commodity: eur,
+        parentId: 'a1',
+        childrenIds: [] as string[],
+      } as Account,
+    ];
+
+    const totals = aggregateChildrenTotals(
+      'root',
+      accounts,
+      {} as PriceDBMap,
+      DateTime.now(),
+      {},
+    );
+
+    expect(totals.type_asset.toString()).toEqual('0.00 EUR');
+    expect(totals.a5.toString()).toEqual('0.00 EUR');
+  });
+});

--- a/src/__tests__/lib/queries/getAccountsTotals.test.ts
+++ b/src/__tests__/lib/queries/getAccountsTotals.test.ts
@@ -11,6 +11,12 @@ import {
 import { getAccountsTotals } from '@/lib/queries';
 import { PriceDBMap } from '@/book/prices';
 import Money from '@/book/Money';
+import * as aggregateChildrenTotals from '@/helpers/aggregateChildrenTotals';
+
+jest.mock('@/helpers/aggregateChildrenTotals', () => ({
+  __esModule: true,
+  ...jest.requireActual('@/helpers/aggregateChildrenTotals'),
+}));
 
 describe('getAccountsTotals', () => {
   let datasource: DataSource;
@@ -20,6 +26,7 @@ describe('getAccountsTotals', () => {
   let expensesAccount: Account;
 
   beforeEach(async () => {
+    jest.spyOn(aggregateChildrenTotals, 'default').mockReturnValue({ totals: new Money(0, 'EUR') });
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
@@ -66,26 +73,33 @@ describe('getAccountsTotals', () => {
     await datasource.destroy();
   });
 
-  it('returns empty when no accounts', async () => {
-    const totals = await getAccountsTotals([], {} as PriceDBMap, DateTime.now());
+  it('calls with expected params whe no accounts', async () => {
+    await getAccountsTotals([], {} as PriceDBMap, DateTime.now());
 
-    expect(totals).toEqual({});
+    expect(aggregateChildrenTotals.default).toBeCalledWith('type_root', [], {}, DateTime.now(), {});
   });
 
-  it('returns empty for accounts without splits', async () => {
-    const totals = await getAccountsTotals(
+  it('calls with expected params when accounts without splits', async () => {
+    await getAccountsTotals(
       [root, assetAccount, expensesAccount],
       {} as PriceDBMap,
       DateTime.now(),
     );
 
-    expect(totals[assetAccount.guid].toString()).toEqual(new Money(0, 'EUR').toString());
-    expect(totals[expensesAccount.guid].toString()).toEqual(new Money(0, 'EUR').toString());
-    expect(totals.type_asset.toString()).toEqual(new Money(0, 'EUR').toString());
-    expect(totals.type_expense.toString()).toEqual(new Money(0, 'EUR').toString());
+    expect(aggregateChildrenTotals.default).toBeCalledWith(
+      'type_root',
+      [
+        root,
+        assetAccount,
+        expensesAccount,
+      ],
+      {},
+      DateTime.now(),
+      {},
+    );
   });
 
-  it('aggregates with same currency', async () => {
+  it('sums splits and calls as expected', async () => {
     await Transaction.create({
       description: 'description',
       date: DateTime.fromISO('2022-01-01'),
@@ -129,16 +143,28 @@ describe('getAccountsTotals', () => {
       ],
     }).save();
 
-    const totals = await getAccountsTotals(
+    await getAccountsTotals(
       [root, assetAccount, expensesAccount],
       {} as PriceDBMap,
       DateTime.now(),
     );
 
-    expect(totals[assetAccount.guid].toString()).toEqual(new Money(-300, 'EUR').toString());
-    expect(totals[expensesAccount.guid].toString()).toEqual(new Money(300, 'EUR').toString());
-    expect(totals.type_asset.toString()).toEqual(new Money(-300, 'EUR').toString());
-    expect(totals.type_expense.toString()).toEqual(new Money(300, 'EUR').toString());
+    expect(aggregateChildrenTotals.default).toBeCalledWith(
+      'type_root',
+      [root, assetAccount, expensesAccount],
+      {},
+      DateTime.now(),
+      {
+        abcdef: expect.any(Money),
+        ghijk: expect.any(Money),
+      },
+    );
+    expect(
+      (aggregateChildrenTotals.default as jest.Mock).mock.calls[0][4].abcdef.toString(),
+    ).toEqual('300.00 EUR');
+    expect(
+      (aggregateChildrenTotals.default as jest.Mock).mock.calls[0][4].ghijk.toString(),
+    ).toEqual('300.00 EUR');
   });
 
   it('filters by date', async () => {
@@ -185,271 +211,17 @@ describe('getAccountsTotals', () => {
       ],
     }).save();
 
-    const totals = await getAccountsTotals(
+    await getAccountsTotals(
       [root, assetAccount, expensesAccount],
       {} as PriceDBMap,
       DateTime.fromISO('2023-01-10'),
     );
 
-    expect(totals[assetAccount.guid].toString()).toEqual(new Money(-100, 'EUR').toString());
-    expect(totals[expensesAccount.guid].toString()).toEqual(new Money(100, 'EUR').toString());
-  });
-
-  /**
-   * While income and expense accounts can only be in main currency, asset
-   * and liability accounts can be in any commodity. When calculating aggregate
-   * we want to convert all the quantities to main currency so we have an accurate
-   * total.
-   */
-  it('aggregates with different currency', async () => {
-    const usd = await Commodity.create({
-      mnemonic: 'USD',
-      namespace: 'CURRENCY',
-    }).save();
-
-    const bankAccount = await Account.create({
-      name: 'Bank',
-      fk_commodity: usd,
-      parent: assetAccount,
-      type: 'BANK',
-    }).save();
-    // refresh childrenIds
-    await bankAccount.reload();
-    await assetAccount.reload();
-
-    await Transaction.create({
-      description: 'description',
-      date: DateTime.fromISO('2022-01-01'),
-      fk_currency: eur,
-      splits: [
-        Split.create({
-          valueNum: 100,
-          valueDenom: 1,
-          quantityNum: 100,
-          quantityDenom: 1,
-          fk_account: expensesAccount,
-        }),
-        Split.create({
-          valueNum: -100,
-          valueDenom: 1,
-          quantityNum: -107.71,
-          quantityDenom: 1,
-          fk_account: bankAccount,
-        }),
-      ],
-    }).save();
-    await Transaction.create({
-      description: 'description',
-      date: DateTime.fromISO('2022-02-01'),
-      fk_currency: eur,
-      splits: [
-        Split.create({
-          valueNum: 200,
-          valueDenom: 1,
-          quantityNum: 200,
-          quantityDenom: 1,
-          fk_account: expensesAccount,
-        }),
-        Split.create({
-          valueNum: -200,
-          valueDenom: 1,
-          quantityNum: -215.42,
-          quantityDenom: 1,
-          fk_account: bankAccount,
-        }),
-      ],
-    }).save();
-
-    const todayUSDEURPrice = await Price.create({
-      valueNum: 9284,
-      valueDenom: 10000,
-      date: DateTime.now(),
-      fk_commodity: usd,
-      fk_currency: eur,
-    }).save();
-
-    const totals = await getAccountsTotals(
-      [root, assetAccount, expensesAccount, bankAccount],
-      new PriceDBMap([todayUSDEURPrice]),
-      DateTime.now(),
-    );
-
-    expect(totals[bankAccount.guid].toString()).toEqual(new Money(-323.13, 'USD').toString());
-    expect(totals.type_asset.toString()).toEqual(new Money(-300, 'EUR').toString());
-    expect(totals.type_expense.toString()).toEqual(new Money(300, 'EUR').toString());
-  });
-
-  /**
-   * Same as above but when a selectedDate is passed, the exchange rate is
-   * for that day
-   */
-  it('picks exchange rate from selectedDate', async () => {
-    const usd = await Commodity.create({
-      mnemonic: 'USD',
-      namespace: 'CURRENCY',
-    }).save();
-
-    const bankAccount = await Account.create({
-      name: 'Bank',
-      fk_commodity: usd,
-      parent: assetAccount,
-      type: 'BANK',
-    }).save();
-    // refresh childrenIds
-    await bankAccount.reload();
-    await assetAccount.reload();
-
-    await Transaction.create({
-      description: 'description',
-      date: DateTime.fromISO('2023-01-01'),
-      fk_currency: eur,
-      splits: [
-        Split.create({
-          valueNum: 100,
-          valueDenom: 1,
-          quantityNum: 100,
-          quantityDenom: 1,
-          fk_account: expensesAccount,
-        }),
-        Split.create({
-          valueNum: -100,
-          valueDenom: 1,
-          quantityNum: -107.71,
-          quantityDenom: 1,
-          fk_account: bankAccount,
-        }),
-      ],
-    }).save();
-    await Transaction.create({
-      description: 'description',
-      date: DateTime.fromISO('2023-02-01'),
-      fk_currency: eur,
-      splits: [
-        Split.create({
-          valueNum: 200,
-          valueDenom: 1,
-          quantityNum: 200,
-          quantityDenom: 1,
-          fk_account: expensesAccount,
-        }),
-        Split.create({
-          valueNum: -200,
-          valueDenom: 1,
-          quantityNum: -215.42,
-          quantityDenom: 1,
-          fk_account: bankAccount,
-        }),
-      ],
-    }).save();
-
-    const todayUSDEURPrice = await Price.create({
-      valueNum: 9284,
-      valueDenom: 10000,
-      date: DateTime.now(),
-      fk_commodity: usd,
-      fk_currency: eur,
-    }).save();
-
-    const selectedUSDEURPrice = await Price.create({
-      valueNum: 8000,
-      valueDenom: 10000,
-      date: DateTime.fromISO('2023-02-01'),
-      fk_commodity: usd,
-      fk_currency: eur,
-    }).save();
-
-    const totals = await getAccountsTotals(
-      [root, assetAccount, expensesAccount, bankAccount],
-      new PriceDBMap([todayUSDEURPrice, selectedUSDEURPrice]),
-      DateTime.fromISO('2023-02-01'),
-    );
-
-    expect(totals[bankAccount.guid].toString()).toEqual(new Money(-323.13, 'USD').toString());
-    // Asset and Expense account having different total amounts may be counter intuitive
-    // but this is the right thing:
-    //
-    // - Asset accounts reflect the net worth for the given date. I.e. if you have 300 USD
-    //   but the exchange rate at the selected date is 0.8, then that's your asset value
-    // - Expense accounts reflect what you spent at the time you did. Their value is
-    //   retrieved from the value field specified in the field and it doesn't depend on
-    //   exchange rate of the passed date or today's
-    expect(totals.type_asset.toString()).toEqual(new Money(-258.51, 'EUR').toString());
-    expect(totals.type_expense.toString()).toEqual(new Money(300, 'EUR').toString());
-  });
-
-  /**
-   * All investment commodities must have an associated currency. When aggregating
-   * investment accounts, we retrieve the price of that stock/ticker. If the currency
-   * associated to that stock is different to the parent's account, then we convert
-   * it to that currency
-   */
-  it('aggregates for stock account', async () => {
-    const usd = await Commodity.create({
-      mnemonic: 'USD',
-      namespace: 'CURRENCY',
-    }).save();
-    const ticker = await Commodity.create({
-      mnemonic: 'TICKER',
-      namespace: 'CUSTOM',
-    }).save();
-
-    const stockAccount = await Account.create({
-      name: 'STOCK',
-      fk_commodity: ticker,
-      parent: assetAccount,
-      type: 'INVESTMENT',
-    }).save();
-    // refresh childrenIds
-    await stockAccount.reload();
-    await assetAccount.reload();
-
-    await Transaction.create({
-      description: 'description',
-      date: DateTime.fromISO('2023-01-01'),
-      fk_currency: eur,
-      splits: [
-        Split.create({
-          valueNum: -1000,
-          valueDenom: 1,
-          quantityNum: -1000,
-          quantityDenom: 1,
-          fk_account: assetAccount,
-        }),
-        Split.create({
-          valueNum: 1000,
-          valueDenom: 1,
-          quantityNum: 2,
-          quantityDenom: 1,
-          fk_account: stockAccount,
-        }),
-      ],
-    }).save();
-
-    const todayUSDEURPrice = await Price.create({
-      valueNum: 9284,
-      valueDenom: 10000,
-      date: DateTime.now(),
-      fk_commodity: usd,
-      fk_currency: eur,
-    }).save();
-
-    const todayStockPrice = await Price.create({
-      valueNum: 600,
-      valueDenom: 1,
-      date: DateTime.now(),
-      fk_commodity: ticker,
-      fk_currency: eur,
-    }).save();
-
-    const totals = await getAccountsTotals(
-      [root, assetAccount, expensesAccount, stockAccount],
-      new PriceDBMap([todayUSDEURPrice, todayStockPrice]),
-      DateTime.now(),
-    );
-
-    expect(totals[stockAccount.guid].toString()).toEqual(new Money(2, 'TICKER').toString());
-    // We get 200 here because we bought 2 stocks at price of 1000 but when converting
-    // with today's price we get 1200 (1 is 600) so it's a benefit of 200
-    expect(totals.type_asset.toString()).toEqual(new Money(200, 'EUR').toString());
+    expect(
+      (aggregateChildrenTotals.default as jest.Mock).mock.calls[0][4].abcdef.toString(),
+    ).toEqual('100.00 EUR');
+    expect(
+      (aggregateChildrenTotals.default as jest.Mock).mock.calls[0][4].ghijk.toString(),
+    ).toEqual('100.00 EUR');
   });
 });

--- a/src/components/pages/accounts/AccountsTable.tsx
+++ b/src/components/pages/accounts/AccountsTable.tsx
@@ -9,9 +9,6 @@ import Money from '@/book/Money';
 import Table from '@/components/Table';
 import type { AccountsMap } from '@/types/book';
 import { Account } from '@/book/entities';
-import {
-  isLiability,
-} from '@/book/helpers/accountType';
 import { useAccounts, useAccountsTotal } from '@/hooks/api';
 import mapAccounts from '@/helpers/mapAccounts';
 import { accountColorCode } from '@/helpers/classNames';
@@ -79,7 +76,7 @@ function getTreeTotals(
 
   return {
     account: current,
-    total: current.type === 'INCOME' || isLiability(current) ? accountTotal.multiply(-1) : accountTotal,
+    total: accountTotal,
     leaves,
   };
 }

--- a/src/components/pages/accounts/NetWorthPie.tsx
+++ b/src/components/pages/accounts/NetWorthPie.tsx
@@ -29,7 +29,7 @@ export default function NetWorthPie({
           datasets: [
             {
               backgroundColor: ['#06B6D4', '#F97316'],
-              data: [assetsTotal.toNumber(), Math.abs(liabilitiesTotal.toNumber())],
+              data: [assetsTotal.toNumber(), liabilitiesTotal.toNumber()],
             },
           ],
         }}
@@ -63,7 +63,7 @@ export default function NetWorthPie({
       <div className="-mt-12">
         <p className="flex justify-center">Net worth</p>
         <p className="flex justify-center text-xl">
-          {moneyToString(assetsTotal.toNumber() + liabilitiesTotal.toNumber(), unit)}
+          {moneyToString(assetsTotal.toNumber() - liabilitiesTotal.toNumber(), unit)}
         </p>
       </div>
     </>

--- a/src/helpers/aggregateChildrenTotals.ts
+++ b/src/helpers/aggregateChildrenTotals.ts
@@ -1,0 +1,102 @@
+import { DateTime } from 'luxon';
+
+import Money from '@/book/Money';
+import { Account, Commodity } from '@/book/entities';
+import type { AccountsTotals, AccountsMap } from '@/types/book';
+import type { PriceDBMap } from '@/book/prices';
+import mapAccounts from './mapAccounts';
+
+/**
+ * Given an AccountsTotal, aggregate the totals of the children into
+ * their the account identified by 'guid'.
+ *
+ * If the children have different commodities, convert
+ * them accordingly.
+ */
+export default function aggregateChildrenTotals(
+  guid: string,
+  accounts: Account[],
+  prices: PriceDBMap,
+  selectedDate: DateTime,
+  totals: AccountsTotals,
+): AccountsTotals {
+  const accountsMap = mapAccounts(accounts);
+  const aggregatedTotals: AccountsTotals = {};
+  accountsMap[guid].childrenIds.forEach((childId: string) => {
+    aggregate(
+      childId,
+      accountsMap,
+      prices,
+      selectedDate,
+      totals,
+      aggregatedTotals,
+    );
+
+    aggregatedTotals[`type_${accountsMap[childId].type.toLowerCase()}`] = aggregatedTotals[childId];
+  });
+
+  return aggregatedTotals;
+}
+
+function aggregate(
+  guid: string,
+  accounts: AccountsMap,
+  prices: PriceDBMap,
+  selectedDate: DateTime,
+  totals: AccountsTotals,
+  aggregatedTotals: AccountsTotals,
+): Money {
+  const current = accounts[guid];
+  aggregatedTotals[current.guid] = totals[current.guid] || new Money(0, current.commodity.mnemonic);
+
+  current.childrenIds.forEach((childId: string) => {
+    aggregatedTotals[current.guid] = aggregatedTotals[current.guid].add(
+      convertToParentCommodity(
+        aggregate(childId, accounts, prices, selectedDate, totals, aggregatedTotals),
+        accounts[childId].commodity,
+        current.commodity,
+        prices,
+        selectedDate,
+      ),
+    );
+  });
+
+  return aggregatedTotals[current.guid];
+}
+
+/**
+ * Given a Money amount it converts it to the specified currency in parameter
+ * to.
+ *
+ * If the passed commodity in from is an investment, we retrieve the price of the
+ * stock and if the currency of the stock doesn't match the specified currency,
+ * we re-convert again
+ */
+function convertToParentCommodity(
+  amount: Money,
+  from: Commodity,
+  to: Commodity,
+  prices: PriceDBMap,
+  selectedDate: DateTime,
+): Money {
+  let rate = 1;
+  let currency = from;
+
+  if (currency.namespace !== 'CURRENCY') {
+    const stockPrice = prices.getInvestmentPrice(
+      currency.mnemonic,
+      selectedDate,
+    );
+    rate = stockPrice.value;
+    currency = stockPrice.currency;
+  }
+  if (currency.guid !== to.guid) {
+    rate *= prices.getPrice(
+      currency.mnemonic,
+      to.mnemonic,
+      selectedDate,
+    ).value;
+  }
+
+  return amount.convert(to.mnemonic, rate);
+}

--- a/src/hooks/api/useSplits.ts
+++ b/src/hooks/api/useSplits.ts
@@ -1,4 +1,5 @@
 import {
+  useQueries,
   useQuery,
   UseQueryResult,
 } from '@tanstack/react-query';
@@ -142,7 +143,7 @@ export function useAccountTotal(
  * by accumulating the splits for each account plus the total of their children
  *
  * If a child has different currency (for asset or liability accounts) the price
- * is converted using the latest available matching exchange rate.
+ * is converted using the exchange rate for the selected date (or the closest one found).
  */
 export function useAccountsTotal(
   selectedDate: DateTime = DateTime.now(),
@@ -175,6 +176,12 @@ export function useAccountsTotal(
   return result;
 }
 
+/**
+ * Aggregates monthly splits for each account to produce
+ * monthly histograms of transactions. For accounts where their children
+ * have different commodity, the monthly aggregation is converted using an
+ * exchange rate for that month
+ */
 export function useAccountsMonthlyTotal(
   interval?: Interval,
 ): UseQueryResult<AccountsMonthlyTotals> {

--- a/src/lib/queries/getAccountsTotals.ts
+++ b/src/lib/queries/getAccountsTotals.ts
@@ -1,10 +1,11 @@
 import { DateTime } from 'luxon';
 
 import Money from '@/book/Money';
-import { Commodity, Split } from '@/book/entities';
+import { Split } from '@/book/entities';
 import type { Account } from '@/book/entities';
 import mapAccounts from '@/helpers/mapAccounts';
-import type { AccountsMap, AccountsTotals } from '@/types/book';
+import aggregateChildrenTotals from '@/helpers/aggregateChildrenTotals';
+import type { AccountsTotals } from '@/types/book';
 import type { PriceDBMap } from '@/book/prices';
 
 export default async function getAccountsTotals(
@@ -15,7 +16,7 @@ export default async function getAccountsTotals(
   const rows: { total: number, accountId: string, mnemonic: string }[] = await Split
     .query(`
       SELECT
-        SUM(cast(splits.quantity_num as REAL) / splits.quantity_denom) as total,
+        ABS(SUM(cast(splits.quantity_num as REAL) / splits.quantity_denom)) as total,
         splits.account_guid as accountId
       FROM splits
       JOIN accounts as account ON splits.account_guid = account.guid
@@ -33,82 +34,11 @@ export default async function getAccountsTotals(
     totals[row.accountId] = new Money(row.total, accountsMap[row.accountId].commodity.mnemonic);
   });
 
-  accountsMap.type_root.childrenIds.forEach((childId: string) => {
-    totals[childId] = aggregateTotals(
-      childId,
-      accountsMap,
-      prices,
-      selectedDate,
-      totals,
-    );
-
-    totals[`type_${accountsMap[childId].type.toLowerCase()}`] = totals[childId];
-  });
-
-  return totals as AccountsTotals;
-}
-
-function aggregateTotals(
-  guid: string,
-  accounts: AccountsMap,
-  prices: PriceDBMap,
-  selectedDate: DateTime,
-  totals: { [guid: string]: Money },
-) {
-  const current = accounts[guid];
-  current.childrenIds.forEach((childId: string) => {
-    totals[current.guid] = (
-      totals[current.guid]
-      || new Money(0, current.commodity.mnemonic)
-    ).add(
-      convertToParentCommodity(
-        aggregateTotals(childId, accounts, prices, selectedDate, totals),
-        accounts[childId].commodity,
-        current.commodity,
-        prices,
-        selectedDate,
-      ),
-    );
-  });
-
-  totals[current.guid] = totals[current.guid] || new Money(0, current.commodity.mnemonic);
-
-  return totals[current.guid] || new Money(0, current.commodity.mnemonic);
-}
-
-/**
- * Given a Money amount it converts it to the specified currency in parameter
- * to.
- *
- * If the passed commodity in from is an investment, we retrieve the price of the
- * stock and if the currency of the stock doesn't match the specified currency,
- * we re-convert again
- */
-function convertToParentCommodity(
-  amount: Money,
-  from: Commodity,
-  to: Commodity,
-  prices: PriceDBMap,
-  selectedDate: DateTime,
-): Money {
-  let rate = 1;
-  let currency = from;
-
-  if (currency.namespace !== 'CURRENCY') {
-    const stockPrice = prices.getInvestmentPrice(
-      currency.mnemonic,
-      selectedDate,
-    );
-    rate = stockPrice.value;
-    currency = stockPrice.currency;
-  }
-  if (currency.guid !== to.guid) {
-    rate *= prices.getPrice(
-      currency.mnemonic,
-      to.mnemonic,
-      selectedDate,
-    ).value;
-  }
-
-  return amount.convert(to.mnemonic, rate);
+  return aggregateChildrenTotals(
+    'type_root',
+    accounts as Account[],
+    prices as PriceDBMap,
+    selectedDate,
+    totals,
+  );
 }


### PR DESCRIPTION
First step for refactoring monthly worth. I've extracted the aggregation of children totals into the parent as we will use this on demand. The idea is as follows:

- useAccountsTotal will now return the total for each account without taking into account the children.
- it accepts a select parameter for when you want to add the aggregation so you display accordingly.

It's true that it is extra computing but let's see how it reacts and we can always adapt.