### PR TITLE
Always show realized profit

### DIFF
--- a/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
@@ -98,6 +98,8 @@ describe('InvestmentInfo', () => {
         value: new Money(150, 'EUR'),
         unrealizedProfitAbs: new Money(50, 'EUR'),
         unrealizedProfitPct: 50,
+        realizedProfit: new Money(10, 'EUR'),
+        realizedProfitPct: 5,
         avgPrice: 10,
         quantity: new Money(10, 'TICKER'),
         account,
@@ -144,125 +146,27 @@ describe('InvestmentInfo', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       3,
       {
-        className: 'col-span-7',
+        className: 'col-span-6',
         title: 'Unrealized Profit',
         statsTextClass: 'amount-positive',
-        stats: '€50.00 (50%)',
-        description: '',
+        stats: '50 %',
+        description: expect.anything(),
       },
       {},
     );
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       4,
       {
-        className: 'col-span-5',
-        title: 'Total Dividends',
-        statsTextClass: 'badge default',
-        stats: '€20.00',
-        description: '',
+        className: 'col-span-6',
+        title: 'Realized Profit',
+        statsTextClass: 'amount-positive',
+        stats: '€10.00',
+        description: '+ €20.00 from dividends',
       },
       {},
     );
 
     expect(container).toMatchSnapshot();
-  });
-
-  it('renders as expected with closed position', async () => {
-    const account = {
-      guid: 'guid',
-      commodity: ticker,
-    } as Account;
-    jest.spyOn(apiHook, 'usePrices').mockReturnValue({
-      data: new PriceDBMap([
-        {
-          date: DateTime.fromISO('2023-01-01'),
-          value: 10,
-          currency: eur,
-          commodity: ticker,
-        } as Price,
-        {
-          date: DateTime.fromISO('2023-02-01'),
-          value: 15,
-          currency: eur,
-          commodity: ticker,
-        } as Price,
-      ]),
-    } as UseQueryResult<PriceDBMap>);
-    jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
-      data: {
-        cost: new Money(0, 'EUR'),
-        value: new Money(0, 'EUR'),
-        totalBought: new Money(150, 'EUR'),
-        unrealizedProfitAbs: new Money(0, 'EUR'),
-        unrealizedProfitPct: 0,
-        realizedProfitPct: 50,
-        realizedProfit: new Money(50, 'EUR'),
-        avgPrice: 10,
-        quantity: new Money(0, 'TICKER'),
-        isClosed: true,
-        account,
-        currency: 'EUR',
-        realizedDividends: new Money(20, 'EUR'),
-      },
-    } as UseQueryResult<InvestmentAccount>);
-
-    render(
-      <InvestmentInfo account={account} />,
-    );
-
-    await screen.findByText('0 titles');
-    await screen.findByText('€0.00');
-
-    expect(InvestmentChart).toBeCalledWith(
-      {
-        account,
-      },
-      {},
-    );
-    expect(StatisticsWidget).toHaveBeenNthCalledWith(
-      1,
-      {
-        className: 'col-span-6',
-        title: 'Latest known price',
-        statsTextClass: 'table-caption badge default disabled',
-        stats: '€15.00',
-        description: 'on 2/1/2023',
-      },
-      {},
-    );
-    expect(StatisticsWidget).toHaveBeenNthCalledWith(
-      2,
-      {
-        className: 'col-span-6',
-        title: 'Current value is',
-        statsTextClass: 'amount-positive',
-        stats: '€0.00',
-        description: 'from €0.00 invested',
-      },
-      {},
-    );
-    expect(StatisticsWidget).toHaveBeenNthCalledWith(
-      3,
-      {
-        className: 'col-span-7',
-        title: 'Realized Profit',
-        statsTextClass: 'amount-positive',
-        stats: '€50.00 (50%)',
-        description: 'Bought a total of €150.00',
-      },
-      {},
-    );
-    expect(StatisticsWidget).toHaveBeenNthCalledWith(
-      4,
-      {
-        className: 'col-span-5',
-        title: 'Total Dividends',
-        statsTextClass: 'badge default disabled',
-        stats: '€20.00',
-        description: '',
-      },
-      {},
-    );
   });
 
   it('renders as expected when dividend with different currency', async () => {
@@ -292,6 +196,8 @@ describe('InvestmentInfo', () => {
         value: new Money(150, 'EUR'),
         unrealizedProfitAbs: new Money(50, 'EUR'),
         unrealizedProfitPct: 50,
+        realizedProfit: new Money(10, 'EUR'),
+        realizedProfitPct: 5,
         avgPrice: 10,
         quantity: new Money(10, 'TICKER'),
         account,
@@ -307,11 +213,11 @@ describe('InvestmentInfo', () => {
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       4,
       {
-        className: 'col-span-5',
-        title: 'Total Dividends',
-        statsTextClass: 'badge default',
-        stats: '$20.00',
-        description: '',
+        className: 'col-span-6',
+        title: 'Realized Profit',
+        statsTextClass: 'amount-positive',
+        stats: '€10.00',
+        description: '+ $20.00 from dividends',
       },
       {},
     );

--- a/src/components/pages/account/InvestmentInfo.tsx
+++ b/src/components/pages/account/InvestmentInfo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
+import { BiTrendingDown, BiTrendingUp } from 'react-icons/bi';
 
 import type { Account } from '@/book/entities';
 import { useInvestment, usePrices } from '@/hooks/api';
@@ -88,33 +89,38 @@ export default function InvestmentInfo({
             }
           />
           <StatisticsWidget
-            className="col-span-7"
+            className="col-span-6"
             statsTextClass={classNames({
-              'amount-positive': investment.isClosed
-                ? investment.realizedProfitPct >= 0
-                : investment.unrealizedProfitPct >= 0,
-              'amount-negative': investment.isClosed
-                ? investment.realizedProfitPct < 0
-                : investment.unrealizedProfitPct < 0,
+              'amount-positive': investment.unrealizedProfitPct >= 0,
+              'amount-negative': investment.unrealizedProfitPct < 0,
             })}
-            title={investment.isClosed ? 'Realized Profit' : 'Unrealized Profit'}
+            title="Unrealized Profit"
             stats={
-              investment.isClosed
-                ? `${investment.realizedProfit.format()} (${toFixed(investment.realizedProfitPct)}%)`
-                : `${investment.unrealizedProfitAbs.format()} (${toFixed(investment.unrealizedProfitPct)}%)`
+              `${toFixed(investment.unrealizedProfitPct)} %`
             }
-            description={
-              investment.isClosed
-                ? `Bought a total of ${investment.totalBought.format()}`
-                : ''
-            }
+            description={(
+              <div className="flex items-center">
+                {
+                  investment.unrealizedProfitPct >= 0
+                  && <BiTrendingUp className="mr-1 amount-positive" />
+                }
+                {
+                  investment.unrealizedProfitPct < 0
+                  && <BiTrendingDown className="mr-1 amount-negative" />
+                }
+                {investment.unrealizedProfitAbs.format()}
+              </div>
+            )}
           />
           <StatisticsWidget
-            className="col-span-5"
-            title="Total Dividends"
-            stats={investment.realizedDividends.format()}
-            statsTextClass={classNames('badge default', { disabled: investment.isClosed })}
-            description=""
+            className="col-span-6"
+            title="Realized Profit"
+            stats={investment.realizedProfit.format()}
+            statsTextClass={classNames({
+              'amount-positive': investment.realizedProfitPct >= 0,
+              'amount-negative': investment.realizedProfitPct < 0,
+            })}
+            description={`+ ${investment.realizedDividends.format()} from dividends`}
           />
         </div>
       </div>


### PR DESCRIPTION
For positions that we've sold and re-bought or sold partially, it's quite annoying to not be able to see the realized profit in detail page