### PR TITLE
Fix price deletion

### DIFF
--- a/src/__tests__/components/pages/account/AccountInfo.test.tsx
+++ b/src/__tests__/components/pages/account/AccountInfo.test.tsx
@@ -68,7 +68,7 @@ describe('AccountInfo', () => {
       1,
       {
         className: 'mr-2',
-        title: 'This account has a total of',
+        title: 'Total',
         description: '',
         stats: '€0.00',
       },
@@ -90,7 +90,7 @@ describe('AccountInfo', () => {
       1,
       {
         className: 'mr-2',
-        title: 'This account has a total of',
+        title: 'Total',
         description: '',
         stats: '€100.00',
       },

--- a/src/__tests__/lib/queries/getPrices.test.ts
+++ b/src/__tests__/lib/queries/getPrices.test.ts
@@ -41,9 +41,6 @@ describe('getPrices', () => {
             guid: undefined,
           },
         },
-        order: {
-          date: 'ASC',
-        },
       },
     );
   });
@@ -76,9 +73,6 @@ describe('getPrices', () => {
             guid: undefined,
           },
         },
-        order: {
-          date: 'ASC',
-        },
       },
     );
     expect(Price.find).toHaveBeenNthCalledWith(
@@ -92,9 +86,6 @@ describe('getPrices', () => {
           fk_currency: {
             guid: 'guid',
           },
-        },
-        order: {
-          date: 'ASC',
         },
       },
     );
@@ -112,9 +103,6 @@ describe('getPrices', () => {
         fk_currency: {
           guid: 'guid',
         },
-      },
-      order: {
-        date: 'ASC',
       },
     });
   });
@@ -150,9 +138,6 @@ describe('getPrices', () => {
             guid: 'guid2',
           },
         },
-        order: {
-          date: 'ASC',
-        },
       },
     );
     expect(Price.find).toHaveBeenNthCalledWith(
@@ -166,9 +151,6 @@ describe('getPrices', () => {
           fk_currency: {
             guid: 'guid1',
           },
-        },
-        order: {
-          date: 'ASC',
         },
       },
     );

--- a/src/book/__tests__/entities/Price.test.ts
+++ b/src/book/__tests__/entities/Price.test.ts
@@ -1,7 +1,8 @@
 import { DateTime } from 'luxon';
-import { DataSource, BaseEntity } from 'typeorm';
+import { DataSource, BaseEntity as BE } from 'typeorm';
 
 import {
+  BaseEntity,
   Commodity,
   Price,
 } from '../../entities';
@@ -18,6 +19,9 @@ describe('Price', () => {
       logging: false,
     });
     await datasource.initialize();
+
+    // @ts-ignore
+    jest.spyOn(BaseEntity.prototype, 'remove').mockImplementation(BE.prototype.remove);
   });
 
   afterEach(async () => {
@@ -143,8 +147,6 @@ describe('caching', () => {
 
     // @ts-ignore
     jest.spyOn(Price, 'upsert').mockImplementation();
-    // @ts-ignore
-    jest.spyOn(BaseEntity.prototype, 'remove').mockImplementation();
   });
 
   it('invalidates keys when saving', async () => {

--- a/src/book/entities/Price.ts
+++ b/src/book/entities/Price.ts
@@ -115,12 +115,13 @@ export default class Price extends BaseEntity {
   }
 
   async remove(options?: SaveOptions): Promise<this> {
+    const entity = await super.remove(options);
+
     if (this.queryClient) {
-      updateCache({ queryClient: this.queryClient, entity: this, isDelete: true });
+      updateCache({ queryClient: this.queryClient, entity, isDelete: true });
     }
 
-    const price = await super.remove(options);
-    return price;
+    return entity;
   }
 }
 

--- a/src/components/pages/account/AccountInfo.tsx
+++ b/src/components/pages/account/AccountInfo.tsx
@@ -25,8 +25,8 @@ export default function AccountInfo({
           <div className="col-span-4">
             <StatisticsWidget
               className="mr-2"
-              title="This account has a total of"
-              stats={total.format()}
+              title="Total"
+              stats={total.abs().format()}
               description=""
             />
           </div>

--- a/src/hooks/api/usePrices.ts
+++ b/src/hooks/api/usePrices.ts
@@ -14,11 +14,12 @@ export function usePrices(params: {
   from?: Commodity,
   to?: Commodity,
 }): UseQueryResult<PriceDBMap> {
+  const queryKey = [...Price.CACHE_KEY, { from: params.from?.guid, to: params.to?.guid }];
   return useQuery({
-    queryKey: [...Price.CACHE_KEY, { from: params.from?.guid, to: params.to?.guid }],
+    queryKey,
     queryFn: fetcher(
       () => getPrices(params),
-      `/${Price.CACHE_KEY.join('/')}/${params.from?.guid}.${params.to?.guid}`,
+      queryKey,
     ),
     enabled: (
       !!('from' in params && params.from)

--- a/src/lib/queries/getPrices.ts
+++ b/src/lib/queries/getPrices.ts
@@ -20,9 +20,6 @@ export default async function getPrices({
         guid: to?.guid,
       },
     },
-    order: {
-      date: 'ASC',
-    },
   });
 
   let reversePrices: Price[] = [];
@@ -36,9 +33,6 @@ export default async function getPrices({
         fk_currency: {
           guid: from?.guid,
         },
-      },
-      order: {
-        date: 'ASC',
       },
     });
     reversePrices.forEach((price, i) => {


### PR DESCRIPTION
Updating cache and price removal were in the wrong order causing the deleted price to still be shown to the user. This PR fixes it.