### PR TITLE
Fix inconsistent totals

### DIFF
--- a/src/__tests__/components/charts/TotalsPie.test.tsx
+++ b/src/__tests__/components/charts/TotalsPie.test.tsx
@@ -29,7 +29,7 @@ jest.mock('@/hooks/state', () => ({
 describe('TotalsPie', () => {
   beforeEach(() => {
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { guid: 'eur', mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
-    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<AccountsTotals>);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: {} });
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
     jest.spyOn(apiHook, 'usePrices').mockReturnValue({ data: {} } as UseQueryResult<PriceDBMap>);
     jest.spyOn(stateHooks, 'useInterval').mockReturnValue({ data: TEST_INTERVAL } as DefinedUseQueryResult<Interval>);
@@ -124,7 +124,7 @@ describe('TotalsPie', () => {
           type_asset: new Money(1500, 'EUR'),
           type_liability: new Money(-150, 'EUR'),
         } as AccountsTotals,
-      } as UseQueryResult<AccountsTotals>,
+      },
     );
 
     render(
@@ -175,7 +175,7 @@ describe('TotalsPie', () => {
           2: new Money(500, 'EUR'),
           3: new Money(100, 'EUR'),
         } as AccountsTotals,
-      } as UseQueryResult<AccountsTotals>,
+      },
     );
 
     render(
@@ -223,7 +223,7 @@ describe('TotalsPie', () => {
           1: new Money(50, 'TICKER1'),
           2: new Money(500, 'TICKER2'),
         } as AccountsTotals,
-      } as UseQueryResult<AccountsTotals>,
+      },
     );
     jest.spyOn(apiHook, 'usePrices').mockReturnValue(
       // @ts-ignore

--- a/src/__tests__/components/pages/account/TotalWidget.test.tsx
+++ b/src/__tests__/components/pages/account/TotalWidget.test.tsx
@@ -22,7 +22,7 @@ describe('TotalWidgetTest', () => {
   let account: Account;
 
   beforeEach(() => {
-    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<AccountsTotals>);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: {} });
     account = {
       guid: 'guid',
       commodity: {
@@ -52,7 +52,7 @@ describe('TotalWidgetTest', () => {
   it('renders as expected', () => {
     jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({
       data: { guid: new Money(100, 'EUR') } as AccountsTotals,
-    } as UseQueryResult<AccountsTotals>);
+    });
 
     render(<TotalWidget account={account} />);
 

--- a/src/__tests__/components/tables/AccountsTable.test.tsx
+++ b/src/__tests__/components/tables/AccountsTable.test.tsx
@@ -24,7 +24,7 @@ describe('AccountsTable', () => {
   beforeEach(() => {
     jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2023-01-01') as DateTime<true>);
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue({ data: undefined } as UseQueryResult<Account[]>);
-    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: undefined } as UseQueryResult<AccountsTotals>);
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: {} });
   });
 
   afterEach(() => {
@@ -109,7 +109,7 @@ describe('AccountsTable', () => {
           a1: new Money(300, 'EUR'),
           a2: new Money(100, 'EUR'),
         } as AccountsTotals,
-      } as UseQueryResult<AccountsTotals>,
+      },
     );
 
     render(<AccountsTable guids={['a1', 'a2']} />);
@@ -188,7 +188,7 @@ describe('AccountsTable', () => {
         data: {
           a1: new Money(200, 'EUR'),
         } as AccountsTotals,
-      } as UseQueryResult<AccountsTotals>,
+      },
     );
 
     render(<AccountsTable guids={['a1']} />);

--- a/src/__tests__/hooks/api/useAccountsTotals.test.tsx
+++ b/src/__tests__/hooks/api/useAccountsTotals.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { DateTime, Interval } from 'luxon';
-import { DefinedUseQueryResult, QueryClientProvider, UseQueryResult } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { DefinedUseQueryResult, UseQueryResult } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
 
 import { useAccountsTotals } from '@/hooks/api';
 import * as incomeStatementHook from '@/hooks/api/useIncomeStatement';
@@ -25,10 +24,6 @@ jest.mock('@/hooks/state', () => ({
   ...jest.requireActual('@/hooks/state'),
 }));
 
-const wrapper = ({ children }: React.PropsWithChildren) => (
-  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
-);
-
 describe('useAccountsTotals', () => {
   beforeEach(() => {
     jest.spyOn(incomeStatementHook, 'useIncomeStatement').mockReturnValue({ data: undefined } as UseQueryResult<AccountsTotals>);
@@ -38,61 +33,12 @@ describe('useAccountsTotals', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    QUERY_CLIENT.removeQueries();
   });
 
-  it('is disabled when no balance sheet', async () => {
-    jest.spyOn(incomeStatementHook, 'useIncomeStatement').mockReturnValue({
-      data: {},
-      dataUpdatedAt: 1,
-    } as UseQueryResult<AccountsTotals>);
+  it('works when no data', async () => {
+    const { result } = renderHook(() => useAccountsTotals());
 
-    renderHook(
-      () => useAccountsTotals(),
-      { wrapper },
-    );
-
-    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
-    expect(queryCache).toHaveLength(1);
-    expect(queryCache[0].queryKey).toEqual(
-      [
-        'api',
-        'splits',
-        {
-          interval: TEST_INTERVAL.toISODate(),
-          aggregation: 'total',
-          bsUpdatedAt: undefined,
-          iesUpdatedAt: 1,
-        },
-      ],
-    );
-  });
-
-  it('is disabled when no income statement', async () => {
-    jest.spyOn(balanceSheetHook, 'useBalanceSheet').mockReturnValue({
-      data: {},
-      dataUpdatedAt: 1,
-    } as UseQueryResult<AccountsTotals>);
-
-    renderHook(
-      () => useAccountsTotals(),
-      { wrapper },
-    );
-
-    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
-    expect(queryCache).toHaveLength(1);
-    expect(queryCache[0].queryKey).toEqual(
-      [
-        'api',
-        'splits',
-        {
-          interval: TEST_INTERVAL.toISODate(),
-          aggregation: 'total',
-          bsUpdatedAt: 1,
-          iesUpdatedAt: undefined,
-        },
-      ],
-    );
+    expect(result.current.data).toEqual({});
   });
 
   it('merges balance sheet and income statement', async () => {
@@ -109,14 +55,10 @@ describe('useAccountsTotals', () => {
       dataUpdatedAt: 1,
     } as UseQueryResult<AccountsTotals>);
 
-    const { result } = renderHook(
-      () => useAccountsTotals(),
-      { wrapper },
-    );
+    const { result } = renderHook(() => useAccountsTotals());
 
-    await waitFor(() => expect(result.current.status).toEqual('success'));
-    expect(result.current.data?.type_asset.format()).toEqual('€10.00');
-    expect(result.current.data?.type_expense.format()).toEqual('€20.00');
+    expect(result.current.data?.type_asset.toString()).toEqual('10.00 EUR');
+    expect(result.current.data?.type_expense.toString()).toEqual('20.00 EUR');
 
     expect(balanceSheetHook.useBalanceSheet).toBeCalledWith(TEST_INTERVAL.end, undefined);
     expect(incomeStatementHook.useIncomeStatement).toBeCalledWith(TEST_INTERVAL, undefined);
@@ -128,24 +70,7 @@ describe('useAccountsTotals', () => {
       DateTime.fromISO('2023'),
     );
 
-    renderHook(
-      () => useAccountsTotals(interval),
-      { wrapper },
-    );
-
-    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
-    expect(queryCache[0].queryKey).toEqual(
-      [
-        'api',
-        'splits',
-        {
-          interval: interval.toISODate(),
-          aggregation: 'total',
-          bsUpdatedAt: undefined,
-          iesUpdatedAt: undefined,
-        },
-      ],
-    );
+    renderHook(() => useAccountsTotals(interval));
 
     expect(balanceSheetHook.useBalanceSheet).toBeCalledWith(interval.end, undefined);
     expect(incomeStatementHook.useIncomeStatement).toBeCalledWith(interval, undefined);
@@ -154,10 +79,7 @@ describe('useAccountsTotals', () => {
   it('uses custom select', async () => {
     const mockSelect = jest.fn();
 
-    renderHook(
-      () => useAccountsTotals(undefined, mockSelect),
-      { wrapper },
-    );
+    renderHook(() => useAccountsTotals(undefined, mockSelect));
 
     expect(balanceSheetHook.useBalanceSheet).toBeCalledWith(TEST_INTERVAL.end, mockSelect);
     expect(incomeStatementHook.useIncomeStatement).toBeCalledWith(TEST_INTERVAL, mockSelect);

--- a/src/hooks/api/useAccountsTotals.ts
+++ b/src/hooks/api/useAccountsTotals.ts
@@ -1,7 +1,5 @@
 import { DateTime, Interval } from 'luxon';
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
-import { Split } from '@/book/entities';
 import type { AccountsTotals } from '@/types/book';
 import { useInterval } from '../state';
 import { useBalanceSheet } from './useBalanceSheet';
@@ -16,7 +14,7 @@ import { useIncomeStatement } from './useIncomeStatement';
 export function useAccountsTotals(
   selectedInterval?: Interval,
   select?: (data: AccountsTotals) => AccountsTotals,
-): UseQueryResult<AccountsTotals> {
+): { data: AccountsTotals } {
   const { data: defaultInterval } = useInterval();
   const interval = selectedInterval || defaultInterval;
 
@@ -29,21 +27,7 @@ export function useAccountsTotals(
     dataUpdatedAt: iesUpdatedAt,
   } = useIncomeStatement(interval, select);
 
-  const queryKey = [
-    ...Split.CACHE_KEY,
-    {
-      aggregation: 'total',
-      interval: interval.toISODate(),
-      bsUpdatedAt,
-      iesUpdatedAt,
-    },
-  ];
-  const result = useQuery({
-    queryKey,
-    queryFn: () => ({ ...balanceSheet, ...incomeStatement }),
-    enabled: !!balanceSheet && !!incomeStatement,
-    networkMode: 'always',
-  });
-
-  return result;
+  return {
+    data: { ...balanceSheet, ...incomeStatement },
+  };
 }


### PR DESCRIPTION
useAccountsTotals basically merges balance sheet and income statement. The problem though is that, because balance sheet uses prices to aggregate totals in the select, it produced inconsistent results because dataUpdatedAt does not take into account the select results which means useAccountsTotals didn't update the data whenever the select result of useBalanceSheet changed.

To fix that, I've changed `useAccountsTotals` to just aggregate the data always without using useQuery