### PR TITLE
Fix split update

### DIFF
--- a/src/__tests__/components/pages/account/TransactionsTable.test.tsx
+++ b/src/__tests__/components/pages/account/TransactionsTable.test.tsx
@@ -385,6 +385,7 @@ describe('TransactionsTable', () => {
             quantity: s.quantity,
           })),
         },
+        onSave: expect.any(Function),
       },
       {},
     );
@@ -413,6 +414,19 @@ describe('TransactionsTable', () => {
       },
       {},
     );
+
+    const updateOnSave = (TransactionForm as jest.Mock).mock.calls[0][0].onSave;
+    // @ts-ignore
+    tx.queryClient = {
+      invalidateQueries: jest.fn(),
+    };
+    updateOnSave();
+    // Make sure we update the split related to the account we are displaying on update.
+    // This is because sometimes the user may change the main split to be from
+    // another account so we want to make sure the split disappears from the
+    // transactions table and the total aggregations
+    // @ts-ignore
+    expect(tx.queryClient.invalidateQueries).toBeCalledWith({ queryKey: ['api', 'splits', 'account_guid_1'] });
 
     expect(container).toMatchSnapshot();
   });

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -286,7 +286,7 @@ describe('caching', () => {
 
     await tx.save();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(8);
+    expect(mockInvalidateQueries).toBeCalledTimes(7);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', tx.guid],
     });
@@ -301,9 +301,6 @@ describe('caching', () => {
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'splits', '2'],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'aggregations', 'accounts', 'totals'],
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'splits', { aggregation: 'total' }],
@@ -326,7 +323,7 @@ describe('caching', () => {
 
     await tx.remove();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(8);
+    expect(mockInvalidateQueries).toBeCalledTimes(7);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', tx.guid],
     });
@@ -341,9 +338,6 @@ describe('caching', () => {
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'splits', '2'],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'aggregations', 'accounts', 'totals'],
     });
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'splits', { aggregation: 'total' }],

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -100,10 +100,6 @@ export default class Transaction extends BaseEntity {
 
 /**
  * Update some detail keys for consistency
- *
- * - /api/txs/latest -> Latest 5 transactions that happened
- * - /api/txs/start -> The transaction date that happened the earliest
- * - /api/splits/<account> -> For each split in the transaction, we invalidate this key
  */
 export async function updateCache(
   {
@@ -129,10 +125,6 @@ export async function updateCache(
     queryClient.invalidateQueries({
       queryKey: [...Split.CACHE_KEY, split.accountId],
     });
-  });
-
-  queryClient.invalidateQueries({
-    queryKey: ['api', 'aggregations', 'accounts', 'totals'],
   });
 
   queryClient.invalidateQueries({

--- a/src/components/pages/account/TransactionsTable.tsx
+++ b/src/components/pages/account/TransactionsTable.tsx
@@ -242,6 +242,9 @@ function ActionsCell({ row }: CellContext<Split, unknown>): JSX.Element {
         <TransactionForm
           action="update"
           defaultValues={defaultValues}
+          onSave={() => tx.queryClient?.invalidateQueries({
+            queryKey: [...Split.CACHE_KEY, row.original.accountId],
+          })}
         />
       </FormButton>
       <FormButton


### PR DESCRIPTION
Make sure we update Splits.CACHE_KEY/accountId for the account we are displaying for cases where user changes the mainsplit account to be a different one.

Currently, without this changes, when changing the split this happens:

<img width="287" alt="Screenshot 2024-03-04 at 11 11 37 AM" src="https://github.com/maffin-io/maffin-app/assets/3578154/b8a92eb1-58c0-422f-bad7-f8d5c07af414">

This is in the my bank account. The transaction doesn't have a My bank split anymore but stays there because with current code we don't update the key for My bank account.