### PR TITLE
Do not edit rates when updating

### DIFF
--- a/src/__tests__/components/forms/transaction/SplitField.test.tsx
+++ b/src/__tests__/components/forms/transaction/SplitField.test.tsx
@@ -96,11 +96,11 @@ describe('SplitField', () => {
     expect(screen.getByRole('spinbutton', { name: 'splits.1.value' })).toBeVisible();
   });
 
-  // When we load data with defaults, we want to keep it as
-  // we are loading the split for deleting or updating
-  it('loads with default and doesnt reset value', async () => {
+  // When we load data for updating/deleting, we want to keep it as it is
+  it('loads with default and doesnt reset value when update', async () => {
     render(
       <FormWrapper
+        action="update"
         defaults={{
           fk_currency: { mnemonic: 'SGD' } as Commodity,
           splits: [
@@ -757,10 +757,12 @@ describe('SplitField', () => {
 
 function FormWrapper(
   {
+    action = 'add',
     disabled = false,
     defaults = {} as FormValues,
     submit,
   }: {
+    action?: 'add' | 'update' | 'delete',
     disabled?: boolean,
     defaults?: Partial<FormValues>,
     submit?: Function,
@@ -815,7 +817,7 @@ function FormWrapper(
         {...form.register('date')}
         type="date"
       />
-      <SplitField index={1} form={form} disabled={disabled} />
+      <SplitField index={1} form={form} action={action} disabled={disabled} />
       <button type="submit">
         submit
       </button>

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -17,11 +17,13 @@ export type SplitFieldProps = {
   index: number;
   form: UseFormReturn<FormValues>,
   disabled?: boolean,
+  action?: 'add' | 'update' | 'delete',
 };
 
 export default function SplitField({
   index,
   form,
+  action = 'add',
   disabled = false,
 }: SplitFieldProps): JSX.Element {
   const account = form.watch(`splits.${index}.fk_account`) as Account;
@@ -39,7 +41,7 @@ export default function SplitField({
     if (
       account
       && date
-      && form.formState.isDirty
+      && action === 'add'
       && prices
     ) {
       let rate = null;
@@ -54,17 +56,17 @@ export default function SplitField({
         setExchangeRate(Price.create({ valueNum: 1, valueDenom: 1 }));
       }
     }
-  }, [account, txCurrency, date, disabled, form.formState.isDirty, index, prices]);
+  }, [account, txCurrency, date, disabled, action, index, prices]);
 
   React.useEffect(() => {
-    if (value && form.formState.isDirty) {
+    if (value && action === 'add') {
       form.setValue(
         `splits.${index}.quantity`,
         toFixed(value / exchangeRate.value, 3),
       );
     }
     form.trigger('splits');
-  }, [value, exchangeRate, form, form.formState.isDirty, index]);
+  }, [value, exchangeRate, form, action, index]);
 
   return (
     <fieldset className="grid grid-cols-13" key={`splits.${index}`}>

--- a/src/components/forms/transaction/SplitsField.tsx
+++ b/src/components/forms/transaction/SplitsField.tsx
@@ -15,7 +15,7 @@ export type SplitsFieldProps = {
 };
 
 export default function SplitsField({
-  action,
+  action = 'add',
   form,
   disabled = false,
 }: SplitsFieldProps): JSX.Element {
@@ -34,7 +34,7 @@ export default function SplitsField({
   React.useEffect(() => {
     if (
       splits.length === 2
-      && form.formState.isDirty
+      && action === 'add'
     ) {
       if (
         splits[0].account?.commodity?.guid === splits[1].account?.commodity?.guid
@@ -67,6 +67,7 @@ export default function SplitsField({
             <fieldset className="grid grid-cols-12" key={item.id}>
               <div className="col-span-11">
                 <SplitField
+                  action={action}
                   index={index}
                   form={form}
                   disabled={disabled}


### PR DESCRIPTION
When updating an old transaction, editing anything like the description would change quantities which is very inconvenient. Changed so it only updates rates automatically when adding a new one, not updating.

It may be useful when updating dates but it's not 100% of the cases and it's very annoying to loose the correct quantities when updating so disabling completely.