### PR TITLE
Transaction add dropdown

### DIFF
--- a/src/__tests__/components/buttons/AddTxDropdown.test.tsx
+++ b/src/__tests__/components/buttons/AddTxDropdown.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { DateTime } from 'luxon';
+import { render, screen } from '@testing-library/react';
+
+import AddTxDropdown from '@/components/buttons/AddTxDropdown';
+import FormButton from '@/components/buttons/FormButton';
+import TransactionForm from '@/components/forms/transaction/TransactionForm';
+import { Account, Split } from '@/book/entities';
+
+jest.mock('@/components/buttons/FormButton', () => jest.fn(
+  (props: React.PropsWithChildren) => (
+    <div data-testid="FormButton">
+      {props.children}
+    </div>
+  ),
+));
+
+jest.mock('@/components/forms/transaction/TransactionForm', () => jest.fn(
+  () => <div data-testid="TransactionForm" />,
+));
+
+describe('AddTxDropdown', () => {
+  beforeEach(() => {
+    jest.spyOn(Split, 'create').mockReturnValue({ guid: 'createdSplit' } as Split);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders as expected', async () => {
+    const account = {
+      guid: 'guid',
+      path: 'path',
+      name: 'account',
+      type: 'TYPE',
+      parentId: 'parent',
+      commodity: {
+        mnemonic: 'EUR',
+      },
+    } as Account;
+
+    const { container } = render(<AddTxDropdown account={account} latestDate={DateTime.now()} />);
+
+    await screen.findAllByTestId('FormButton');
+    expect(FormButton).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        id: 'add-tx',
+        modalTitle: 'Add transaction to account',
+      }),
+      {},
+    );
+    expect(TransactionForm).toBeCalledWith(
+      {
+        defaultValues: {
+          date: DateTime.now().toISODate(),
+          description: '',
+          fk_currency: {
+            mnemonic: 'EUR',
+          },
+          splits: [
+            { guid: 'createdSplit' },
+            {
+              action: '',
+              guid: expect.any(String),
+            },
+          ],
+        },
+      },
+      {},
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/components/buttons/__snapshots__/AddTxDropdown.test.tsx.snap
+++ b/src/__tests__/components/buttons/__snapshots__/AddTxDropdown.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddTxDropdown renders as expected 1`] = `
+<div>
+  <div
+    class="group relative h-full"
+  >
+    <button
+      class="group-hover:bg-cyan-700/80 dark:group-hover:bg-cyan-600 flex h-full w-full items-center btn btn-primary"
+      type="button"
+    >
+      <svg
+        class="mr-1"
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4z"
+        />
+        <path
+          d="M12 2C6.486 2 2 6.486 2 12s4.486 10 10 10 10-4.486 10-10S17.514 2 12 2zm0 18c-4.411 0-8-3.589-8-8s3.589-8 8-8 8 3.589 8 8-3.589 8-8 8z"
+        />
+      </svg>
+      Add
+    </button>
+    <ul
+      class="absolute rounded-md w-40 hidden py-2 group-hover:block bg-white dark:bg-dark-800 "
+    >
+      <li
+        class="text-sm hover:bg-light-100 dark:hover:bg-dark-700"
+      >
+        <div
+          data-testid="FormButton"
+        >
+          <div
+            data-testid="TransactionForm"
+          />
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/src/__tests__/components/pages/account/Header.test.tsx
+++ b/src/__tests__/components/pages/account/Header.test.tsx
@@ -3,12 +3,13 @@ import {
   render,
   screen,
 } from '@testing-library/react';
+import { DateTime } from 'luxon';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { Header } from '@/components/pages/account';
 import FormButton from '@/components/buttons/FormButton';
 import AccountForm from '@/components/forms/account/AccountForm';
-import TransactionForm from '@/components/forms/transaction/TransactionForm';
+import AddTxDropdown from '@/components/buttons/AddTxDropdown';
 import { Account, Split } from '@/book/entities';
 import * as apiHook from '@/hooks/api';
 
@@ -34,8 +35,8 @@ jest.mock('@/components/forms/account/AccountForm', () => jest.fn(
   () => <div data-testid="AccountForm" />,
 ));
 
-jest.mock('@/components/forms/transaction/TransactionForm', () => jest.fn(
-  () => <div data-testid="TransactionForm" />,
+jest.mock('@/components/buttons/AddTxDropdown', () => jest.fn(
+  () => <div data-testid="AddTxDropdown" />,
 ));
 
 describe('Header', () => {
@@ -66,36 +67,16 @@ describe('Header', () => {
 
     const { container } = render(<Header account={account} />);
 
-    await screen.findAllByTestId('FormButton');
-    expect(FormButton).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        id: 'add-tx',
-        modalTitle: 'Add transaction to undefined',
-      }),
-      {},
-    );
-    expect(TransactionForm).toBeCalledWith(
+    expect(AddTxDropdown).toBeCalledWith(
       {
-        defaultValues: {
-          date: '2023-01-01',
-          description: '',
-          fk_currency: {
-            mnemonic: 'EUR',
-          },
-          splits: [
-            { guid: 'createdSplit' },
-            {
-              action: '',
-              guid: expect.any(String),
-            },
-          ],
-        },
+        account,
+        latestDate: DateTime.now(),
       },
       {},
     );
+    await screen.findAllByTestId('FormButton');
     expect(FormButton).toHaveBeenNthCalledWith(
-      2,
+      1,
       expect.objectContaining({
         id: 'edit-account',
         modalTitle: 'Edit account',
@@ -116,7 +97,7 @@ describe('Header', () => {
       {},
     );
     expect(FormButton).toHaveBeenNthCalledWith(
-      3,
+      2,
       expect.objectContaining({
         className: 'btn btn-danger',
         'data-tooltip-id': 'delete-help',

--- a/src/__tests__/components/pages/account/__snapshots__/Header.test.tsx.snap
+++ b/src/__tests__/components/pages/account/__snapshots__/Header.test.tsx.snap
@@ -24,12 +24,8 @@ exports[`Header renders as expected with account 1`] = `
           class=""
         >
           <div
-            data-testid="FormButton"
-          >
-            <div
-              data-testid="TransactionForm"
-            />
-          </div>
+            data-testid="AddTxDropdown"
+          />
         </div>
         <div
           data-testid="FormButton"
@@ -84,12 +80,8 @@ exports[`Header shows parent link 1`] = `
           class=""
         >
           <div
-            data-testid="FormButton"
-          >
-            <div
-              data-testid="TransactionForm"
-            />
-          </div>
+            data-testid="AddTxDropdown"
+          />
         </div>
         <div
           data-testid="FormButton"

--- a/src/components/buttons/AddTxDropdown.tsx
+++ b/src/components/buttons/AddTxDropdown.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { DateTime } from 'luxon';
+import { BiPlusCircle, BiShareAlt } from 'react-icons/bi';
+
+import FormButton from '@/components/buttons/FormButton';
+import TransactionForm from '@/components/forms/transaction/TransactionForm';
+import { Split } from '@/book/entities';
+import type { Account } from '@/book/entities';
+
+export type AddTxDropdownProps = {
+  account: Account,
+  latestDate: DateTime,
+};
+
+export default function AddTxDropdown({
+  account,
+  latestDate,
+}: AddTxDropdownProps): JSX.Element {
+  return (
+    <div className="group relative h-full">
+      <button
+        type="button"
+        className="group-hover:bg-cyan-700/80 dark:group-hover:bg-cyan-600 flex h-full w-full items-center btn btn-primary"
+      >
+        <BiPlusCircle className="mr-1" />
+        Add
+      </button>
+      <ul className="absolute rounded-md w-40 hidden py-2 group-hover:block bg-white dark:bg-dark-800 ">
+        <li className="text-sm hover:bg-light-100 dark:hover:bg-dark-700">
+          <FormButton
+            id="add-tx"
+            className="flex items-center text-left px-3 py-2 w-full text-cyan-700 hover:text-cyan-600 whitespace-nowrap"
+            modalTitle={`Add transaction to ${account.name}`}
+            buttonContent={(
+              <>
+                <BiShareAlt className="mr-1" />
+                Transaction
+              </>
+            )}
+          >
+            <TransactionForm
+              defaultValues={
+                {
+                  date: (latestDate || DateTime.now()).toISODate() as string,
+                  description: '',
+                  splits: [Split.create({ fk_account: account }), new Split()],
+                  fk_currency: account.commodity,
+                }
+              }
+            />
+          </FormButton>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/components/pages/account/Header.tsx
+++ b/src/components/pages/account/Header.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import classNames from 'classnames';
-import { BiEdit, BiXCircle, BiPlusCircle } from 'react-icons/bi';
+import { BiEdit, BiXCircle } from 'react-icons/bi';
 import { DateTime } from 'luxon';
 import { useRouter } from 'next/navigation';
 
 import { Tooltip } from '@/components/tooltips';
 import FormButton from '@/components/buttons/FormButton';
 import AccountForm from '@/components/forms/account/AccountForm';
-import TransactionForm from '@/components/forms/transaction/TransactionForm';
+import AddTxDropdown from '@/components/buttons/AddTxDropdown';
 import {
   isInvestment,
   isAsset,
   isLiability,
 } from '@/book/helpers/accountType';
-import { Account, Split } from '@/book/entities';
+import { Account } from '@/book/entities';
 import { useAccount, useSplitsPagination } from '@/hooks/api';
 import Link from 'next/link';
 
@@ -72,35 +72,8 @@ export default function Header({
             },
           )}
         >
-          <div
-            className={classNames(
-              '',
-              {
-                hidden: account.placeholder,
-              },
-            )}
-          >
-            <FormButton
-              id="add-tx"
-              modalTitle={`Add transaction to ${account?.name}`}
-              buttonContent={(
-                <>
-                  <BiPlusCircle className="mr-1" />
-                  Add transaction
-                </>
-              )}
-            >
-              <TransactionForm
-                defaultValues={
-                  {
-                    date: (latestDate || DateTime.now()).toISODate() as string,
-                    description: '',
-                    splits: [Split.create({ fk_account: account }), new Split()],
-                    fk_currency: account.commodity,
-                  }
-                }
-              />
-            </FormButton>
+          <div className={classNames({ hidden: account.placeholder })}>
+            <AddTxDropdown account={account} latestDate={latestDate || DateTime.now()} />
           </div>
           <FormButton
             id="edit-account"


### PR DESCRIPTION
Changing the "Add transaction" button to a dropdown. For now it only has "add transaction" as option but I'll be working on adding other actions depending on the account type like:

- dividend
- split
- transfer

and so on. This will help with validation and simplify actions for the users

<img width="200" alt="Screenshot 2024-03-31 at 10 44 20 AM" src="https://github.com/maffin-io/maffin-app/assets/3578154/7714281e-3632-45e2-9890-f4b06ee9d897">
