### PR TITLE
Cash flow in currency

### DIFF
--- a/src/__tests__/components/DateRangeInput.test.tsx
+++ b/src/__tests__/components/DateRangeInput.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import Datepicker from 'react-tailwindcss-datepicker';
 import { DateTime, Interval } from 'luxon';
-import { DefinedUseQueryResult, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DefinedUseQueryResult, QueryClientProvider } from '@tanstack/react-query';
 import * as query from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 
@@ -29,9 +29,8 @@ jest.mock('@/hooks/state', () => ({
   ...jest.requireActual('@/hooks/state'),
 }));
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('DateRangeInput', () => {

--- a/src/__tests__/components/charts/AssetSankey.test.tsx
+++ b/src/__tests__/components/charts/AssetSankey.test.tsx
@@ -6,7 +6,7 @@ import { AssetSankey } from '@/components/charts';
 import Sankey from '@/components/charts/Sankey';
 import Money from '@/book/Money';
 import * as apiHooks from '@/hooks/api';
-import type { Commodity } from '@/book/entities';
+import type { Account } from '@/book/entities';
 import type { CashFlowRow } from '@/hooks/api/useCashFlow';
 
 jest.mock('@/hooks/api');
@@ -16,11 +16,15 @@ jest.mock('@/components/charts/Sankey', () => jest.fn(
 ));
 
 describe('AssetSankey', () => {
+  let account: Account;
+
   beforeEach(() => {
+    account = {
+      guid: 'guid1',
+      name: '1',
+      commodity: { mnemonic: 'EUR' },
+    } as Account;
     jest.spyOn(apiHooks, 'useCashFlow').mockReturnValue({ data: undefined } as UseQueryResult<CashFlowRow[]>);
-    jest.spyOn(apiHooks, 'useMainCurrency').mockReturnValue(
-      { data: { mnemonic: 'EUR' } as Commodity } as UseQueryResult<Commodity>,
-    );
   });
 
   afterEach(() => {
@@ -28,21 +32,15 @@ describe('AssetSankey', () => {
   });
 
   it('renders with no data', () => {
-    render(<AssetSankey guid="guid" />);
+    render(<AssetSankey account={account} />);
 
-    screen.getByText('No movements this month yet', { exact: false });
+    screen.getByText('No movements for this period', { exact: false });
   });
 
   it('generates data as expected', () => {
     jest.spyOn(apiHooks, 'useCashFlow').mockReturnValue(
       {
         data: [
-          {
-            guid: 'guid1',
-            name: '1',
-            type: 'BANK',
-            total: new Money(10, 'EUR'),
-          },
           {
             guid: 'guid2',
             name: '2',
@@ -77,7 +75,7 @@ describe('AssetSankey', () => {
       } as UseQueryResult<CashFlowRow[]>,
     );
 
-    render(<AssetSankey guid="guid1" />);
+    render(<AssetSankey account={account} />);
 
     expect(Sankey).toBeCalledWith(
       {
@@ -113,40 +111,48 @@ describe('AssetSankey', () => {
               colorFrom: expect.any(Function),
               colorTo: expect.any(Function),
               nodeWidth: 2,
+              labels: {
+                guid1: '1',
+                guid2: '2',
+                guid3: '3',
+                guid4: '4',
+                guid5: '5',
+                guid6: '6',
+              },
               data: [
                 {
                   flow: 10,
-                  from: '2',
+                  from: 'guid2',
                   fromType: 'INCOME',
-                  to: '1',
+                  to: 'guid1',
                   toType: 'ASSET',
                 },
                 {
                   flow: 20,
-                  from: '3',
+                  from: 'guid3',
                   fromType: 'INCOME',
-                  to: '1',
+                  to: 'guid1',
                   toType: 'ASSET',
                 },
                 {
                   flow: 10,
-                  from: '1',
+                  from: 'guid1',
                   fromType: 'ASSET',
-                  to: '4',
+                  to: 'guid4',
                   toType: 'EXPENSE',
                 },
                 {
                   flow: 20,
-                  from: '1',
+                  from: 'guid1',
                   fromType: 'ASSET',
-                  to: '5',
+                  to: 'guid5',
                   toType: 'LIABILITY',
                 },
                 {
                   flow: 30,
-                  from: '1',
+                  from: 'guid1',
                   fromType: 'ASSET',
-                  to: '6',
+                  to: 'guid6',
                   toType: 'ASSET',
                 },
               ],
@@ -173,7 +179,7 @@ describe('AssetSankey', () => {
 
     const { label } = (Sankey as jest.Mock).mock.calls[0][0].options.plugins.tooltip.callbacks;
 
-    expect(label({ raw: { flow: 10, toType: 'EXPENSE' } })).toEqual('-€10.00 (16.67 %)');
-    expect(label({ raw: { flow: 10, toType: 'ASSET' } })).toEqual('€10.00 (33.33 %)');
+    expect(label({ raw: { flow: 10, to: 'guid4' } })).toEqual('-€10.00 (16.67 %)');
+    expect(label({ raw: { flow: 10, to: 'guid1' } })).toEqual('€10.00 (33.33 %)');
   });
 });

--- a/src/__tests__/components/charts/AssetSankey.test.tsx
+++ b/src/__tests__/components/charts/AssetSankey.test.tsx
@@ -4,8 +4,10 @@ import type { UseQueryResult } from '@tanstack/react-query';
 
 import { AssetSankey } from '@/components/charts';
 import Sankey from '@/components/charts/Sankey';
+import Money from '@/book/Money';
 import * as apiHooks from '@/hooks/api';
 import type { Commodity } from '@/book/entities';
+import type { CashFlowRow } from '@/hooks/api/useCashFlow';
 
 jest.mock('@/hooks/api');
 
@@ -15,7 +17,7 @@ jest.mock('@/components/charts/Sankey', () => jest.fn(
 
 describe('AssetSankey', () => {
   beforeEach(() => {
-    jest.spyOn(apiHooks, 'useCashFlow').mockReturnValue({ data: undefined } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>);
+    jest.spyOn(apiHooks, 'useCashFlow').mockReturnValue({ data: undefined } as UseQueryResult<CashFlowRow[]>);
     jest.spyOn(apiHooks, 'useMainCurrency').mockReturnValue(
       { data: { mnemonic: 'EUR' } as Commodity } as UseQueryResult<Commodity>,
     );
@@ -39,40 +41,40 @@ describe('AssetSankey', () => {
             guid: 'guid1',
             name: '1',
             type: 'BANK',
-            total: 10,
+            total: new Money(10, 'EUR'),
           },
           {
             guid: 'guid2',
             name: '2',
             type: 'INCOME',
-            total: -10,
+            total: new Money(-10, 'EUR'),
           },
           {
             guid: 'guid3',
             name: '3',
             type: 'INCOME',
-            total: -20,
+            total: new Money(-20, 'EUR'),
           },
           {
             guid: 'guid4',
             name: '4',
             type: 'EXPENSE',
-            total: 10,
+            total: new Money(10, 'EUR'),
           },
           {
             guid: 'guid5',
             name: '5',
             type: 'LIABILITY',
-            total: 20,
+            total: new Money(20, 'EUR'),
           },
           {
             guid: 'guid6',
             name: '6',
             type: 'ASSET',
-            total: 30,
+            total: new Money(30, 'EUR'),
           },
         ],
-      } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>,
+      } as UseQueryResult<CashFlowRow[]>,
     );
 
     render(<AssetSankey guid="guid1" />);

--- a/src/__tests__/components/onboarding/Onboarding.test.tsx
+++ b/src/__tests__/components/onboarding/Onboarding.test.tsx
@@ -8,7 +8,7 @@ import {
 import { DataSource } from 'typeorm';
 import { DateTime } from 'luxon';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import Onboarding from '@/components/onboarding/Onboarding';
@@ -26,9 +26,8 @@ jest.mock('@/hooks/api', () => ({
   ...jest.requireActual('@/hooks/api'),
 }));
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('Onboarding', () => {
@@ -56,10 +55,10 @@ describe('Onboarding', () => {
   // This test is huge but doing it like this because the onboarding
   // steps are linked one after the other
   it('full onboarding', async () => {
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
     const user = userEvent.setup();
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={QUERY_CLIENT}>
         <div>
           <span id="save-button" />
           <span id="theme-button" />

--- a/src/__tests__/components/pages/account/AssetInfo.test.tsx
+++ b/src/__tests__/components/pages/account/AssetInfo.test.tsx
@@ -85,7 +85,7 @@ describe('AssetInfo', () => {
       },
       {},
     );
-    expect(AssetSankey).toBeCalledWith({ height: 270, guid: 'guid' }, {});
+    expect(AssetSankey).toBeCalledWith({ height: 270, account }, {});
     expect(TotalWidget).toBeCalledWith(
       { account },
       {},

--- a/src/__tests__/components/pages/account/EarnWidget.test.tsx
+++ b/src/__tests__/components/pages/account/EarnWidget.test.tsx
@@ -6,6 +6,8 @@ import EarnWidget from '@/components/pages/account/EarnWidget';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import * as apiHook from '@/hooks/api';
 import type { Account, Commodity } from '@/book/entities';
+import type { CashFlowRow } from '@/hooks/api/useCashFlow';
+import Money from '@/book/Money';
 
 jest.mock('@/hooks/api', () => ({
   __esModule: true,
@@ -21,7 +23,7 @@ describe('EarnWidgetTest', () => {
 
   beforeEach(() => {
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: undefined } as UseQueryResult<Commodity>);
-    jest.spyOn(apiHook, 'useCashFlow').mockReturnValue({ data: undefined } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>);
+    jest.spyOn(apiHook, 'useCashFlow').mockReturnValue({ data: undefined } as UseQueryResult<CashFlowRow[]>);
     account = {
       guid: 'guid',
       commodity: {
@@ -42,7 +44,7 @@ describe('EarnWidgetTest', () => {
         className: 'mr-2',
         description: expect.anything(),
         stats: '€0.00',
-        title: 'This month income',
+        title: 'Income',
       },
       {},
     );
@@ -57,56 +59,56 @@ describe('EarnWidgetTest', () => {
             guid: 'guid3',
             name: '3',
             type: 'INCOME',
-            total: -30,
+            total: new Money(-30, 'EUR'),
           },
           {
             guid: 'guid4',
             name: '4',
             type: 'EXPENSE',
-            total: 20,
+            total: new Money(20, 'EUR'),
           },
           {
             guid: 'guid5',
             name: '5',
             type: 'LIABILITY',
-            total: 20,
+            total: new Money(20, 'EUR'),
           },
           {
             guid: 'guid6',
             name: '6',
             type: 'ASSET',
-            total: 30,
+            total: new Money(30, 'EUR'),
           },
         ],
-      } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>)
+      } as UseQueryResult<CashFlowRow[]>)
       .mockReturnValueOnce({
         data: [
           {
             guid: 'guid3',
             name: '3',
             type: 'INCOME',
-            total: -20,
+            total: new Money(-20, 'EUR'),
           },
           {
             guid: 'guid4',
             name: '4',
             type: 'EXPENSE',
-            total: 10,
+            total: new Money(10, 'EUR'),
           },
           {
             guid: 'guid5',
             name: '5',
             type: 'LIABILITY',
-            total: 20,
+            total: new Money(20, 'EUR'),
           },
           {
             guid: 'guid6',
             name: '6',
             type: 'ASSET',
-            total: 30,
+            total: new Money(30, 'EUR'),
           },
         ],
-      } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>);
+      } as UseQueryResult<CashFlowRow[]>);
 
     render(<EarnWidget account={account} />);
 
@@ -115,7 +117,7 @@ describe('EarnWidgetTest', () => {
         className: 'mr-2',
         description: expect.anything(),
         stats: '€30.00',
-        title: 'This month income',
+        title: 'Income',
       },
       {},
     );

--- a/src/__tests__/components/pages/account/EarnWidget.test.tsx
+++ b/src/__tests__/components/pages/account/EarnWidget.test.tsx
@@ -54,6 +54,7 @@ describe('EarnWidgetTest', () => {
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
     jest.spyOn(apiHook, 'useCashFlow')
       .mockReturnValueOnce({
+        // period cash flow
         data: [
           {
             guid: 'guid3',
@@ -81,6 +82,7 @@ describe('EarnWidgetTest', () => {
           },
         ],
       } as UseQueryResult<CashFlowRow[]>)
+      // last month cash flow
       .mockReturnValueOnce({
         data: [
           {

--- a/src/__tests__/components/pages/account/SpendWidget.test.tsx
+++ b/src/__tests__/components/pages/account/SpendWidget.test.tsx
@@ -6,6 +6,8 @@ import SpendWidget from '@/components/pages/account/SpendWidget';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import * as apiHook from '@/hooks/api';
 import type { Account, Commodity } from '@/book/entities';
+import type { CashFlowRow } from '@/hooks/api/useCashFlow';
+import Money from '@/book/Money';
 
 jest.mock('@/hooks/api', () => ({
   __esModule: true,
@@ -21,7 +23,7 @@ describe('SpendWidgetTest', () => {
 
   beforeEach(() => {
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: undefined } as UseQueryResult<Commodity>);
-    jest.spyOn(apiHook, 'useCashFlow').mockReturnValue({ data: undefined } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>);
+    jest.spyOn(apiHook, 'useCashFlow').mockReturnValue({ data: undefined } as UseQueryResult<CashFlowRow[]>);
     account = {
       guid: 'guid',
       commodity: {
@@ -42,7 +44,7 @@ describe('SpendWidgetTest', () => {
         className: 'mr-2',
         description: expect.anything(),
         stats: '€0.00',
-        title: 'This month expenses',
+        title: 'Expenses',
       },
       {},
     );
@@ -57,56 +59,56 @@ describe('SpendWidgetTest', () => {
             guid: 'guid3',
             name: '3',
             type: 'INCOME',
-            total: -20,
+            total: new Money(-20, 'EUR'),
           },
           {
             guid: 'guid4',
             name: '4',
             type: 'EXPENSE',
-            total: 20,
+            total: new Money(20, 'EUR'),
           },
           {
             guid: 'guid5',
             name: '5',
             type: 'LIABILITY',
-            total: 20,
+            total: new Money(20, 'EUR'),
           },
           {
             guid: 'guid6',
             name: '6',
             type: 'ASSET',
-            total: 30,
+            total: new Money(30, 'EUR'),
           },
         ],
-      } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>)
+      } as UseQueryResult<CashFlowRow[]>)
       .mockReturnValueOnce({
         data: [
           {
             guid: 'guid3',
             name: '3',
             type: 'INCOME',
-            total: -20,
+            total: new Money(-20, 'EUR'),
           },
           {
             guid: 'guid4',
             name: '4',
             type: 'EXPENSE',
-            total: 10,
+            total: new Money(10, 'EUR'),
           },
           {
             guid: 'guid5',
             name: '5',
             type: 'LIABILITY',
-            total: 20,
+            total: new Money(20, 'EUR'),
           },
           {
             guid: 'guid6',
             name: '6',
             type: 'ASSET',
-            total: 30,
+            total: new Money(30, 'EUR'),
           },
         ],
-      } as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>);
+      } as UseQueryResult<CashFlowRow[]>);
 
     render(<SpendWidget account={account} />);
 
@@ -114,8 +116,8 @@ describe('SpendWidgetTest', () => {
       {
         className: 'mr-2',
         description: expect.anything(),
-        stats: '€20.00',
-        title: 'This month expenses',
+        stats: '€40.00',
+        title: 'Expenses',
       },
       {},
     );

--- a/src/__tests__/components/pages/account/SpendWidget.test.tsx
+++ b/src/__tests__/components/pages/account/SpendWidget.test.tsx
@@ -53,6 +53,7 @@ describe('SpendWidgetTest', () => {
   it('renders as expected', () => {
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
     jest.spyOn(apiHook, 'useCashFlow')
+      // period cash flow
       .mockReturnValueOnce({
         data: [
           {
@@ -81,6 +82,7 @@ describe('SpendWidgetTest', () => {
           },
         ],
       } as UseQueryResult<CashFlowRow[]>)
+      // last month cash flow
       .mockReturnValueOnce({
         data: [
           {
@@ -116,7 +118,7 @@ describe('SpendWidgetTest', () => {
       {
         className: 'mr-2',
         description: expect.anything(),
-        stats: '€40.00',
+        stats: '€20.00',
         title: 'Expenses',
       },
       {},

--- a/src/__tests__/hooks/api/useAccounts.test.tsx
+++ b/src/__tests__/hooks/api/useAccounts.test.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 import { useAccount, useAccounts } from '@/hooks/api';
 import { Account } from '@/book/entities';
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('useAccounts', () => {
@@ -32,7 +31,7 @@ describe('useAccounts', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
   });
 
   it('calls query as expected', async () => {
@@ -42,7 +41,7 @@ describe('useAccounts', () => {
     expect(Account.find).toBeCalledWith();
     expect(result.current.data).toEqual([account1, account2]);
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(['api', 'accounts']);
   });
@@ -93,7 +92,7 @@ describe('useAccount', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
   });
 
   it('calls query as expected', async () => {
@@ -103,7 +102,7 @@ describe('useAccount', () => {
     expect(Account.find).toBeCalledWith();
     expect(result.current.data).toEqual(account1);
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(['api', 'accounts']);
   });

--- a/src/__tests__/hooks/api/useCashFlow.test.tsx
+++ b/src/__tests__/hooks/api/useCashFlow.test.tsx
@@ -3,7 +3,6 @@ import { DataSource } from 'typeorm';
 import { DateTime, Interval } from 'luxon';
 import { renderHook, waitFor } from '@testing-library/react';
 import {
-  QueryClient,
   QueryClientProvider,
   DefinedUseQueryResult,
 } from '@tanstack/react-query';
@@ -23,16 +22,17 @@ jest.mock('@/hooks/state', () => ({
   ...jest.requireActual('@/hooks/state'),
 }));
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('useCashFlow', () => {
   let datasource: DataSource;
+  let root: Account;
   let account1: Account;
   let account2: Account;
   let tx: Transaction;
+  let eur: Commodity;
 
   beforeEach(async () => {
     datasource = new DataSource({
@@ -44,21 +44,30 @@ describe('useCashFlow', () => {
     });
     await datasource.initialize();
 
-    const eur = await Commodity.create({ mnemonic: 'EUR', namespace: 'CURRENCY' }).save();
+    eur = await Commodity.create({ mnemonic: 'EUR', namespace: 'CURRENCY' }).save();
 
-    account1 = await Account.create({
-      guid: 'guid',
+    root = await Account.create({
       name: 'hi',
       type: 'ROOT',
     }).save();
 
-    account2 = await Account.create({
-      name: 'Bank',
+    account1 = await Account.create({
+      guid: 'guid1',
+      name: 'Bank1',
       fk_commodity: eur,
-      parent: account1,
+      parent: root,
       type: 'ASSET',
     }).save();
 
+    account2 = await Account.create({
+      guid: 'guid2',
+      name: 'Bank2',
+      fk_commodity: eur,
+      parent: root,
+      type: 'ASSET',
+    }).save();
+
+    // transfer 50 eur from bank2 to bank1
     tx = await Transaction.create({
       fk_currency: eur,
       description: 'description',
@@ -84,8 +93,9 @@ describe('useCashFlow', () => {
     jest.spyOn(stateHooks, 'useInterval').mockReturnValue({ data: TEST_INTERVAL } as DefinedUseQueryResult<Interval>);
   });
 
-  afterEach(() => {
-    queryClient.removeQueries();
+  afterEach(async () => {
+    await datasource.destroy();
+    QUERY_CLIENT.removeQueries();
   });
 
   it('calls query as expected', async () => {
@@ -102,20 +112,13 @@ describe('useCashFlow', () => {
         type: account2.type,
         total: expect.any(Money),
       },
-      {
-        guid: account1.guid,
-        name: account1.name,
-        type: account1.type,
-        total: expect.any(Money),
-      },
     ]);
     expect(result.current.data?.[0].total.toString()).toEqual('-50.00 EUR');
-    expect(result.current.data?.[1].total.toString()).toEqual('50.00 EUR');
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(
-      ['api', 'splits', 'guid', 'cashflow', TEST_INTERVAL.toISODate()],
+      ['api', 'splits', 'guid1', 'cashflow', TEST_INTERVAL.toISODate()],
     );
   });
 
@@ -134,19 +137,51 @@ describe('useCashFlow', () => {
     await waitFor(() => expect(result.current.status).toEqual('success'));
     expect(result.current.data).toEqual([]);
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(
-      ['api', 'splits', 'guid', 'cashflow', '2022-01-01/2022-01-02'],
+      ['api', 'splits', 'guid1', 'cashflow', '2022-01-01/2022-01-02'],
     );
   });
 
-  it('works with different commodities', async () => {
-    account2.fk_commodity = await Commodity.create({ mnemonic: 'USD', namespace: 'CURRENCY' }).save();
+  /**
+   * Given the following:
+   * - one account in EUR and another in USD
+   * - first tx in EUR and second in USD
+   * - first tx sends 50 EUR to account1 and second sends 100 EUR in to account1
+   *
+   * check that when we retrieve the cash flow for
+   * account1 it creates a row  with 150 EUR referencing account2
+   */
+  it('works with different commodities with account in tx currency', async () => {
+    const usd = await Commodity.create({ mnemonic: 'USD', namespace: 'CURRENCY' }).save();
+    account2.fk_commodity = usd;
     await account2.save();
 
     tx.splits[1].quantityNum = -55;
     await tx.save();
+
+    await Transaction.create({
+      fk_currency: eur,
+      description: 'tx2',
+      date: DateTime.now(),
+      splits: [
+        Split.create({
+          fk_account: account1,
+          valueNum: 100,
+          valueDenom: 1,
+          quantityNum: 100,
+          quantityDenom: 1,
+        }),
+        Split.create({
+          fk_account: account2,
+          valueNum: -100,
+          valueDenom: 1,
+          quantityNum: -108,
+          quantityDenom: 1,
+        }),
+      ],
+    }).save();
 
     const { result } = renderHook(
       () => useCashFlow(account1.guid),
@@ -155,13 +190,242 @@ describe('useCashFlow', () => {
 
     await waitFor(() => expect(result.current.status).toEqual('success'));
 
-    expect(result.current.data?.[0].total.toString()).toEqual('-50.00 EUR');
-    expect(result.current.data?.[1].total.toString()).toEqual('50.00 EUR');
+    expect(result.current.data?.[0].total.toString()).toEqual('-150.00 EUR');
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(
-      ['api', 'splits', 'guid', 'cashflow', TEST_INTERVAL.toISODate()],
+      ['api', 'splits', 'guid1', 'cashflow', TEST_INTERVAL.toISODate()],
+    );
+  });
+
+  /**
+   * Given the following:
+   *  - one account in EUR, another in USD and another in EUR
+   *  - first tx in EUR, second in USD and third in EUR
+   *  - first tx withdraws 55 USD from account2
+   *  - second tx withdraws 108 USD from account2
+   *  - third tx adds 108 USD to account2
+   *
+   * check that it creates two entries:
+   *  - one that withdraws 163 USD referencing account1
+   *  - one that sends 108 USD referencing account3
+   */
+  it('works with different commodities with account not in tx currency', async () => {
+    const usd = await Commodity.create({ mnemonic: 'USD', namespace: 'CURRENCY' }).save();
+    account2.fk_commodity = usd;
+    await account2.save();
+
+    tx.splits[1].quantityNum = -55;
+    await tx.save();
+
+    await Transaction.create({
+      fk_currency: usd,
+      description: 'tx2',
+      date: DateTime.now(),
+      splits: [
+        Split.create({
+          fk_account: account1,
+          valueNum: 100,
+          valueDenom: 1,
+          quantityNum: 100,
+          quantityDenom: 1,
+        }),
+        Split.create({
+          fk_account: account2,
+          valueNum: -100,
+          valueDenom: 1,
+          quantityNum: -108,
+          quantityDenom: 1,
+        }),
+      ],
+    }).save();
+
+    const account3 = await Account.create({
+      guid: 'guid3',
+      name: 'Bank3',
+      fk_commodity: eur,
+      parent: root,
+      type: 'ASSET',
+    }).save();
+
+    tx = await Transaction.create({
+      fk_currency: eur,
+      description: 'tx3',
+      date: DateTime.now(),
+      splits: [
+        Split.create({
+          fk_account: account2,
+          valueNum: 100,
+          valueDenom: 1,
+          quantityNum: 108,
+          quantityDenom: 1,
+        }),
+        Split.create({
+          fk_account: account3,
+          valueNum: -100,
+          valueDenom: 1,
+          quantityNum: -100,
+          quantityDenom: 1,
+        }),
+      ],
+    }).save();
+
+    const { result } = renderHook(
+      () => useCashFlow(account2.guid),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toEqual('success'));
+
+    expect(result.current.data?.[0].total.toString()).toEqual('163.00 USD');
+    expect(result.current.data?.[1].total.toString()).toEqual('-108.00 USD');
+
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
+    expect(queryCache).toHaveLength(1);
+    expect(queryCache[0].queryKey).toEqual(
+      ['api', 'splits', 'guid2', 'cashflow', TEST_INTERVAL.toISODate()],
+    );
+  });
+
+  /**
+   * Transactions with more than 2 splits are calculated differently for
+   * cash flow computation. We pick the total amount in the split of the account
+   * we are checking and then use the other splits to calculate the partial amount.
+   *
+   * As an example, say we have a tx with the following:
+   *  - -100 in account1
+   *  - +75 in account2
+   *  - +25 in account3
+   *
+   * This case is simple as we want two rows same as the splits.
+   */
+  it('works with 3 splits in same currency', async () => {
+    const account3 = await Account.create({
+      guid: 'guid3',
+      name: 'Bank3',
+      fk_commodity: eur,
+      parent: root,
+      type: 'ASSET',
+    }).save();
+
+    await Transaction.create({
+      fk_currency: eur,
+      description: 'tx1',
+      date: DateTime.now(),
+      splits: [
+        Split.create({
+          fk_account: account1,
+          valueNum: 25,
+          valueDenom: 1,
+          quantityNum: 25,
+          quantityDenom: 1,
+        }),
+        Split.create({
+          fk_account: account2,
+          valueNum: 75,
+          valueDenom: 1,
+          quantityNum: 75,
+          quantityDenom: 1,
+        }),
+        Split.create({
+          fk_account: account3,
+          valueNum: -100,
+          valueDenom: 1,
+          quantityNum: -100,
+          quantityDenom: 1,
+        }),
+      ],
+    }).save();
+
+    const { result } = renderHook(
+      () => useCashFlow(account3.guid),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toEqual('success'));
+
+    expect(result.current.data?.[0].name).toEqual('Bank1');
+    expect(result.current.data?.[0].total.toString()).toEqual('25.00 EUR');
+    expect(result.current.data?.[1].name).toEqual('Bank2');
+    expect(result.current.data?.[1].total.toString()).toEqual('75.00 EUR');
+
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
+    expect(queryCache).toHaveLength(1);
+    expect(queryCache[0].queryKey).toEqual(
+      ['api', 'splits', 'guid3', 'cashflow', TEST_INTERVAL.toISODate()],
+    );
+  });
+
+  /**
+   * The above case is simple however, when
+   * the accounts have different currencies, this gets a bit more complicated:
+   *
+   * - -108 USD/-100 EUR in account1
+   * - 75 EUR/75 EUR in account2
+   * - 25 EUR/25 EUR in account3
+   *
+   * Because the tx currency is in EUR, we don't know the partial amounts in USD
+   * for the other splits. We want the cashflow in USD as we are generating it for
+   * account1 so we have to calculate those amounts as:
+   *
+   *  108/100 * split.quantity
+   */
+  it('works with 3 splits transactions with different currency', async () => {
+    const usd = await Commodity.create({ mnemonic: 'USD', namespace: 'CURRENCY' }).save();
+    const account3 = await Account.create({
+      guid: 'guid3',
+      name: 'Bank3',
+      fk_commodity: usd,
+      parent: root,
+      type: 'ASSET',
+    }).save();
+
+    await Transaction.create({
+      fk_currency: eur,
+      description: 'tx1',
+      date: DateTime.now(),
+      splits: [
+        Split.create({
+          fk_account: account1,
+          valueNum: 25,
+          valueDenom: 1,
+          quantityNum: 25,
+          quantityDenom: 1,
+        }),
+        Split.create({
+          fk_account: account2,
+          valueNum: 75,
+          valueDenom: 1,
+          quantityNum: 75,
+          quantityDenom: 1,
+        }),
+        Split.create({
+          fk_account: account3,
+          valueNum: -100,
+          valueDenom: 1,
+          quantityNum: -108,
+          quantityDenom: 1,
+        }),
+      ],
+    }).save();
+
+    const { result } = renderHook(
+      () => useCashFlow(account3.guid),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.status).toEqual('success'));
+
+    expect(result.current.data?.[0].name).toEqual('Bank1');
+    expect(result.current.data?.[0].total.toString()).toEqual('27.00 USD');
+    expect(result.current.data?.[1].name).toEqual('Bank2');
+    expect(result.current.data?.[1].total.toString()).toEqual('81.00 USD');
+
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
+    expect(queryCache).toHaveLength(1);
+    expect(queryCache[0].queryKey).toEqual(
+      ['api', 'splits', 'guid3', 'cashflow', TEST_INTERVAL.toISODate()],
     );
   });
 });

--- a/src/__tests__/hooks/api/useCommodities.test.tsx
+++ b/src/__tests__/hooks/api/useCommodities.test.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 import { useCommodity, useCommodities } from '@/hooks/api';
 import { Commodity } from '@/book/entities';
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('useCommodities', () => {
@@ -26,7 +25,7 @@ describe('useCommodities', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
   });
 
   it('calls query as expected', async () => {
@@ -36,7 +35,7 @@ describe('useCommodities', () => {
     expect(Commodity.find).toBeCalledWith();
     expect(result.current.data).toEqual([commodity1, commodity2]);
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(['api', 'commodities']);
   });
@@ -58,7 +57,7 @@ describe('useCommodity', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
   });
 
   it('calls query as expected', async () => {
@@ -68,7 +67,7 @@ describe('useCommodity', () => {
     expect(Commodity.find).toBeCalledWith();
     expect(result.current.data).toEqual(commodity1);
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(['api', 'commodities']);
   });

--- a/src/__tests__/hooks/api/useMainCurrency.test.tsx
+++ b/src/__tests__/hooks/api/useMainCurrency.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider, UseQueryResult } from '@tanstack/react-query';
+import { QueryClientProvider, UseQueryResult } from '@tanstack/react-query';
 
 import { useMainCurrency } from '@/hooks/api';
 import * as queries from '@/lib/queries';
@@ -13,9 +13,8 @@ jest.mock('@/hooks/api/useAccounts', () => ({
   ...jest.requireActual('@/hooks/api/useAccounts'),
 }));
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('useMainCurrency', () => {
@@ -25,7 +24,7 @@ describe('useMainCurrency', () => {
     } as UseQueryResult<Account[]>);
     renderHook(() => useMainCurrency(), { wrapper });
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     // @ts-ignore
     expect(queryCache[0].options.enabled).toBe(false);
@@ -44,7 +43,7 @@ describe('useMainCurrency', () => {
     const { result } = renderHook(() => useMainCurrency(), { wrapper });
 
     await waitFor(() => expect(result.current.data).toEqual({ guid: 'eur' }));
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     // @ts-ignore
     expect(queryCache[0].options.enabled).toBe(true);

--- a/src/__tests__/hooks/api/useSplits.test.tsx
+++ b/src/__tests__/hooks/api/useSplits.test.tsx
@@ -3,7 +3,6 @@ import { DateTime, Interval } from 'luxon';
 import { DataSource } from 'typeorm';
 import { renderHook, waitFor } from '@testing-library/react';
 import {
-  QueryClient,
   QueryClientProvider,
   UseQueryResult,
   DefinedUseQueryResult,
@@ -52,9 +51,8 @@ jest.mock('@/hooks/state', () => ({
   ...jest.requireActual('@/hooks/state'),
 }));
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('useSplits', () => {
@@ -97,7 +95,7 @@ describe('useSplits', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
   });
 
   describe('useSplits', () => {
@@ -132,7 +130,7 @@ describe('useSplits', () => {
         },
       });
 
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache).toHaveLength(1);
       expect(queryCache[0].queryKey).toEqual(['api', 'splits', 'guid', { guid: 'guid' }]);
     });
@@ -219,7 +217,7 @@ describe('useSplits', () => {
           }),
         ]);
 
-        const queryCache = queryClient.getQueryCache().getAll();
+        const queryCache = QUERY_CLIENT.getQueryCache().getAll();
         expect(queryCache).toHaveLength(1);
         expect(queryCache[0].queryKey).toEqual(
           ['api', 'splits', 'guid', 'page', { interval: TEST_INTERVAL.toISODate(), pageIndex: 0, pageSize: 1 }],
@@ -245,7 +243,7 @@ describe('useSplits', () => {
           }),
         ]);
 
-        const queryCache = queryClient.getQueryCache().getAll();
+        const queryCache = QUERY_CLIENT.getQueryCache().getAll();
         expect(queryCache).toHaveLength(1);
         expect(queryCache[0].queryKey).toEqual(
           ['api', 'splits', 'guid', 'page', { interval: TEST_INTERVAL.toISODate(), pageIndex: 0, pageSize: 1 }],
@@ -263,7 +261,7 @@ describe('useSplits', () => {
         await waitFor(() => expect(result.current.status).toEqual('success'));
         expect(result.current.data).toEqual(1);
 
-        const queryCache = queryClient.getQueryCache().getAll();
+        const queryCache = QUERY_CLIENT.getQueryCache().getAll();
         expect(queryCache).toHaveLength(1);
         expect(queryCache[0].queryKey).toEqual(
           ['api', 'splits', 'guid', 'count', { interval: TEST_INTERVAL.toISODate() }],
@@ -316,7 +314,7 @@ describe('useSplits', () => {
       await waitFor(() => expect(result.current.status).toEqual('success'));
       expect(result.current.data).toEqual(100);
 
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache).toHaveLength(1);
       expect(queryCache[0].queryKey).toEqual(
         ['api', 'splits', 'guid', 'total', '2023-01-01'],
@@ -348,7 +346,7 @@ describe('useSplits', () => {
 
       await waitFor(() => expect(result.current.status).toEqual('pending'));
 
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache).toHaveLength(1);
       expect(queryCache[0].queryKey).toEqual(
         ['api', 'splits', { aggregation: 'total', date: '2023-01-01' }],
@@ -368,7 +366,7 @@ describe('useSplits', () => {
       );
 
       await waitFor(() => expect(result.current.status).toEqual('success'));
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache[0].queryKey).toEqual(
         [
           'api',
@@ -443,7 +441,7 @@ describe('useSplits', () => {
 
       await waitFor(() => expect(result.current.status).toEqual('pending'));
 
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache).toHaveLength(1);
       expect(queryCache[0].queryKey).toEqual(
         [
@@ -473,7 +471,7 @@ describe('useSplits', () => {
       );
 
       await waitFor(() => expect(result.current.status).toEqual('success'));
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache[0].queryKey).toEqual(
         [
           'api',
@@ -548,7 +546,7 @@ describe('useSplits', () => {
 
       await waitFor(() => expect(result.current.status).toEqual('pending'));
 
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache).toHaveLength(2);
       // this hook depends on the useAccountsTotals hook
       expect(queryCache[0].queryKey).toEqual(
@@ -593,7 +591,7 @@ describe('useSplits', () => {
       );
 
       await waitFor(() => expect(result.current.status).toEqual('success'));
-      const queryCache = queryClient.getQueryCache().getAll();
+      const queryCache = QUERY_CLIENT.getQueryCache().getAll();
       expect(queryCache[1].queryKey).toEqual(
         [
           'api',

--- a/src/__tests__/hooks/state/useInterval.test.tsx
+++ b/src/__tests__/hooks/state/useInterval.test.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { DateTime, Interval } from 'luxon';
 
 import { useInterval } from '@/hooks/state';
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('useMainCurrency', () => {
   beforeEach(() => {
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
   });
 
   it('sets now - 6 months as default', async () => {
@@ -26,7 +25,7 @@ describe('useMainCurrency', () => {
 
     expect(result.current.data.splitBy({ month: 1 })).toHaveLength(6);
 
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(['state', 'interval']);
     expect(queryCache[0].gcTime).toEqual(Infinity);

--- a/src/__tests__/hooks/state/useTheme.test.tsx
+++ b/src/__tests__/hooks/state/useTheme.test.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 import { useTheme } from '@/hooks/state';
 
-const queryClient = new QueryClient();
 const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
 );
 
 describe('useMainCurrency', () => {
   beforeEach(() => {
     localStorage.removeItem('theme');
-    queryClient.removeQueries();
+    QUERY_CLIENT.removeQueries();
   });
 
   // We set dark theme as default in setupTests
@@ -20,7 +19,7 @@ describe('useMainCurrency', () => {
     const { result } = renderHook(() => useTheme(), { wrapper });
 
     await waitFor(() => expect(result.current.data).toEqual('dark'));
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].queryKey).toEqual(['state', 'theme']);
     expect(queryCache[0].gcTime).toEqual(Infinity);
@@ -32,7 +31,7 @@ describe('useMainCurrency', () => {
     const { result } = renderHook(() => useTheme(), { wrapper });
 
     await waitFor(() => expect(result.current.data).toEqual('light'));
-    const queryCache = queryClient.getQueryCache().getAll();
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
     expect(queryCache).toHaveLength(1);
     expect(queryCache[0].gcTime).toEqual(Infinity);
   });

--- a/src/components/DateRangeInput.tsx
+++ b/src/components/DateRangeInput.tsx
@@ -13,17 +13,17 @@ export default function DateRangeInput(): JSX.Element {
 
   const now = DateTime.now();
   const shortcuts: { [key: string]: { text: string, period: { start: Date, end: Date } } } = {
-    t3: {
-      text: 'Last 3 months',
-      period: {
-        start: now.minus({ months: 2 }).startOf('month').toJSDate(),
-        end: now.toJSDate(),
-      },
-    },
     t6: {
       text: 'Last 6 months',
       period: {
         start: now.minus({ months: 5 }).startOf('month').toJSDate(),
+        end: now.toJSDate(),
+      },
+    },
+    t3: {
+      text: 'Last 3 months',
+      period: {
+        start: now.minus({ months: 2 }).startOf('month').toJSDate(),
         end: now.toJSDate(),
       },
     },

--- a/src/components/charts/AssetSankey.tsx
+++ b/src/components/charts/AssetSankey.tsx
@@ -2,36 +2,40 @@ import React from 'react';
 import type { ChartDataset } from 'chart.js';
 
 import Money from '@/book/Money';
-import { useCashFlow, useMainCurrency } from '@/hooks/api';
-import { isAsset, isLiability } from '@/book/helpers/accountType';
+import { useCashFlow } from '@/hooks/api';
+import { isLiability } from '@/book/helpers/accountType';
 import { moneyToString, toFixed } from '@/helpers/number';
+import type { Account } from '@/book/entities';
 import Sankey from './Sankey';
 
 export type AssetSankeyProps = {
-  guid: string,
+  account: Account,
   height?: number,
 };
 
 export default function AssetSankey({
-  guid,
+  account,
   height = 250,
 }: AssetSankeyProps): JSX.Element {
-  const { data: byAccount, isPending } = useCashFlow(guid);
-  const { data: currency } = useMainCurrency();
+  const { data: cashflow, isPending } = useCashFlow(account.guid);
 
-  const assetName = byAccount?.find(r => r.guid === guid)?.name || '';
+  const labels: { [guid: string]: string } = {
+    [account.guid]: account.name,
+  };
 
-  let totalIn = new Money(0, currency?.mnemonic || '');
-  let totalOut = new Money(0, currency?.mnemonic || '');
+  let totalIn = new Money(0, account.commodity.mnemonic);
+  let totalOut = new Money(0, account.commodity.mnemonic);
 
-  const data = byAccount?.filter(r => r.guid !== guid).map(r => {
+  const data = cashflow?.filter(r => r.guid !== account.guid).map(r => {
+    labels[r.guid] = r.name;
+
     if (r.total.isNegative()) {
       totalIn = totalIn.add(r.total.abs());
 
       return {
-        from: r.name,
+        from: r.guid,
         fromType: r.type,
-        to: assetName,
+        to: account.guid,
         toType: 'ASSET',
         flow: r.total.abs().toNumber(),
       };
@@ -39,9 +43,9 @@ export default function AssetSankey({
 
     totalOut = totalOut.add(r.total);
     return {
-      from: assetName,
+      from: account.guid,
       fromType: 'ASSET',
-      to: r.name,
+      to: r.guid,
       toType: r.type,
       flow: r.total.toNumber(),
     };
@@ -50,7 +54,7 @@ export default function AssetSankey({
   if (!isPending && !data?.length) {
     return (
       <div className="flex h-[400px] text-sm place-content-center place-items-center">
-        No movements this month yet!
+        No movements for this period!
       </div>
     );
   }
@@ -58,6 +62,7 @@ export default function AssetSankey({
   const datasets: ChartDataset<'sankey'>[] = [
     {
       data: data || [],
+      labels,
       colorFrom: (d) => {
         if (!d.raw) {
           return '';
@@ -103,12 +108,12 @@ export default function AssetSankey({
             displayColors: false,
             callbacks: {
               label: (ctx) => {
-                const raw = ctx.raw as { flow: number, toType: string };
-                let absolute = moneyToString(-raw.flow, currency?.mnemonic || '');
+                const raw = ctx.raw as { flow: number, to: string };
+                let absolute = moneyToString(-raw.flow, account.commodity.mnemonic);
                 let percentage = toFixed((raw.flow / totalOut.toNumber()) * 100);
-                if (isAsset(raw.toType)) {
+                if (raw.to === account.guid) {
                   percentage = toFixed((raw.flow / totalIn.toNumber()) * 100);
-                  absolute = moneyToString(raw.flow, currency?.mnemonic || '');
+                  absolute = moneyToString(raw.flow, account.commodity.mnemonic);
                 }
                 return `${absolute} (${percentage} %)`;
               },

--- a/src/components/pages/account/AssetInfo.tsx
+++ b/src/components/pages/account/AssetInfo.tsx
@@ -68,7 +68,7 @@ export default function AssetInfo({
               && (
                 <AssetSankey
                   height={270}
-                  guid={account.guid}
+                  account={account}
                 />
               )
             }

--- a/src/components/pages/account/EarnWidget.tsx
+++ b/src/components/pages/account/EarnWidget.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BiCalendar } from 'react-icons/bi';
 import { DateTime, Interval } from 'luxon';
 
-import { useMainCurrency, useCashFlow } from '@/hooks/api';
+import { useCashFlow } from '@/hooks/api';
 import type { Account } from '@/book/entities';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import Money from '@/book/Money';
@@ -18,8 +18,7 @@ export type EarnWidgetProps = {
 export default function EarnWidget({
   account,
 }: EarnWidgetProps): JSX.Element {
-  const { data: currency } = useMainCurrency();
-  const zero = new Money(0, currency?.mnemonic || '');
+  const zero = new Money(0, account.commodity.mnemonic || '');
 
   const { data: periodCashflow } = useCashFlow(account.guid);
   const periodEarn = periodCashflow?.filter(c => c.type === 'INCOME').reduce(

--- a/src/components/pages/account/SpendWidget.tsx
+++ b/src/components/pages/account/SpendWidget.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BiCalendar } from 'react-icons/bi';
 import { DateTime, Interval } from 'luxon';
 
-import { useMainCurrency, useCashFlow } from '@/hooks/api';
+import { useCashFlow } from '@/hooks/api';
 import type { Account } from '@/book/entities';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import Money from '@/book/Money';
@@ -14,18 +14,15 @@ export type SpendWidgetProps = {
 
 /**
  * Given a cashflow, compute the money that has been spent in this account
- * through INCOME accounts
+ * through EXPENSE accounts.
  */
 export default function SpendWidget({
   account,
 }: SpendWidgetProps): JSX.Element {
-  const { data: currency } = useMainCurrency();
-  const zero = new Money(0, currency?.mnemonic || '');
+  const zero = new Money(0, account.commodity.mnemonic || '');
 
   const { data: periodCashflow } = useCashFlow(account.guid);
-  const periodSpend = periodCashflow?.filter(
-    c => c.type === 'EXPENSE' || isLiability(c.type),
-  ).reduce(
+  const periodSpend = periodCashflow?.filter(c => c.type === 'EXPENSE').reduce(
     (total, c) => c.total.add(total),
     zero,
   ) || zero;

--- a/src/hooks/api/useCashFlow.ts
+++ b/src/hooks/api/useCashFlow.ts
@@ -14,10 +14,11 @@ export type CashFlowRow = {
 };
 
 /**
- * Retrieve the cashflow for a given account in the specified date.
+ * Retrieve the cashflow for a given account in the specified period.
  *
- * Returns an array containing the account guid, the total for that account, the type and
- * the name.
+ * The query works for transactions in multiple splits and in different currencies.
+ * We do that by calculating the exchange rate in the transaction and applying it to
+ * the splits for the other accounts.
  */
 export function useCashFlow(
   account: string,
@@ -32,24 +33,30 @@ export function useCashFlow(
       const rows = await Split.query(`
         SELECT
           splits.account_guid as guid,
-          accounts.name,
+          accounts.name as name,
           accounts.account_type as type,
-          commodities.mnemonic,
-          SUM(cast(splits.value_num as REAL) / splits.value_denom) as total
+          (
+            SELECT commodities.mnemonic 
+            FROM commodities
+            JOIN accounts AS main_account ON main_account.guid = '${account}'
+            WHERE commodities.guid = main_account.commodity_guid
+          ) AS mnemonic,
+          SUM(((cast(main_split.quantity_num as REAL) / main_split.quantity_denom) / (cast(main_split.value_num as REAL) / main_split.value_denom)) * (cast(splits.value_num as REAL) / splits.value_denom)) as total
+
         FROM transactions AS tx
         JOIN splits ON splits.tx_guid = tx.guid
-        JOIN commodities ON tx.currency_guid = commodities.guid
         JOIN accounts ON splits.account_guid = accounts.guid
+        JOIN splits AS main_split ON main_split.tx_guid = tx.guid AND main_split.account_guid = '${account}'
+
         WHERE tx.guid IN (
           SELECT DISTINCT tx_guid
           FROM splits
           WHERE account_guid = '${account}'
         )
-        AND tx.post_date >= '${((interval as Interval).start as DateTime).toSQLDate()}'
-        AND tx.post_date <= '${((interval as Interval).end as DateTime).toSQLDate()}'
-        GROUP BY splits.account_guid
-        HAVING SUM(cast(splits.quantity_num as REAL) / splits.quantity_denom) != 0
-        ORDER BY total
+        AND accounts.guid != '${account}'
+        AND tx.post_date BETWEEN '${((interval as Interval).start as DateTime).toSQLDate()}' AND '${((interval as Interval).end as DateTime).toSQLDate()}'
+
+        GROUP BY splits.account_guid, accounts.name, accounts.account_type, mnemonic
       `) as { guid: string, type: string, name: string, total: number, mnemonic: string }[];
 
       return rows.map(r => ({

--- a/src/hooks/api/useCashFlow.ts
+++ b/src/hooks/api/useCashFlow.ts
@@ -4,6 +4,14 @@ import type { UseQueryResult } from '@tanstack/react-query';
 
 import { Split } from '@/book/entities';
 import { useInterval } from '@/hooks/state';
+import Money from '@/book/Money';
+
+export type CashFlowRow = {
+  guid: string,
+  total: Money,
+  type: string,
+  name: string,
+};
 
 /**
  * Retrieve the cashflow for a given account in the specified date.
@@ -14,34 +22,45 @@ import { useInterval } from '@/hooks/state';
 export function useCashFlow(
   account: string,
   selectedInterval?: Interval,
-): UseQueryResult<{ guid: string, total: number, type: string, name: string }[]> {
+): UseQueryResult<CashFlowRow[]> {
   const { data: defaultInterval } = useInterval();
   const interval = selectedInterval || defaultInterval;
 
   const result = useQuery({
     queryKey: [...Split.CACHE_KEY, account, 'cashflow', interval.toISODate()],
-    queryFn: () => Split.query(`
-      SELECT
-        splits.account_guid as guid,
-        accounts.name,
-        accounts.account_type as type,
-        SUM(cast(splits.quantity_num as REAL) / splits.quantity_denom) as total
-      FROM transactions AS tx
-      JOIN splits ON splits.tx_guid = tx.guid
-      JOIN accounts ON splits.account_guid = accounts.guid
-      WHERE tx.guid IN (
-        SELECT DISTINCT tx_guid
-        FROM splits
-        WHERE account_guid = '${account}'
-      )
-      AND tx.post_date >= '${((interval as Interval).start as DateTime).toSQLDate()}'
-      AND tx.post_date <= '${((interval as Interval).end as DateTime).toSQLDate()}'
-      GROUP BY splits.account_guid
-      HAVING SUM(cast(splits.quantity_num as REAL) / splits.quantity_denom) != 0
-      ORDER BY total
-    `),
+    queryFn: async () => {
+      const rows = await Split.query(`
+        SELECT
+          splits.account_guid as guid,
+          accounts.name,
+          accounts.account_type as type,
+          commodities.mnemonic,
+          SUM(cast(splits.value_num as REAL) / splits.value_denom) as total
+        FROM transactions AS tx
+        JOIN splits ON splits.tx_guid = tx.guid
+        JOIN commodities ON tx.currency_guid = commodities.guid
+        JOIN accounts ON splits.account_guid = accounts.guid
+        WHERE tx.guid IN (
+          SELECT DISTINCT tx_guid
+          FROM splits
+          WHERE account_guid = '${account}'
+        )
+        AND tx.post_date >= '${((interval as Interval).start as DateTime).toSQLDate()}'
+        AND tx.post_date <= '${((interval as Interval).end as DateTime).toSQLDate()}'
+        GROUP BY splits.account_guid
+        HAVING SUM(cast(splits.quantity_num as REAL) / splits.quantity_denom) != 0
+        ORDER BY total
+      `) as { guid: string, type: string, name: string, total: number, mnemonic: string }[];
+
+      return rows.map(r => ({
+        guid: r.guid,
+        type: r.type,
+        name: r.name,
+        total: new Money(r.total, r.mnemonic),
+      }));
+    },
     networkMode: 'always',
-  }) as UseQueryResult<{ guid: string, total: number, type: string, name: string }[]>;
+  });
 
   return result;
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom';
 import crypto from 'crypto';
 
 import { DateTime, Interval, Settings } from 'luxon';
+import { QueryClient } from '@tanstack/react-query';
 
 // https://github.com/chartjs/chartjs-adapter-luxon/issues/91
 jest.mock('chartjs-adapter-luxon', jest.fn());
@@ -50,6 +51,7 @@ Settings.now = () => 1672531200000; // 2023-01-01
 
 declare global {
   const TEST_INTERVAL: Interval;
+  const QUERY_CLIENT: QueryClient;
 }
 
 Object.defineProperty(
@@ -61,5 +63,19 @@ Object.defineProperty(
       DateTime.now().minus({ month: 5 }).startOf('month'),
       DateTime.now().endOf('day'),
     ),
+  },
+);
+
+Object.defineProperty(
+  global,
+  'QUERY_CLIENT',
+  {
+    value: new QueryClient({
+      defaultOptions: {
+        queries: {
+          throwOnError: true,
+        },
+      },
+    }),
   },
 );


### PR DESCRIPTION
Fixed an issue with cash flow calculation where currencies of the accounts were not being take into account. In this version, we now retrieve each split in a transaction related to the account we are generating the cash flow report on and convert the quantities to the currency of the account.

To do that we use the following formula: `(main_split.quantity / main_split.value) * other_split.value`. The beauty of this is that it works for any kind of transaction regardless on the amount of splits it has or the currencies it has.

This is how the "Broker cash" account of the demo account looks like now:

<img width="522" alt="Screenshot 2024-03-25 at 12 47 17 PM" src="https://github.com/maffin-io/maffin-app/assets/3578154/906025dd-2bf4-47a2-9a35-7aebf261d080">

vs before

<img width="523" alt="Screenshot 2024-03-25 at 12 47 55 PM" src="https://github.com/maffin-io/maffin-app/assets/3578154/9eb10294-c1e3-4686-9fc9-85e2000782e8">

> 35 was the number of stocks, not the euros amount
