### PR TITLE
Fix query invalidation for txs

### DIFF
--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -286,7 +286,7 @@ describe('caching', () => {
 
     await tx.save();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(7);
+    expect(mockInvalidateQueries).toBeCalledTimes(4);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', tx.guid],
     });
@@ -297,16 +297,7 @@ describe('caching', () => {
       queryKey: ['api', 'txs', { name: 'start' }],
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', '1'],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', '2'],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', { aggregation: 'total' }],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', { aggregation: 'monthly-total' }],
+      queryKey: ['api', 'splits'],
     });
   });
 
@@ -323,7 +314,7 @@ describe('caching', () => {
 
     await tx.remove();
 
-    expect(mockInvalidateQueries).toBeCalledTimes(7);
+    expect(mockInvalidateQueries).toBeCalledTimes(4);
     expect(mockInvalidateQueries).toBeCalledWith({
       queryKey: ['api', 'txs', tx.guid],
     });
@@ -334,16 +325,7 @@ describe('caching', () => {
       queryKey: ['api', 'txs', { name: 'start' }],
     });
     expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', '1'],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', '2'],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', { aggregation: 'total' }],
-    });
-    expect(mockInvalidateQueries).toBeCalledWith({
-      queryKey: ['api', 'splits', { aggregation: 'monthly-total' }],
+      queryKey: ['api', 'splits'],
     });
   });
 });

--- a/src/book/entities/Transaction.ts
+++ b/src/book/entities/Transaction.ts
@@ -121,18 +121,8 @@ export async function updateCache(
     queryKey: [...Transaction.CACHE_KEY, { name: 'start' }],
   });
 
-  entity.splits.forEach(split => {
-    queryClient.invalidateQueries({
-      queryKey: [...Split.CACHE_KEY, split.accountId],
-    });
-  });
-
   queryClient.invalidateQueries({
-    queryKey: [...Split.CACHE_KEY, { aggregation: 'total' }],
-  });
-
-  queryClient.invalidateQueries({
-    queryKey: [...Split.CACHE_KEY, { aggregation: 'monthly-total' }],
+    queryKey: [...Split.CACHE_KEY],
   });
 }
 


### PR DESCRIPTION
When I refactored the accounts total query to use balance-sheet and income-statement forgot to update the keys so numbers where updated on new transactions