### PR TITLE
Allow to edit main split account tx form

### DIFF
--- a/src/__tests__/components/forms/transaction/__snapshots__/SplitsField.test.tsx.snap
+++ b/src/__tests__/components/forms/transaction/__snapshots__/SplitsField.test.tsx.snap
@@ -10,59 +10,22 @@ exports[`SplitsField renders with default values 1`] = `
       name="date"
       type="date"
     />
-    <label
-      class="inline-block mb-2"
-    >
-      Amount
-    </label>
-    <div
-      class="flex w-1/2"
-    >
-      <div
-        class="flex items-center rounded-md bg-light-100 dark:bg-dark-800"
+    <div>
+      <label
+        class="inline-block mb-2"
       >
-        <input
-          aria-label="splits.0.quantity"
-          class="w-full text-right m-0"
-          name="splits.0.quantity"
-          step="0.001"
-          type="number"
-        />
-        <span
-          class="pr-2"
-        >
-          €
-        </span>
-      </div>
+        Amount
+      </label>
       <div
-        class="flex items-center rounded-md hidden"
+        class="flex w-1/2"
       >
-        <span
-          class="badge mx-3"
-          data-tooltip-id="value-help"
-        >
-          <svg
-            fill="currentColor"
-            height="1em"
-            stroke="currentColor"
-            stroke-width="0"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m11.293 17.293 1.414 1.414L19.414 12l-6.707-6.707-1.414 1.414L15.586 11H6v2h9.586z"
-            />
-          </svg>
-        </span>
         <div
-          class="flex items-center rounded-md  bg-light-100 dark:bg-dark-800"
+          class="flex items-center rounded-md bg-light-100 dark:bg-dark-800"
         >
           <input
-            aria-label="splits.0.value"
+            aria-label="splits.0.quantity"
             class="w-full text-right m-0"
-            hidden=""
-            name="splits.0.value"
+            name="splits.0.quantity"
             step="0.001"
             type="number"
           />
@@ -71,6 +34,45 @@ exports[`SplitsField renders with default values 1`] = `
           >
             €
           </span>
+        </div>
+        <div
+          class="flex items-center rounded-md hidden"
+        >
+          <span
+            class="badge mx-3"
+            data-tooltip-id="value-help"
+          >
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m11.293 17.293 1.414 1.414L19.414 12l-6.707-6.707-1.414 1.414L15.586 11H6v2h9.586z"
+              />
+            </svg>
+          </span>
+          <div
+            class="flex items-center rounded-md  bg-light-100 dark:bg-dark-800"
+          >
+            <input
+              aria-label="splits.0.value"
+              class="w-full text-right m-0"
+              hidden=""
+              name="splits.0.value"
+              step="0.001"
+              type="number"
+            />
+            <span
+              class="pr-2"
+            >
+              €
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/__tests__/components/forms/transaction/__snapshots__/TransactionForm.test.tsx.snap
+++ b/src/__tests__/components/forms/transaction/__snapshots__/TransactionForm.test.tsx.snap
@@ -51,59 +51,22 @@ exports[`TransactionForm renders as expected with action add 1`] = `
     <fieldset
       class="text-sm my-5"
     >
-      <label
-        class="inline-block mb-2"
-      >
-        Amount
-      </label>
-      <div
-        class="flex w-1/2"
-      >
-        <div
-          class="flex items-center rounded-md bg-light-100 dark:bg-dark-800"
+      <div>
+        <label
+          class="inline-block mb-2"
         >
-          <input
-            aria-label="splits.0.quantity"
-            class="w-full text-right m-0"
-            name="splits.0.quantity"
-            step="0.001"
-            type="number"
-          />
-          <span
-            class="pr-2"
-          >
-            €
-          </span>
-        </div>
+          Amount
+        </label>
         <div
-          class="flex items-center rounded-md hidden"
+          class="flex w-1/2"
         >
-          <span
-            class="badge mx-3"
-            data-tooltip-id="value-help"
-          >
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m11.293 17.293 1.414 1.414L19.414 12l-6.707-6.707-1.414 1.414L15.586 11H6v2h9.586z"
-              />
-            </svg>
-          </span>
           <div
-            class="flex items-center rounded-md  bg-light-100 dark:bg-dark-800"
+            class="flex items-center rounded-md bg-light-100 dark:bg-dark-800"
           >
             <input
-              aria-label="splits.0.value"
+              aria-label="splits.0.quantity"
               class="w-full text-right m-0"
-              hidden=""
-              name="splits.0.value"
+              name="splits.0.quantity"
               step="0.001"
               type="number"
             />
@@ -112,6 +75,45 @@ exports[`TransactionForm renders as expected with action add 1`] = `
             >
               €
             </span>
+          </div>
+          <div
+            class="flex items-center rounded-md hidden"
+          >
+            <span
+              class="badge mx-3"
+              data-tooltip-id="value-help"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m11.293 17.293 1.414 1.414L19.414 12l-6.707-6.707-1.414 1.414L15.586 11H6v2h9.586z"
+                />
+              </svg>
+            </span>
+            <div
+              class="flex items-center rounded-md  bg-light-100 dark:bg-dark-800"
+            >
+              <input
+                aria-label="splits.0.value"
+                class="w-full text-right m-0"
+                hidden=""
+                name="splits.0.value"
+                step="0.001"
+                type="number"
+              />
+              <span
+                class="pr-2"
+              >
+                €
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -368,61 +370,23 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
     <fieldset
       class="text-sm my-5"
     >
-      <label
-        class="inline-block mb-2"
-      >
-        Amount
-      </label>
-      <div
-        class="flex w-1/2"
-      >
-        <div
-          class="flex items-center rounded-md bg-light-100 dark:bg-dark-800"
+      <div>
+        <label
+          class="inline-block mb-2"
         >
-          <input
-            aria-label="splits.0.quantity"
-            class="w-full text-right m-0"
-            disabled=""
-            name="splits.0.quantity"
-            step="0.001"
-            type="number"
-          />
-          <span
-            class="pr-2"
-          >
-            €
-          </span>
-        </div>
+          Amount
+        </label>
         <div
-          class="flex items-center rounded-md hidden"
+          class="flex w-1/2"
         >
-          <span
-            class="badge mx-3"
-            data-tooltip-id="value-help"
-          >
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m11.293 17.293 1.414 1.414L19.414 12l-6.707-6.707-1.414 1.414L15.586 11H6v2h9.586z"
-              />
-            </svg>
-          </span>
           <div
-            class="flex items-center rounded-md  bg-light-100 dark:bg-dark-800"
+            class="flex items-center rounded-md bg-light-100 dark:bg-dark-800"
           >
             <input
-              aria-label="splits.0.value"
+              aria-label="splits.0.quantity"
               class="w-full text-right m-0"
               disabled=""
-              hidden=""
-              name="splits.0.value"
+              name="splits.0.quantity"
               step="0.001"
               type="number"
             />
@@ -431,6 +395,46 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
             >
               €
             </span>
+          </div>
+          <div
+            class="flex items-center rounded-md hidden"
+          >
+            <span
+              class="badge mx-3"
+              data-tooltip-id="value-help"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m11.293 17.293 1.414 1.414L19.414 12l-6.707-6.707-1.414 1.414L15.586 11H6v2h9.586z"
+                />
+              </svg>
+            </span>
+            <div
+              class="flex items-center rounded-md  bg-light-100 dark:bg-dark-800"
+            >
+              <input
+                aria-label="splits.0.value"
+                class="w-full text-right m-0"
+                disabled=""
+                hidden=""
+                name="splits.0.value"
+                step="0.001"
+                type="number"
+              />
+              <span
+                class="pr-2"
+              >
+                €
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -457,7 +461,7 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
               >
                 <span
                   class="css-1f43avz-a11yText-A11yText"
-                  id="react-select-4-live-region"
+                  id="react-select-5-live-region"
                 />
                 <span
                   aria-atomic="false"
@@ -489,7 +493,7 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                   >
                     <div
                       class="selector__placeholder css-1jqq78o-placeholder"
-                      id="react-select-4-placeholder"
+                      id="react-select-5-placeholder"
                     >
                       &lt;account&gt;
                     </div>
@@ -500,7 +504,7 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                       <input
                         aria-activedescendant=""
                         aria-autocomplete="list"
-                        aria-describedby="react-select-4-placeholder"
+                        aria-describedby="react-select-5-placeholder"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="splits.1.account"
@@ -509,7 +513,7 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                         autocorrect="off"
                         class="selector__input"
                         disabled=""
-                        id="react-select-4-input"
+                        id="react-select-5-input"
                         role="combobox"
                         spellcheck="false"
                         style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -676,70 +680,6 @@ exports[`TransactionForm renders as expected with action update 1`] = `
       class="text-sm my-5"
     >
       <label
-        class="inline-block mb-2"
-      >
-        Amount
-      </label>
-      <div
-        class="flex w-1/2"
-      >
-        <div
-          class="flex items-center rounded-md bg-light-100 dark:bg-dark-800"
-        >
-          <input
-            aria-label="splits.0.quantity"
-            class="w-full text-right m-0"
-            name="splits.0.quantity"
-            step="0.001"
-            type="number"
-          />
-          <span
-            class="pr-2"
-          >
-            €
-          </span>
-        </div>
-        <div
-          class="flex items-center rounded-md hidden"
-        >
-          <span
-            class="badge mx-3"
-            data-tooltip-id="value-help"
-          >
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m11.293 17.293 1.414 1.414L19.414 12l-6.707-6.707-1.414 1.414L15.586 11H6v2h9.586z"
-              />
-            </svg>
-          </span>
-          <div
-            class="flex items-center rounded-md  bg-light-100 dark:bg-dark-800"
-          >
-            <input
-              aria-label="splits.0.value"
-              class="w-full text-right m-0"
-              hidden=""
-              name="splits.0.value"
-              step="0.001"
-              type="number"
-            />
-            <span
-              class="pr-2"
-            >
-              €
-            </span>
-          </div>
-        </div>
-      </div>
-      <label
         class="inline-block mt-5 mb-2"
       >
         Records
@@ -758,7 +698,7 @@ exports[`TransactionForm renders as expected with action update 1`] = `
             >
               <div
                 class="selector css-b62m3t-container"
-                id="splits.1.account"
+                id="splits.0.account"
               >
                 <span
                   class="css-1f43avz-a11yText-A11yText"
@@ -789,11 +729,166 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                     />
                   </svg>
                   <div
+                    class="selector__value-container selector__value-container--has-value css-1fdsijx-ValueContainer"
+                  >
+                    <div
+                      class="!text-inherit selector__single-value css-1dimb5e-singleValue"
+                    >
+                      Assets:asset1
+                    </div>
+                    <div
+                      class="!text-inherit selector__input-container css-qbdosj-Input"
+                      data-value=""
+                    >
+                      <input
+                        aria-activedescendant=""
+                        aria-autocomplete="list"
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        aria-label="splits.0.account"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        autocorrect="off"
+                        class="selector__input"
+                        id="react-select-3-input"
+                        role="combobox"
+                        spellcheck="false"
+                        style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                        tabindex="0"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="selector__indicators css-1hb7zxy-IndicatorsContainer"
+                  >
+                    <span
+                      class="hidden selector__indicator-separator css-1u9des2-indicatorSeparator"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="selector__indicator selector__dropdown-indicator css-1xc3v61-indicatorContainer"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="css-tj5bde-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                      >
+                        <path
+                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  name="splits.0.account"
+                  type="hidden"
+                  value="Assets:asset1"
+                />
+              </div>
+              <p
+                class="invalid-feedback"
+              />
+            </div>
+            <div
+              class="col-span-4"
+            >
+              <div
+                class="flex items-center rounded-none bg-light-100 dark:bg-dark-800 rounded-r-md"
+              >
+                <input
+                  aria-label="splits.0.quantity"
+                  class="w-full text-right m-0"
+                  name="splits.0.quantity"
+                  step="0.001"
+                  type="number"
+                />
+                <span
+                  class="pr-2"
+                >
+                  €
+                </span>
+              </div>
+            </div>
+            <div
+              class="col-span-3"
+              hidden=""
+            >
+              <div
+                class="flex items-center rounded-r-md bg-light-100 dark:bg-dark-800"
+              >
+                <input
+                  aria-label="splits.0.value"
+                  class="w-full text-right m-0"
+                  name="splits.0.value"
+                  step="0.001"
+                  type="number"
+                />
+                <span
+                  class="pr-2"
+                >
+                  €
+                </span>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </fieldset>
+      <fieldset
+        class="grid grid-cols-12"
+      >
+        <div
+          class="col-span-11"
+        >
+          <fieldset
+            class="grid grid-cols-13"
+          >
+            <div
+              class="col-span-9"
+            >
+              <div
+                class="selector css-b62m3t-container"
+                id="splits.1.account"
+              >
+                <span
+                  class="css-1f43avz-a11yText-A11yText"
+                  id="react-select-4-live-region"
+                />
+                <span
+                  aria-atomic="false"
+                  aria-live="polite"
+                  aria-relevant="additions text"
+                  class="css-1f43avz-a11yText-A11yText"
+                  role="log"
+                />
+                <div
+                  class="selector__control css-13cymwt-control"
+                >
+                  <svg
+                    class="absolute text-md left-[10px]"
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 18a7.952 7.952 0 0 0 4.897-1.688l4.396 4.396 1.414-1.414-4.396-4.396A7.952 7.952 0 0 0 18 10c0-4.411-3.589-8-8-8s-8 3.589-8 8 3.589 8 8 8zm0-14c3.309 0 6 2.691 6 6s-2.691 6-6 6-6-2.691-6-6 2.691-6 6-6z"
+                    />
+                  </svg>
+                  <div
                     class="selector__value-container css-1fdsijx-ValueContainer"
                   >
                     <div
                       class="selector__placeholder css-1jqq78o-placeholder"
-                      id="react-select-3-placeholder"
+                      id="react-select-4-placeholder"
                     >
                       &lt;account&gt;
                     </div>
@@ -804,7 +899,7 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                       <input
                         aria-activedescendant=""
                         aria-autocomplete="list"
-                        aria-describedby="react-select-3-placeholder"
+                        aria-describedby="react-select-4-placeholder"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="splits.1.account"
@@ -812,7 +907,7 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                         autocomplete="off"
                         autocorrect="off"
                         class="selector__input"
-                        id="react-select-3-input"
+                        id="react-select-4-input"
                         role="combobox"
                         spellcheck="false"
                         style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"

--- a/src/__tests__/components/pages/account/InvestmentChart.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentChart.test.tsx
@@ -323,7 +323,7 @@ describe('InvestmentChart', () => {
               border: {
                 display: false,
               },
-              min: DateTime.now().minus({ year: 1 }).toISODate(),
+              min: account.splits[0].transaction.date.toISODate(),
             },
             yStocks: {
               offset: true,
@@ -582,7 +582,7 @@ describe('InvestmentChart', () => {
               border: {
                 display: false,
               },
-              min: DateTime.now().minus({ year: 1 }).toISODate(),
+              min: account.splits[0].transaction.date.toISODate(),
             },
             yStocks: {
               offset: true,

--- a/src/__tests__/components/pages/investments/InvestmentsTable.test.tsx
+++ b/src/__tests__/components/pages/investments/InvestmentsTable.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { UseQueryResult } from '@tanstack/react-query';
 
-import Money from '@/book/Money';
 import { InvestmentAccount } from '@/book/models';
 import Table from '@/components/Table';
 import { InvestmentsTable } from '@/components/pages/investments';

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { DateTime } from 'luxon';
 import { BiPlusCircle } from 'react-icons/bi';
-import dynamic from 'next/dynamic';
 
 import FormButton from '@/components/buttons/FormButton';
 import AccountForm from '@/components/forms/account/AccountForm';
@@ -11,6 +10,8 @@ import {
   AccountsTable,
   NetWorthPie,
   MonthlyTotalHistogram,
+  NetWorthHistogram,
+  IncomeExpenseHistogram,
   LatestTransactions,
 } from '@/components/pages/accounts';
 import Loading from '@/components/Loading';
@@ -18,9 +19,6 @@ import DateRangeInput from '@/components/DateRangeInput';
 import Onboarding from '@/components/onboarding/Onboarding';
 import { useAccounts } from '@/hooks/api';
 import mapAccounts from '@/helpers/mapAccounts';
-
-const NetWorthHistogram = dynamic(() => import('@/components/pages/accounts/NetWorthHistogram'), { ssr: false });
-const IncomeExpenseHistogram = dynamic(() => import('@/components/pages/accounts/IncomeExpenseHistogram'), { ssr: false });
 
 export default function AccountsPage(): JSX.Element {
   const { data, isLoading } = useAccounts();

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -286,7 +286,10 @@ describe('caching', () => {
 
     await tx.save();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(7);
+    expect(mockInvalidateQueries).toBeCalledTimes(8);
+    expect(mockInvalidateQueries).toBeCalledWith({
+      queryKey: ['api', 'txs', tx.guid],
+    });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', { name: 'latest' }],
     });
@@ -323,7 +326,10 @@ describe('caching', () => {
 
     await tx.remove();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(7);
+    expect(mockInvalidateQueries).toBeCalledTimes(8);
+    expect(mockInvalidateQueries).toBeCalledWith({
+      queryKey: ['api', 'txs', tx.guid],
+    });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', { name: 'latest' }],
     });

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -116,6 +116,9 @@ export async function updateCache(
   },
 ) {
   queryClient.invalidateQueries({
+    queryKey: [...Transaction.CACHE_KEY, entity.guid],
+  });
+  queryClient.invalidateQueries({
     queryKey: [...Transaction.CACHE_KEY, { name: 'latest' }],
   });
   queryClient.invalidateQueries({

--- a/src/components/forms/transaction/SplitsField.tsx
+++ b/src/components/forms/transaction/SplitsField.tsx
@@ -9,11 +9,13 @@ import SplitField from './SplitField';
 import MainSplit from './MainSplit';
 
 export type SplitsFieldProps = {
+  action?: 'add' | 'update' | 'delete',
   form: UseFormReturn<FormValues>,
   disabled?: boolean,
 };
 
 export default function SplitsField({
+  action,
   form,
   disabled = false,
 }: SplitsFieldProps): JSX.Element {
@@ -24,6 +26,10 @@ export default function SplitsField({
 
   const splits = form.watch('splits');
   const mainSplit = splits[0];
+  let firstSplitIndex = 1;
+  if (action === 'update') {
+    firstSplitIndex = 0;
+  }
 
   React.useEffect(() => {
     if (
@@ -44,12 +50,19 @@ export default function SplitsField({
 
   return (
     <>
-      <label className="inline-block mb-2">Amount</label>
-      <MainSplit form={form} disabled={disabled} />
+      {
+        action !== 'update'
+        && (
+          <div>
+            <label className="inline-block mb-2">Amount</label>
+            <MainSplit form={form} disabled={disabled} />
+          </div>
+        )
+      }
       <label className="inline-block mt-5 mb-2">Records</label>
       {
-        fields.slice(1).map((item, index) => {
-          index += 1;
+        fields.slice(firstSplitIndex).map((item, index) => {
+          index += firstSplitIndex;
           return (
             <fieldset className="grid grid-cols-12" key={item.id}>
               <div className="col-span-11">

--- a/src/components/forms/transaction/TransactionForm.tsx
+++ b/src/components/forms/transaction/TransactionForm.tsx
@@ -85,6 +85,7 @@ export default function TransactionForm({
 
       <fieldset className="text-sm my-5">
         <SplitsField
+          action={action}
           disabled={disabled}
           form={form}
         />

--- a/src/components/pages/account/InvestmentChart.tsx
+++ b/src/components/pages/account/InvestmentChart.tsx
@@ -166,7 +166,9 @@ export default function InvestmentChart({
             border: {
               display: false,
             },
-            min: DateTime.now().minus({ year: 1 }).toISODate(),
+            min: (startDate.toMillis() > DateTime.now().minus({ year: 1 }).toMillis())
+              ? startDate.toISODate() || undefined
+              : DateTime.now().minus({ year: 1 }).toISODate() || undefined,
           },
           yStocks: {
             offset: true,

--- a/src/components/pages/account/InvestmentInfo.tsx
+++ b/src/components/pages/account/InvestmentInfo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import dynamic from 'next/dynamic';
 
 import type { Account } from '@/book/entities';
 import { useInvestment, usePrices } from '@/hooks/api';
@@ -7,7 +8,8 @@ import Loading from '@/components/Loading';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import { toFixed } from '@/helpers/number';
 import Money from '@/book/Money';
-import InvestmentChart from './InvestmentChart';
+
+const InvestmentChart = dynamic(() => import('./InvestmentChart'), { ssr: false });
 
 export type InvestmentInfoProps = {
   account: Account,

--- a/src/components/pages/accounts/index.ts
+++ b/src/components/pages/accounts/index.ts
@@ -2,3 +2,5 @@ export { default as AccountsTable } from './AccountsTable';
 export { default as MonthlyTotalHistogram } from './MonthlyTotalHistogram';
 export { default as NetWorthPie } from './NetWorthPie';
 export { default as LatestTransactions } from './LatestTransactions';
+export { default as NetWorthHistogram } from './NetWorthHistogram';
+export { default as IncomeExpenseHistogram } from './IncomeExpenseHistogram';


### PR DESCRIPTION
When creating a new account and wanting to move a bunch of transactions from one to another, it becomes quite difficult as currently you can't edit the main split account and thus, you have to go through the other account in the transaction, filtering for that specific type of transaction (because we don't have global search implemented in the transactions table)