### PR TITLE
Execute vacuum on save

### DIFF
--- a/src/__tests__/hooks/useDataSource.test.ts
+++ b/src/__tests__/hooks/useDataSource.test.ts
@@ -46,6 +46,7 @@ jest.mock('typeorm', () => ({
       runMigrations: jest.fn(),
       initialize: mockInitialize,
       setOptions: jest.fn(),
+      query: jest.fn(),
       sqljsManager: {
         loadDatabase: jest.fn(),
         exportDatabase: jest.fn().mockReturnValue(new Uint8Array([22, 33])),
@@ -239,13 +240,14 @@ describe('useDataSource', () => {
     });
 
     describe('save', () => {
-      it('updates datasource, saves storage and updates state', async () => {
+      it('updates datasource, vacuums, saves storage and updates state', async () => {
         const { result } = renderHook(() => useDataSource());
 
         await waitFor(() => expect(result.current.isLoaded).toBe(true));
         const datasource = result.current.datasource as DataSource;
 
         await result.current.save();
+        expect(datasource.query).toBeCalledWith('VACUUM');
         expect(datasource.options.extra.queryClient.setQueryData).toHaveBeenNthCalledWith(
           1,
           ['state', 'isSaving'],

--- a/src/lib/storage/GDriveBookStorage.ts
+++ b/src/lib/storage/GDriveBookStorage.ts
@@ -101,7 +101,7 @@ export default class GDriveBookStorage implements BookStorage {
           Authorization: `Bearer ${this.gapiClient.getToken().access_token}`,
           'Content-Type': 'application/vnd.sqlite3',
         }),
-        body: new Blob([pako.gzip(rawBook)], { type: 'application/vnd.sqlite3' }),
+        body: new Blob([pako.gzip(rawBook, { level: 9 })], { type: 'application/vnd.sqlite3' }),
       },
     );
     const end = performance.now();


### PR DESCRIPTION
My compressed file size went from 2.3M to 1.4M when executing this so now we execute every time before saving. It's probably a bit overkill but I don't have a better option right now other than periodically executing which adds a bit of complexity and redundancy so leaving as is for now.