### PR TITLE
Show always 7 bars in histogram

### DIFF
--- a/src/__tests__/components/DateRangeInput.test.tsx
+++ b/src/__tests__/components/DateRangeInput.test.tsx
@@ -116,4 +116,25 @@ describe('DateRangeInput', () => {
       {},
     );
   });
+
+  /**
+   * We want this to happen so Interval.spliBy generates proper intervals
+   * for displaying amount of columns we want. If we pass an interval with
+   * end date as 1st of the month without setting end of day, that month
+   * will not be included
+   */
+  it('sets end of day for start date when changing', () => {
+    const mockOnChange = jest.fn();
+    render(<DateRangeInput onChange={mockOnChange} />);
+
+    const datePickerOnChange = (Datepicker as jest.Mock).mock.calls[0][0].onChange;
+    datePickerOnChange({
+      startDate: DateTime.fromISO('2023-01-01'),
+      endDate: DateTime.fromISO('2023-01-01'),
+    });
+    expect(mockOnChange).toBeCalledWith({
+      start: DateTime.fromISO('2023-01-01').endOf('day'),
+      end: DateTime.fromISO('2023-01-01'),
+    });
+  });
 });

--- a/src/__tests__/helpers/monthlyDates.test.ts
+++ b/src/__tests__/helpers/monthlyDates.test.ts
@@ -1,0 +1,43 @@
+import { DateTime, Interval } from 'luxon';
+
+import monthlyDates from '@/helpers/monthlyDates';
+
+describe('monthlyDates', () => {
+  it('generates dates as expected when start of day 1', () => {
+    const dates = monthlyDates(Interval.fromDateTimes(
+      DateTime.fromISO('2023-11-01'),
+      DateTime.fromISO('2024-01-01'),
+    ));
+
+    expect(dates).toEqual([
+      DateTime.fromISO('2023-11-01'),
+      DateTime.fromISO('2023-12-01'),
+    ]);
+  });
+
+  it('generates dates as expected when end of day 1', () => {
+    const dates = monthlyDates(Interval.fromDateTimes(
+      DateTime.fromISO('2023-11-01'),
+      DateTime.fromISO('2024-01-01').endOf('day'),
+    ));
+
+    expect(dates).toEqual([
+      DateTime.fromISO('2023-11-01'),
+      DateTime.fromISO('2023-12-01'),
+      DateTime.fromISO('2024-01-01'),
+    ]);
+  });
+
+  it('generates dates as expected mid month', () => {
+    const dates = monthlyDates(Interval.fromDateTimes(
+      DateTime.fromISO('2023-11-15'),
+      DateTime.fromISO('2024-01-30'),
+    ));
+
+    expect(dates).toEqual([
+      DateTime.fromISO('2023-11-01'),
+      DateTime.fromISO('2023-12-01'),
+      DateTime.fromISO('2024-01-01'),
+    ]);
+  });
+});

--- a/src/components/DateRangeInput.tsx
+++ b/src/components/DateRangeInput.tsx
@@ -61,7 +61,7 @@ export default function DateRangeInput({
       onChange={(newValue) => {
         if (newValue) {
           onChange({
-            start: DateTime.fromISO(newValue.startDate as string),
+            start: DateTime.fromISO(newValue.startDate as string).endOf('day'),
             end: DateTime.fromISO(newValue.endDate as string),
           });
         }

--- a/src/components/pages/account/InvestmentChart.tsx
+++ b/src/components/pages/account/InvestmentChart.tsx
@@ -8,6 +8,7 @@ import { moneyToString } from '@/helpers/number';
 import type { Account } from '@/book/entities';
 import { useInvestment, usePrices } from '@/hooks/api';
 import Loading from '@/components/Loading';
+import monthlyDates from '@/helpers/monthlyDates';
 
 Chart.register(Filler);
 
@@ -49,7 +50,7 @@ export default function InvestmentChart({
   const valueData: { x: number, y: number }[] = [];
   const interval = Interval.fromDateTimes(startDate, DateTime.now());
   const monthly = interval.toDuration('months').months >= 3
-    ? interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).startOf('month'))
+    ? monthlyDates(interval)
     : interval.splitBy({ day: 1 }).map(d => (d.start as DateTime));
   monthly.forEach(x => {
     investment.processSplits(x);

--- a/src/components/pages/accounts/IncomeExpenseHistogram.tsx
+++ b/src/components/pages/accounts/IncomeExpenseHistogram.tsx
@@ -5,6 +5,7 @@ import type { ChartDataset } from 'chart.js';
 import Bar from '@/components/charts/Bar';
 import { moneyToString } from '@/helpers/number';
 import { useAccountsMonthlyTotal, useMainCurrency } from '@/hooks/api';
+import monthlyDates from '@/helpers/monthlyDates';
 
 export type IncomeExpenseHistogramProps = {
   selectedDate?: DateTime,
@@ -24,7 +25,6 @@ export default function IncomeExpenseHistogram({
   const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
-  const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).startOf('month'));
   const datasets: ChartDataset<'bar'>[] = [
     {
       label: 'Income',
@@ -57,7 +57,7 @@ export default function IncomeExpenseHistogram({
       <Bar
         height="400"
         data={{
-          labels: dates,
+          labels: monthlyDates(interval),
           datasets,
         }}
         options={{

--- a/src/components/pages/accounts/MonthlyTotalHistogram.tsx
+++ b/src/components/pages/accounts/MonthlyTotalHistogram.tsx
@@ -6,6 +6,7 @@ import Bar from '@/components/charts/Bar';
 import type { Account } from '@/book/entities';
 import { useAccountsMonthlyTotal, useMainCurrency } from '@/hooks/api';
 import { moneyToString } from '@/helpers/number';
+import monthlyDates from '@/helpers/monthlyDates';
 
 export type MonthlyTotalHistogramProps = {
   title: string,
@@ -27,7 +28,7 @@ export default function MonthlyTotalHistogram({
   const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
-  const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).startOf('month'));
+  const dates = monthlyDates(interval);
   const datasets: ChartDataset<'bar'>[] = [];
 
   if (accounts.length && monthlyTotals) {

--- a/src/components/pages/accounts/NetWorthHistogram.tsx
+++ b/src/components/pages/accounts/NetWorthHistogram.tsx
@@ -10,6 +10,7 @@ import {
 import Bar from '@/components/charts/Bar';
 import { moneyToString } from '@/helpers/number';
 import { useAccountsMonthlyWorth, useMainCurrency } from '@/hooks/api';
+import monthlyDates from '@/helpers/monthlyDates';
 
 // We are using Bar chart here but one of the axis uses Line so
 // we have to register here or otherwise we get an error.
@@ -37,8 +38,6 @@ export default function NetWorthHistogram({
 
   const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
-
-  const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).startOf('month'));
 
   const datasets: ChartDataset<'bar'>[] = [
     {
@@ -92,7 +91,7 @@ export default function NetWorthHistogram({
       <Bar
         height="400"
         data={{
-          labels: dates,
+          labels: monthlyDates(interval),
           datasets,
         }}
         options={{

--- a/src/helpers/monthlyDates.ts
+++ b/src/helpers/monthlyDates.ts
@@ -1,0 +1,15 @@
+import { DateTime, Interval } from 'luxon';
+
+/**
+ * Given an interval, return an array of monthly dates at the start of the month.
+ * For example, given a 2023-01-15/2023-03-15 interval, the returned dates would be:
+ *  - 2023-01-01
+ *  - 2023-02-01
+ *  - 2023-03-01
+ *
+ * This function is mainly used in charts where you want to display monthly data
+ */
+export default function monthlyDates(interval: Interval): DateTime[] {
+  const intervals: Interval[] = interval.splitBy({ month: 1 });
+  return intervals.map(d => (d.start as DateTime).startOf('month'));
+}

--- a/src/hooks/api/useSplits.ts
+++ b/src/hooks/api/useSplits.ts
@@ -12,6 +12,7 @@ import { getAccountsTotals, getMonthlyTotals } from '@/lib/queries';
 import type { PriceDBMap } from '@/book/prices';
 import type { AccountsTotals } from '@/types/book';
 import { aggregateChildrenTotals, aggregateMonthlyWorth } from '@/helpers/accountsTotalAggregations';
+import monthlyDates from '@/helpers/monthlyDates';
 import { useAccounts } from './useAccounts';
 import { usePrices } from './usePrices';
 import fetcher from './fetcher';
@@ -207,7 +208,7 @@ export function useAccountsMonthlyTotal(
 
   const aggregate = React.useCallback(
     ((data: AccountsTotals[]) => {
-      const dates = (interval as Interval).splitBy({ month: 1 }).map(d => (d.start as DateTime).endOf('month'));
+      const dates = monthlyDates(interval as Interval).map(d => d.endOf('month'));
       dates[dates.length - 1] = (interval as Interval).end as DateTime;
       return data.map((d, i) => aggregateChildrenTotals(
         'type_root',
@@ -270,7 +271,7 @@ export function useAccountsMonthlyWorth(
 
   const aggregate = React.useCallback(
     ((data: AccountsTotals[]) => {
-      const dates = (interval as Interval).splitBy({ month: 1 }).map(d => (d.start as DateTime).endOf('month'));
+      const dates = monthlyDates(interval as Interval).map(d => d.endOf('month'));
       dates[dates.length - 1] = (interval as Interval).end as DateTime;
       const aggregated = aggregateMonthlyWorth(
         'type_root',

--- a/src/lib/queries/getMonthlyTotals.ts
+++ b/src/lib/queries/getMonthlyTotals.ts
@@ -5,6 +5,7 @@ import Money from '@/book/Money';
 import mapAccounts from '@/helpers/mapAccounts';
 import type { Account } from '@/book/entities';
 import type { AccountsTotals } from '@/types/book';
+import monthlyDates from '@/helpers/monthlyDates';
 import getEarliestDate from './getEarliestDate';
 
 /**
@@ -36,7 +37,7 @@ export default async function getMonthlyTotals(
   const accountsMap = mapAccounts(accounts);
 
   const monthlyTotals: AccountsTotals[] = [];
-  const dates = interval.splitBy({ month: 1 }).map(d => (d.start as DateTime).startOf('month'));
+  const dates = monthlyDates(interval);
 
   dates.forEach(date => {
     const totals: { [guid: string]: Money } = {};


### PR DESCRIPTION
When selecting the first of the month in the date picker, we were showing only 6 bars instead of 7 which as a side effect, caused exceptions/errors when changing back to another day with 7 bars because of the keepExistingData of react-query.

This is because when selecting a date in the datepicker, it was selecting the very first second of the day which meant the `splitBy` function of Interval would return less intervals than expected.

For example, if we have `2023-01-01/2023-03-01` what we wanted is three intervals but it would return only 2. To fix that, I've changed the date picker behavior to select the end of the day the user selects so we get one more interval.