### PR TITLE
Consistent total and monthly net worth

### DIFF
--- a/src/book/Money.ts
+++ b/src/book/Money.ts
@@ -73,8 +73,14 @@ export default class Money {
     );
   }
 
-  toNumber(): number {
-    return parseFloat(djs.toDecimal(this._raw));
+  /**
+   * Return the amount with a default resolution of 10 decimals
+   */
+  toNumber(scale = 10): number {
+    return parseFloat(djs.toDecimal(
+      djs.transformScale(this._raw, scale),
+      ({ value, currency }) => `${value} ${currency.code}`,
+    ));
   }
 
   isNegative(): boolean {

--- a/src/book/__tests__/Money.test.ts
+++ b/src/book/__tests__/Money.test.ts
@@ -48,6 +48,11 @@ describe('Money', () => {
       money = new Money(100, 'USD', 3);
       expect(money.toNumber()).toEqual(0.1);
     });
+
+    it('edge case', () => {
+      money = new Money(9.770491996380624e+27, 'EUR', 24);
+      expect(money.toNumber(4)).toEqual(9770.4919);
+    });
   });
 
   describe('currency', () => {


### PR DESCRIPTION
Discovered a nasty bug when converting Money to a number:

```
      money = new Money(9.770491996380624e+27, 'EUR', 24);
      expect(money.toNumber(4)).toEqual(9770.4919);
```

this was returning `9770.0004`.

Re-converting the scale as we do with toString and others fixes the problem