### PR TITLE
Add missing optiong to keep previous query data

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "debounce-promise": "^3.1.2",
     "dinero.js": "^2.0.0-alpha.14",
     "luxon": "^3.4.4",
-    "next": "^14.1.3",
+    "next": "^14.1.4",
     "pako": "^2.1.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",

--- a/src/__tests__/app/dashboard/accounts/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/page.test.tsx
@@ -18,16 +18,10 @@ import { AccountsTable } from '@/components/tables';
 import { TotalsPie, MonthlyTotalHistogram, NetWorthHistogram } from '@/components/charts';
 import IncomeExpenseHistogram from '@/components/pages/accounts/IncomeExpenseHistogram';
 import * as apiHook from '@/hooks/api';
-import * as stateHooks from '@/hooks/state';
 
 jest.mock('@/hooks/api', () => ({
   __esModule: true,
   ...jest.requireActual('@/hooks/api'),
-}));
-
-jest.mock('@/hooks/state', () => ({
-  __esModule: true,
-  ...jest.requireActual('@/hooks/state'),
 }));
 
 jest.mock('@/components/buttons/FormButton', () => jest.fn(
@@ -78,7 +72,6 @@ describe('AccountsPage', () => {
   beforeEach(() => {
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-02') as DateTime<true>);
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
-    jest.spyOn(stateHooks, 'useInterval').mockReturnValue({ data: TEST_INTERVAL } as DefinedUseQueryResult<Interval>);
   });
 
   afterEach(() => {
@@ -165,7 +158,6 @@ describe('AccountsPage', () => {
       {
         title: 'Income',
         accounts: undefined,
-        interval: TEST_INTERVAL,
       },
       {},
     );
@@ -174,7 +166,6 @@ describe('AccountsPage', () => {
       {
         title: 'Expenses',
         accounts: undefined,
-        interval: TEST_INTERVAL,
       },
       {},
     );
@@ -294,7 +285,6 @@ describe('AccountsPage', () => {
       1,
       {
         title: 'Income',
-        interval: TEST_INTERVAL,
         guids: [accounts[4].guid],
       },
       {},
@@ -303,7 +293,6 @@ describe('AccountsPage', () => {
       2,
       {
         title: 'Expenses',
-        interval: TEST_INTERVAL,
         guids: [accounts[2].guid],
       },
       {},

--- a/src/__tests__/components/pages/account/IEInfo.test.tsx
+++ b/src/__tests__/components/pages/account/IEInfo.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { DateTime, Interval } from 'luxon';
+import { DateTime } from 'luxon';
 
 import { IEInfo } from '@/components/pages/account';
 import TotalWidget from '@/components/pages/account/TotalWidget';
@@ -55,10 +55,6 @@ describe('IEInfo', () => {
       {
         guids: [account.guid],
         title: '',
-        interval: Interval.fromDateTimes(
-          DateTime.now().minus({ year: 1 }).startOf('month'),
-          DateTime.now(),
-        ),
       },
       {},
     );
@@ -90,10 +86,6 @@ describe('IEInfo', () => {
       {
         guids: ['1', '2'],
         title: '',
-        interval: Interval.fromDateTimes(
-          DateTime.now().minus({ year: 1 }).startOf('month'),
-          DateTime.now(),
-        ),
       },
       {},
     );

--- a/src/__tests__/hooks/api/useSplits.test.tsx
+++ b/src/__tests__/hooks/api/useSplits.test.tsx
@@ -416,6 +416,8 @@ describe('useSplits', () => {
       jest.spyOn(usePricesHook, 'usePrices').mockReturnValue({
         data: {},
       } as UseQueryResult<PriceDBMap>);
+      jest.spyOn(stateHooks, 'useInterval').mockReturnValue({ data: TEST_INTERVAL } as DefinedUseQueryResult<Interval>);
+
       jest.spyOn(queries, 'getMonthlyTotals').mockResolvedValue([
         {
           type_asset: new Money(100, 'EUR'),
@@ -449,7 +451,7 @@ describe('useSplits', () => {
           'splits',
           {
             aggregation: 'monthly-total',
-            dates: '2022-07-01/2023-01-01',
+            dates: TEST_INTERVAL.toISODate(),
           },
         ],
       );
@@ -478,7 +480,7 @@ describe('useSplits', () => {
           'splits',
           {
             aggregation: 'monthly-total',
-            dates: '2022-03-01/2022-05-01',
+            dates: interval.toISODate(),
             accountsUpdatedAt: 1,
           }],
       );

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -18,13 +18,11 @@ import { AccountsTable } from '@/components/tables';
 import Loading from '@/components/Loading';
 import Onboarding from '@/components/onboarding/Onboarding';
 import { useAccounts } from '@/hooks/api';
-import { useInterval } from '@/hooks/state';
 import mapAccounts from '@/helpers/mapAccounts';
 import { ASSET, LIABILITY } from '@/constants/colors';
 
 export default function AccountsPage(): JSX.Element {
   const { data, isLoading } = useAccounts();
-  const { data: interval } = useInterval();
 
   if (isLoading) {
     return (
@@ -105,7 +103,6 @@ export default function AccountsPage(): JSX.Element {
             <MonthlyTotalHistogram
               guids={accountsMap?.type_income?.childrenIds}
               title="Income"
-              interval={interval}
             />
           </div>
           <div className="card col-span-8">
@@ -115,7 +112,6 @@ export default function AccountsPage(): JSX.Element {
             <MonthlyTotalHistogram
               guids={accountsMap?.type_expense?.childrenIds}
               title="Expenses"
-              interval={interval}
             />
           </div>
         </div>

--- a/src/components/charts/MonthlyTotalHistogram.tsx
+++ b/src/components/charts/MonthlyTotalHistogram.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { DateTime, Interval } from 'luxon';
 import type { ChartDataset } from 'chart.js';
 
 import Bar from '@/components/charts/Bar';
@@ -7,22 +6,18 @@ import type { Account } from '@/book/entities';
 import { useAccounts, useAccountsMonthlyTotal, useMainCurrency } from '@/hooks/api';
 import { moneyToString } from '@/helpers/number';
 import monthlyDates from '@/helpers/monthlyDates';
+import { useInterval } from '@/hooks/state';
 
 export type MonthlyTotalHistogramProps = {
   title?: string,
-  interval?: Interval,
   guids: string[],
 };
 
 export default function MonthlyTotalHistogram({
-  interval,
   title,
   guids = [],
 }: MonthlyTotalHistogramProps): JSX.Element {
-  interval = interval || Interval.fromDateTimes(
-    DateTime.now().minus({ months: 6 }).startOf('month'),
-    DateTime.now(),
-  );
+  const { data: interval } = useInterval();
   const { data: monthlyTotals } = useAccountsMonthlyTotal(interval);
   const { data: accounts } = useAccounts();
 
@@ -35,7 +30,7 @@ export default function MonthlyTotalHistogram({
   if (accounts && monthlyTotals) {
     guids.forEach(guid => {
       const data = dates.map((_, i) => (
-        monthlyTotals[i][guid]?.toNumber() || 0
+        monthlyTotals[i]?.[guid]?.toNumber() || 0
       ));
       if (!data.every(v => v === 0)) {
         datasets.push({

--- a/src/components/pages/account/IEInfo.tsx
+++ b/src/components/pages/account/IEInfo.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { DateTime, Interval } from 'luxon';
 import classNames from 'classnames';
 
 import type { Account } from '@/book/entities';
@@ -60,12 +59,6 @@ export default function IEInfo({
           <MonthlyTotalHistogram
             title=""
             guids={account.placeholder ? account.childrenIds : [account.guid]}
-            interval={
-              Interval.fromDateTimes(
-                DateTime.now().minus({ year: 1 }).startOf('month'),
-                DateTime.now(),
-              )
-            }
           />
         </div>
         <div className="col-span-12" />

--- a/src/helpers/accountsTotalAggregations.ts
+++ b/src/helpers/accountsTotalAggregations.ts
@@ -40,7 +40,7 @@ function aggregateWorth(
   dates.forEach((_, i) => {
     const zero = new Money(0, current.commodity?.mnemonic);
     const previousMonth = aggregatedTotals[i - 1]?.[current.guid] || zero;
-    const currentMonth = monthlyTotals[i][current.guid] || zero;
+    const currentMonth = monthlyTotals[i]?.[current.guid] || zero;
     aggregatedTotals[i][current.guid] = currentMonth.add(previousMonth);
   });
 }

--- a/src/hooks/api/useSplits.ts
+++ b/src/hooks/api/useSplits.ts
@@ -234,12 +234,11 @@ export function useAccountsTotals(
  * exchange rate for that month
  */
 export function useAccountsMonthlyTotal(
-  interval?: Interval,
+  selectedInterval?: Interval,
 ): UseQueryResult<AccountsTotals[]> {
-  interval = interval || Interval.fromDateTimes(
-    DateTime.now().minus({ month: 6 }).startOf('month'),
-    DateTime.now(),
-  );
+  const { data: defaultInterval } = useInterval();
+  const interval = selectedInterval || defaultInterval;
+
   const { data: accounts, dataUpdatedAt: accountsUpdatedAt } = useAccounts();
   const { data: prices, dataUpdatedAt: pricesUpdatedAt } = usePrices({});
 

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Settings } from 'luxon';
 import Script from 'next/script';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { keepPreviousData, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Toaster } from 'react-hot-toast';
 
@@ -32,6 +32,7 @@ const queryClient = new QueryClient({
       // online and then go to offline, subsequent queries are paused...
       networkMode: 'always',
       throwOnError: true,
+      placeholderData: keepPreviousData,
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,10 +3980,10 @@
     "@types/gapi.client" "*"
     "@types/gapi.client.discovery" "*"
 
-"@next/env@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.1.3.tgz#73007b64d487bbb95ed83145195f734fc1182d10"
-  integrity sha512-VhgXTvrgeBRxNPjyfBsDIMvgsKDxjlpw4IAUsHCX8Gjl1vtHUYRT3+xfQ/wwvLPDd/6kqfLqk9Pt4+7gysuCKQ==
+"@next/env@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.1.4.tgz#432e80651733fbd67230bf262aee28be65252674"
+  integrity sha512-e7X7bbn3Z6DWnDi75UWn+REgAbLEqxI8Tq2pkFOFAMpWAWApz/YCUhtWMWn410h8Q2fYiYL7Yg5OlxMOCfFjJQ==
 
 "@next/eslint-plugin-next@14.1.4":
   version "14.1.4"
@@ -3992,50 +3992,50 @@
   dependencies:
     glob "10.3.10"
 
-"@next/swc-darwin-arm64@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.3.tgz#b4c218fdb49275972d91e9a9a0ccadba243b6739"
-  integrity sha512-LALu0yIBPRiG9ANrD5ncB3pjpO0Gli9ZLhxdOu6ZUNf3x1r3ea1rd9Q+4xxUkGrUXLqKVK9/lDkpYIJaCJ6AHQ==
+"@next/swc-darwin-arm64@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.4.tgz#a3bca0dc4393ac4cf3169bbf24df63441de66bb7"
+  integrity sha512-ubmUkbmW65nIAOmoxT1IROZdmmJMmdYvXIe8211send9ZYJu+SqxSnJM4TrPj9wmL6g9Atvj0S/2cFmMSS99jg==
 
-"@next/swc-darwin-x64@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.3.tgz#aa0d4357179d68daaa6f400708b76666708ffec9"
-  integrity sha512-E/9WQeXxkqw2dfcn5UcjApFgUq73jqNKaE5bysDm58hEUdUGedVrnRhblhJM7HbCZNhtVl0j+6TXsK0PuzXTCg==
+"@next/swc-darwin-x64@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.4.tgz#ba3683d4e2d30099f3f2864dd7349a4d9f440140"
+  integrity sha512-b0Xo1ELj3u7IkZWAKcJPJEhBop117U78l70nfoQGo4xUSvv0PJSTaV4U9xQBLvZlnjsYkc8RwQN1HoH/oQmLlQ==
 
-"@next/swc-linux-arm64-gnu@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.3.tgz#1ba8df39c04368ede185f268c3a817a8f4290e4c"
-  integrity sha512-USArX9B+3rZSXYLFvgy0NVWQgqh6LHWDmMt38O4lmiJNQcwazeI6xRvSsliDLKt+78KChVacNiwvOMbl6g6BBw==
+"@next/swc-linux-arm64-gnu@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.4.tgz#3519969293f16379954b7e196deb0c1eecbb2f8b"
+  integrity sha512-457G0hcLrdYA/u1O2XkRMsDKId5VKe3uKPvrKVOyuARa6nXrdhJOOYU9hkKKyQTMru1B8qEP78IAhf/1XnVqKA==
 
-"@next/swc-linux-arm64-musl@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.3.tgz#2fa8fe435862eb186aca6d6068c8aef2126ab11e"
-  integrity sha512-esk1RkRBLSIEp1qaQXv1+s6ZdYzuVCnDAZySpa62iFTMGTisCyNQmqyCTL9P+cLJ4N9FKCI3ojtSfsyPHJDQNw==
+"@next/swc-linux-arm64-musl@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.4.tgz#4bb3196bd402b3f84cf5373ff1021f547264d62f"
+  integrity sha512-l/kMG+z6MB+fKA9KdtyprkTQ1ihlJcBh66cf0HvqGP+rXBbOXX0dpJatjZbHeunvEHoBBS69GYQG5ry78JMy3g==
 
-"@next/swc-linux-x64-gnu@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.3.tgz#57a687b44337af219e07a79ecc8c63a3c1b2d020"
-  integrity sha512-8uOgRlYEYiKo0L8YGeS+3TudHVDWDjPVDUcST+z+dUzgBbTEwSSIaSgF/vkcC1T/iwl4QX9iuUyUdQEl0Kxalg==
+"@next/swc-linux-x64-gnu@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.4.tgz#1b3372c98c83dcdab946cdb4ee06e068b8139ba3"
+  integrity sha512-BapIFZ3ZRnvQ1uWbmqEGJuPT9cgLwvKtxhK/L2t4QYO7l+/DxXuIGjvp1x8rvfa/x1FFSsipERZK70pewbtJtw==
 
-"@next/swc-linux-x64-musl@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.3.tgz#8c057f8f7fb9679915df25eda6ab0ea1b7af85ff"
-  integrity sha512-DX2zqz05ziElLoxskgHasaJBREC5Y9TJcbR2LYqu4r7naff25B4iXkfXWfcp69uD75/0URmmoSgT8JclJtrBoQ==
+"@next/swc-linux-x64-musl@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.4.tgz#8459088bdc872648ff78f121db596f2533df5808"
+  integrity sha512-mqVxTwk4XuBl49qn2A5UmzFImoL1iLm0KQQwtdRJRKl21ylQwwGCxJtIYo2rbfkZHoSKlh/YgztY0qH3wG1xIg==
 
-"@next/swc-win32-arm64-msvc@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.3.tgz#5367333e701f722009592013502aa8e735bee782"
-  integrity sha512-HjssFsCdsD4GHstXSQxsi2l70F/5FsRTRQp8xNgmQs15SxUfUJRvSI9qKny/jLkY3gLgiCR3+6A7wzzK0DBlfA==
+"@next/swc-win32-arm64-msvc@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.4.tgz#84280a08c00cc3be24ddd3a12f4617b108e6dea6"
+  integrity sha512-xzxF4ErcumXjO2Pvg/wVGrtr9QQJLk3IyQX1ddAC/fi6/5jZCZ9xpuL9Tzc4KPWMFq8GGWFVDMshZOdHGdkvag==
 
-"@next/swc-win32-ia32-msvc@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.3.tgz#dc455021fee85e037f6fb4134e85895dce5a0495"
-  integrity sha512-DRuxD5axfDM1/Ue4VahwSxl1O5rn61hX8/sF0HY8y0iCbpqdxw3rB3QasdHn/LJ6Wb2y5DoWzXcz3L1Cr+Thrw==
+"@next/swc-win32-ia32-msvc@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.4.tgz#23ff7f4bd0a27177428669ef6fa5c3923c738031"
+  integrity sha512-WZiz8OdbkpRw6/IU/lredZWKKZopUMhcI2F+XiMAcPja0uZYdMTZQRoQ0WZcvinn9xZAidimE7tN9W5v9Yyfyw==
 
-"@next/swc-win32-x64-msvc@14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.3.tgz#4a8d4384901f0c48ece9dbb60cb9aea107d39e7c"
-  integrity sha512-uC2DaDoWH7h1P/aJ4Fok3Xiw6P0Lo4ez7NbowW2VGNXw/Xv6tOuLUcxhBYZxsSUJtpeknCi8/fvnSpyCFp4Rcg==
+"@next/swc-win32-x64-msvc@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.4.tgz#bccf5beccfde66d6c66fa4e2509118c796385eda"
+  integrity sha512-4Rto21sPfw555sZ/XNLqfxDUNeLhNYGO2dlPqsnuCg8N8a2a9u1ltqBOPQ4vj1Gf7eJC0W2hHG2eYUHuiXgY2w==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -9441,12 +9441,12 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-next@^14.1.3:
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/next/-/next-14.1.3.tgz#465bb21a1a6e703e776ca53ea71d05642867fdb5"
-  integrity sha512-oexgMV2MapI0UIWiXKkixF8J8ORxpy64OuJ/J9oVUmIthXOUCcuVEZX+dtpgq7wIfIqtBwQsKEDXejcjTsan9g==
+next@^14.1.4:
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/next/-/next-14.1.4.tgz#203310f7310578563fd5c961f0db4729ce7a502d"
+  integrity sha512-1WTaXeSrUwlz/XcnhGTY7+8eiaFvdet5z9u3V2jb+Ek1vFo0VhHKSAIJvDWfQpttWjnyw14kBeq28TPq7bTeEQ==
   dependencies:
-    "@next/env" "14.1.3"
+    "@next/env" "14.1.4"
     "@swc/helpers" "0.5.2"
     busboy "1.6.0"
     caniuse-lite "^1.0.30001579"
@@ -9454,15 +9454,15 @@ next@^14.1.3:
     postcss "8.4.31"
     styled-jsx "5.1.1"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "14.1.3"
-    "@next/swc-darwin-x64" "14.1.3"
-    "@next/swc-linux-arm64-gnu" "14.1.3"
-    "@next/swc-linux-arm64-musl" "14.1.3"
-    "@next/swc-linux-x64-gnu" "14.1.3"
-    "@next/swc-linux-x64-musl" "14.1.3"
-    "@next/swc-win32-arm64-msvc" "14.1.3"
-    "@next/swc-win32-ia32-msvc" "14.1.3"
-    "@next/swc-win32-x64-msvc" "14.1.3"
+    "@next/swc-darwin-arm64" "14.1.4"
+    "@next/swc-darwin-x64" "14.1.4"
+    "@next/swc-linux-arm64-gnu" "14.1.4"
+    "@next/swc-linux-arm64-musl" "14.1.4"
+    "@next/swc-linux-x64-gnu" "14.1.4"
+    "@next/swc-linux-x64-musl" "14.1.4"
+    "@next/swc-win32-arm64-msvc" "14.1.4"
+    "@next/swc-win32-ia32-msvc" "14.1.4"
+    "@next/swc-win32-x64-msvc" "14.1.4"
 
 node-fetch@^2.6.1:
   version "2.7.0"


### PR DESCRIPTION
To prevent UI from flickering when user selects new account/interval/etc it's better to have `keepPreviousData` as default and disable it on specific queries when needed.