### PR TITLE
Use cost for total invested

### DIFF
--- a/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentInfo.test.tsx
@@ -209,7 +209,6 @@ describe('InvestmentInfo', () => {
     jest.spyOn(apiHook, 'useInvestment').mockReturnValue({
       data: {
         cost: new Money(100, 'EUR'),
-        totalBought: new Money(100, 'EUR'),
         value: new Money(150, 'EUR'),
         unrealizedProfitAbs: new Money(50, 'EUR'),
         unrealizedProfitPct: 50,

--- a/src/__tests__/components/pages/account/InvestmentPlaceholderInfo.test.tsx
+++ b/src/__tests__/components/pages/account/InvestmentPlaceholderInfo.test.tsx
@@ -92,7 +92,7 @@ describe('InvestmentPlaceholderInfo', () => {
       },
       {},
     );
-    expect(WeightsChartMock.mock.calls[0][0].totalValue.toString()).toEqual('5.00 EUR');
+    expect(WeightsChartMock.mock.calls[0][0].totalValue.toString()).toEqual('5 EUR');
     expect(StatisticsWidget).toBeCalledTimes(3);
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       1,
@@ -163,7 +163,7 @@ describe('InvestmentPlaceholderInfo', () => {
     render(<InvestmentPlaceholderInfo account={{ childrenIds: ['guid1'] } as Account} />);
 
     await screen.findByTestId('InvestmentsTable');
-    expect(WeightsChartMock.mock.calls[0][0].totalValue.toString()).toEqual('5.00 USD');
+    expect(WeightsChartMock.mock.calls[0][0].totalValue.toString()).toEqual('5 USD');
     expect(StatisticsWidget).toBeCalledTimes(3);
     expect(StatisticsWidget).toHaveBeenNthCalledWith(
       1,

--- a/src/__tests__/components/tables/AccountsTable.test.tsx
+++ b/src/__tests__/components/tables/AccountsTable.test.tsx
@@ -154,8 +154,8 @@ describe('AccountsTable', () => {
       {},
     );
 
-    expect((Table as jest.Mock).mock.calls[0][0].data[0].total.toString()).toEqual('300.00 EUR');
-    expect((Table as jest.Mock).mock.calls[0][0].data[1].total.toString()).toEqual('100.00 EUR');
+    expect((Table as jest.Mock).mock.calls[0][0].data[0].total.toString()).toEqual('300 EUR');
+    expect((Table as jest.Mock).mock.calls[0][0].data[1].total.toString()).toEqual('100 EUR');
   });
 
   it('creates table with expected params when EXPENSE', async () => {
@@ -219,7 +219,7 @@ describe('AccountsTable', () => {
       {},
     );
 
-    expect((Table as jest.Mock).mock.calls[0][0].data[0].total.toString()).toEqual('200.00 EUR');
+    expect((Table as jest.Mock).mock.calls[0][0].data[0].total.toString()).toEqual('200 EUR');
   });
 
   it('ignores hidden accounts', async () => {

--- a/src/__tests__/helpers/accountsTotalAggregations.test.ts
+++ b/src/__tests__/helpers/accountsTotalAggregations.test.ts
@@ -81,20 +81,15 @@ describe('accountsTotalAggregations', () => {
         ['a1', 'a2'],
         accounts,
         monthlyTotals,
-        [
-          DateTime.now().minus({ month: 2 }),
-          DateTime.now().minus({ month: 1 }),
-          DateTime.now(),
-        ],
       );
 
-      expect(aggregated[0].a1.toString()).toEqual('100.00 EUR');
-      expect(aggregated[1].a1.toString()).toEqual('300.00 EUR');
-      expect(aggregated[2].a1.toString()).toEqual('600.00 EUR');
+      expect(aggregated[0].a1.toString()).toEqual('100 EUR');
+      expect(aggregated[1].a1.toString()).toEqual('300 EUR');
+      expect(aggregated[2].a1.toString()).toEqual('600 EUR');
 
-      expect(aggregated[0].a2.toString()).toEqual('200.00 EUR');
-      expect(aggregated[1].a2.toString()).toEqual('400.00 EUR');
-      expect(aggregated[2].a2.toString()).toEqual('800.00 EUR');
+      expect(aggregated[0].a2.toString()).toEqual('200 EUR');
+      expect(aggregated[1].a2.toString()).toEqual('400 EUR');
+      expect(aggregated[2].a2.toString()).toEqual('800 EUR');
     });
 
     /**
@@ -120,11 +115,11 @@ describe('accountsTotalAggregations', () => {
         monthlyTotals,
       );
 
-      expect(aggregated[0].a1.toString()).toEqual('100.00 EUR');
-      expect(aggregated[1].a1.toString()).toEqual('300.00 EUR');
+      expect(aggregated[0].a1.toString()).toEqual('100 EUR');
+      expect(aggregated[1].a1.toString()).toEqual('300 EUR');
 
-      expect(aggregated[0].a2.toString()).toEqual('200.00 EUR');
-      expect(aggregated[1].a2.toString()).toEqual('400.00 EUR');
+      expect(aggregated[0].a2.toString()).toEqual('200 EUR');
+      expect(aggregated[1].a2.toString()).toEqual('400 EUR');
     });
   });
 
@@ -138,10 +133,10 @@ describe('accountsTotalAggregations', () => {
         {},
       );
 
-      expect(totals.type_asset.toString()).toEqual('0.00 EUR');
-      expect(totals.type_liability.toString()).toEqual('0.00 EUR');
-      expect(totals.type_income.toString()).toEqual('0.00 EUR');
-      expect(totals.type_expense.toString()).toEqual('0.00 EUR');
+      expect(totals.type_asset.toString()).toEqual('0 EUR');
+      expect(totals.type_liability.toString()).toEqual('0 EUR');
+      expect(totals.type_income.toString()).toEqual('0 EUR');
+      expect(totals.type_expense.toString()).toEqual('0 EUR');
     });
 
     it('aggregates children with same currency', () => {
@@ -176,9 +171,9 @@ describe('accountsTotalAggregations', () => {
         totals,
       );
 
-      expect(aggregatedTotals.type_expense.toString()).toEqual('700.00 EUR');
-      expect(aggregatedTotals.a5.toString()).toEqual('500.00 EUR');
-      expect(aggregatedTotals.a6.toString()).toEqual('200.00 EUR');
+      expect(aggregatedTotals.type_expense.toString()).toEqual('700 EUR');
+      expect(aggregatedTotals.a5.toString()).toEqual('500 EUR');
+      expect(aggregatedTotals.a6.toString()).toEqual('200 EUR');
 
       // Check that we don't modify original totals
       expect(Object.keys(totals)).toHaveLength(2);
@@ -231,9 +226,9 @@ describe('accountsTotalAggregations', () => {
       );
 
       // 500 + 200 * 0.8
-      expect(totals.type_expense.toString()).toEqual('680.00 EUR');
-      expect(totals.a5.toString()).toEqual('500.00 EUR');
-      expect(totals.a6.toString()).toEqual('200.00 USD');
+      expect(totals.type_expense.toString()).toEqual('680 EUR');
+      expect(totals.a5.toString()).toEqual('500 EUR');
+      expect(totals.a6.toString()).toEqual('200 USD');
     });
 
     it('aggregates children with different currency and specific date', () => {
@@ -289,9 +284,9 @@ describe('accountsTotalAggregations', () => {
       );
 
       // 500 + 200 * 0.8
-      expect(totals.type_expense.toString()).toEqual('660.00 EUR');
-      expect(totals.a5.toString()).toEqual('500.00 EUR');
-      expect(totals.a6.toString()).toEqual('200.00 USD');
+      expect(totals.type_expense.toString()).toEqual('660 EUR');
+      expect(totals.a5.toString()).toEqual('500 EUR');
+      expect(totals.a6.toString()).toEqual('200 USD');
     });
 
     it('aggregates children that are stocks', () => {
@@ -365,9 +360,9 @@ describe('accountsTotalAggregations', () => {
       );
 
       // 2 * 100 + 5 * 50 * 0.9
-      expect(totals.type_asset.toString()).toEqual('425.00 EUR');
-      expect(totals.a5.toString()).toEqual('2.00 TICKER1');
-      expect(totals.a6.toString()).toEqual('5.00 TICKER2');
+      expect(totals.type_asset.toString()).toEqual('425 EUR');
+      expect(totals.a5.toString()).toEqual('2 TICKER1');
+      expect(totals.a6.toString()).toEqual('5 TICKER2');
     });
 
     it('works with children without totals', () => {
@@ -391,8 +386,8 @@ describe('accountsTotalAggregations', () => {
         {},
       );
 
-      expect(totals.type_asset.toString()).toEqual('0.00 EUR');
-      expect(totals.a5.toString()).toEqual('0.00 EUR');
+      expect(totals.type_asset.toString()).toEqual('0 EUR');
+      expect(totals.a5.toString()).toEqual('0 EUR');
     });
   });
 });

--- a/src/__tests__/hooks/api/useAccountsTotals.test.tsx
+++ b/src/__tests__/hooks/api/useAccountsTotals.test.tsx
@@ -57,8 +57,8 @@ describe('useAccountsTotals', () => {
 
     const { result } = renderHook(() => useAccountsTotals());
 
-    expect(result.current.data?.type_asset.toString()).toEqual('10.00 EUR');
-    expect(result.current.data?.type_expense.toString()).toEqual('20.00 EUR');
+    expect(result.current.data?.type_asset.toString()).toEqual('10 EUR');
+    expect(result.current.data?.type_expense.toString()).toEqual('20 EUR');
 
     expect(balanceSheetHook.useBalanceSheet).toBeCalledWith(TEST_INTERVAL.end, undefined);
     expect(incomeStatementHook.useIncomeStatement).toBeCalledWith(TEST_INTERVAL, undefined);

--- a/src/__tests__/hooks/api/useBalanceSheet.test.tsx
+++ b/src/__tests__/hooks/api/useBalanceSheet.test.tsx
@@ -98,7 +98,7 @@ describe('useBalanceSheet', () => {
         DateTime.fromISO('2023-01-01'),
       ),
     );
-    expect(result.current.data?.type_asset.toString()).toEqual('0.00 EUR');
+    expect(result.current.data?.type_asset.toString()).toEqual('0 EUR');
     expect(aggregations.aggregateChildrenTotals).toBeCalledWith(
       ['type_asset', 'type_liability'],
       [],

--- a/src/__tests__/hooks/api/useCashFlow.test.tsx
+++ b/src/__tests__/hooks/api/useCashFlow.test.tsx
@@ -130,7 +130,7 @@ describe('useCashFlow', () => {
         name: account2.name,
         type: account2.type,
         total: expect.objectContaining({
-          readable: '150.00 EUR',
+          readable: '150 EUR',
         }),
       },
     ]);
@@ -198,8 +198,8 @@ describe('useCashFlow', () => {
    * account2 it creates a row with -55 USD referencing account1
    */
   it.each([
-    ['guid1', 'Expense', '50.00 EUR'],
-    ['guid2', 'Bank1', '-55.00 USD'],
+    ['guid1', 'Expense', '50 EUR'],
+    ['guid2', 'Bank1', '-55 USD'],
   ])('works with different commodities for %s account', async (guid, expectedName, expectedAmount) => {
     const usd = await Commodity.create({ mnemonic: 'USD', namespace: 'CURRENCY' }).save();
     account2.fk_commodity = usd;
@@ -311,7 +311,7 @@ describe('useCashFlow', () => {
     expect(result.current.data?.[0]).toMatchObject({
       name: account1.name,
       total: expect.objectContaining({
-        readable: '-163.00 USD',
+        readable: '-163 USD',
       }),
     });
   });
@@ -376,14 +376,14 @@ describe('useCashFlow', () => {
     expect(result.current.data?.[0]).toMatchObject({
       name: account2.name,
       total: expect.objectContaining({
-        readable: '75.00 EUR',
+        readable: '75 EUR',
       }),
     });
 
     expect(result.current.data?.[1]).toMatchObject({
       name: account3.name,
       total: expect.objectContaining({
-        readable: '25.00 EUR',
+        readable: '25 EUR',
       }),
     });
   });
@@ -454,14 +454,14 @@ describe('useCashFlow', () => {
     expect(result.current.data?.[0]).toMatchObject({
       name: account2.name,
       total: expect.objectContaining({
-        readable: '81.00 USD',
+        readable: '81 USD',
       }),
     });
 
     expect(result.current.data?.[1]).toMatchObject({
       name: account3.name,
       total: expect.objectContaining({
-        readable: '27.00 USD',
+        readable: '27 USD',
       }),
     });
   });
@@ -529,7 +529,7 @@ describe('useCashFlow', () => {
     expect(result.current.data?.[0]).toMatchObject({
       name: account1.name,
       total: expect.objectContaining({
-        readable: '-700.00 EUR',
+        readable: '-700 EUR',
       }),
     });
   });
@@ -588,7 +588,7 @@ describe('useCashFlow', () => {
     expect(result.current.data?.[0]).toMatchObject({
       name: account2.name,
       total: expect.objectContaining({
-        readable: '100.00 EUR',
+        readable: '100 EUR',
       }),
     });
   });

--- a/src/__tests__/hooks/api/useIncomeStatement.test.tsx
+++ b/src/__tests__/hooks/api/useIncomeStatement.test.tsx
@@ -96,7 +96,7 @@ describe('useIncomeStatement', () => {
 
     expect(useAccountsHook.useAccounts).toBeCalledWith();
     expect(queries.getAccountsTotals).toBeCalledWith([], TEST_INTERVAL);
-    expect(result.current.data?.type_income.toString()).toEqual('0.00 EUR');
+    expect(result.current.data?.type_income.toString()).toEqual('0 EUR');
     expect(aggregations.aggregateChildrenTotals).toBeCalledWith(
       ['type_income', 'type_expense'],
       [],

--- a/src/__tests__/hooks/api/useMonthlyTotals.test.tsx
+++ b/src/__tests__/hooks/api/useMonthlyTotals.test.tsx
@@ -120,7 +120,7 @@ describe('useMonthlyTotals', () => {
     expect(useAccountsHook.useAccounts).toBeCalledWith();
     expect(usePricesHook.usePrices).toBeCalledWith({});
     expect(queries.getMonthlyTotals).toBeCalledWith([], interval);
-    expect(result.current.data?.[0].type_asset.toString()).toEqual('400.00 EUR');
+    expect(result.current.data?.[0].type_asset.toString()).toEqual('400 EUR');
 
     expect(aggregations.aggregateChildrenTotals).toBeCalledTimes(2);
     expect(aggregations.aggregateChildrenTotals).nthCalledWith(

--- a/src/__tests__/hooks/api/useMonthlyWorth.test.tsx
+++ b/src/__tests__/hooks/api/useMonthlyWorth.test.tsx
@@ -150,7 +150,7 @@ describe('useMonthlyWorth', () => {
         TEST_INTERVAL.end as DateTime,
       ),
     );
-    expect(result.current.data?.[0].type_asset.toString()).toEqual('1000.00 EUR');
+    expect(result.current.data?.[0].type_asset.toString()).toEqual('1000 EUR');
 
     expect(aggregations.aggregateMonthlyWorth).toBeCalledTimes(1);
     expect(aggregations.aggregateMonthlyWorth).toBeCalledWith(
@@ -168,10 +168,10 @@ describe('useMonthlyWorth', () => {
     );
     expect(
       (aggregations.aggregateMonthlyWorth as jest.Mock).mock.calls[0][2][0].type_asset.toString(),
-    ).toEqual('500.00 EUR');
+    ).toEqual('500 EUR');
     expect(
       (aggregations.aggregateMonthlyWorth as jest.Mock).mock.calls[0][2][1].type_asset.toString(),
-    ).toEqual('200.00 EUR');
+    ).toEqual('200 EUR');
 
     expect(aggregations.aggregateChildrenTotals).toBeCalledTimes(3);
     expect(aggregations.aggregateChildrenTotals).toHaveBeenNthCalledWith(

--- a/src/__tests__/lib/queries/getAccountsTotals.test.ts
+++ b/src/__tests__/lib/queries/getAccountsTotals.test.ts
@@ -126,8 +126,8 @@ describe('getAccountsTotals', () => {
       TEST_INTERVAL,
     );
 
-    expect(totals.abcdef.toString()).toEqual('-300.00 EUR');
-    expect(totals.ghijk.toString()).toEqual('300.00 EUR');
+    expect(totals.abcdef.toString()).toEqual('-300 EUR');
+    expect(totals.ghijk.toString()).toEqual('300 EUR');
   });
 
   it('filters by date', async () => {
@@ -179,7 +179,7 @@ describe('getAccountsTotals', () => {
       TEST_INTERVAL,
     );
 
-    expect(totals.abcdef.toString()).toEqual('-100.00 EUR');
-    expect(totals.ghijk.toString()).toEqual('100.00 EUR');
+    expect(totals.abcdef.toString()).toEqual('-100 EUR');
+    expect(totals.ghijk.toString()).toEqual('100 EUR');
   });
 });

--- a/src/__tests__/lib/queries/getMonthlyTotals.test.ts
+++ b/src/__tests__/lib/queries/getMonthlyTotals.test.ts
@@ -122,8 +122,8 @@ describe('getMonthlyTotals', () => {
 
     expect(monthlyTotals).toHaveLength(3);
     expect(monthlyTotals[0]).toEqual({});
-    expect(monthlyTotals[1].abcdef.toString()).toEqual('-200.00 EUR');
-    expect(monthlyTotals[1].ghijk.toString()).toEqual('200.00 EUR');
+    expect(monthlyTotals[1].abcdef.toString()).toEqual('-200 EUR');
+    expect(monthlyTotals[1].ghijk.toString()).toEqual('200 EUR');
     expect(monthlyTotals[2]).toEqual({});
   });
 });

--- a/src/book/Money.ts
+++ b/src/book/Money.ts
@@ -53,10 +53,10 @@ export default class Money {
    * Represents the money object as a string with the currency standardizing
    * the scale to 2 as a default. If the scale is passed then it uses that.
    */
-  toString(scale = 2): string {
+  toString(scale = 4): string {
     return djs.toDecimal(
       djs.transformScale(this._raw, scale),
-      ({ value, currency }) => `${value} ${currency.code}`,
+      ({ value, currency }) => `${toFixed(Number(value))} ${currency.code}`,
     );
   }
 

--- a/src/book/Money.ts
+++ b/src/book/Money.ts
@@ -3,7 +3,7 @@ import * as currencies from '@dinero.js/currencies';
 import type { Currency as DineroCurrency } from 'dinero.js';
 import * as djs from 'dinero.js';
 
-import { toAmountWithScale, moneyToString } from '@/helpers/number';
+import { toAmountWithScale, moneyToString, toFixed } from '@/helpers/number';
 import type { PriceDBMap } from './prices';
 import type { Commodity } from './entities';
 
@@ -66,10 +66,10 @@ export default class Money {
    *
    * The result is a localized string with the currency as a symbol
    */
-  format(scale = 2): string {
+  format(scale = 4): string {
     return djs.toDecimal(
       djs.transformScale(this._raw, scale),
-      ({ value, currency }) => moneyToString(Number(value), currency.code),
+      ({ value, currency }) => moneyToString(toFixed(Number(value)), currency.code),
     );
   }
 

--- a/src/book/__tests__/Money.test.ts
+++ b/src/book/__tests__/Money.test.ts
@@ -11,11 +11,11 @@ describe('Money', () => {
 
   describe('initialisation', () => {
     it('initializes with int', () => {
-      expect(new Money(100, 'EUR').toString()).toEqual('100.00 EUR');
+      expect(new Money(100, 'EUR').toString()).toEqual('100 EUR');
     });
 
     it('initializes with float', () => {
-      expect(new Money(1.235566134, 'EUR').toString()).toEqual('1.23 EUR');
+      expect(new Money(1.235566134, 'EUR').toString()).toEqual('1.24 EUR');
     });
 
     it('initializes with custom scale', () => {
@@ -36,6 +36,11 @@ describe('Money', () => {
     it('works with commodities', () => {
       money = new Money(100.10, 'GOOGL');
       expect(money.format()).toEqual('100.1 GOOGL');
+    });
+
+    it('rounds', () => {
+      money = new Money(100.9999, 'GOOGL');
+      expect(money.format()).toEqual('101 GOOGL');
     });
   });
 
@@ -76,14 +81,14 @@ describe('Money', () => {
     it('adds as expected', () => {
       const b = new Money(100, 'EUR');
       const result = money.add(b);
-      expect(result.toString()).toEqual('200.00 EUR');
+      expect(result.toString()).toEqual('200 EUR');
     });
 
     it('adds big decimals', () => {
       const b = new Money(7590.297130000002, 'EUR');
       const c = new Money(3015.95, 'EUR');
 
-      expect(b.add(c).toString()).toEqual('10606.24 EUR');
+      expect(b.add(c).toString()).toEqual('10606.25 EUR');
     });
   });
 
@@ -91,54 +96,54 @@ describe('Money', () => {
     it('subtracts as expected', () => {
       const b = new Money(50, 'EUR');
       const result = money.subtract(b);
-      expect(result.toString()).toEqual('50.00 EUR');
+      expect(result.toString()).toEqual('50 EUR');
     });
 
     it('goes to 0', () => {
       const b = new Money(100, 'EUR');
       const result = money.subtract(b);
-      expect(result.toString()).toEqual('0.00 EUR');
+      expect(result.toString()).toEqual('0 EUR');
     });
 
     it('subtracts into negative', () => {
       const b = new Money(200, 'EUR');
       const result = money.subtract(b);
-      expect(result.toString()).toEqual('-100.00 EUR');
+      expect(result.toString()).toEqual('-100 EUR');
     });
   });
 
   describe('multiply', () => {
     it('multiplies as expected', () => {
       const result = money.multiply(2);
-      expect(result.toString()).toEqual('200.00 EUR');
+      expect(result.toString()).toEqual('200 EUR');
     });
 
     it('multiplies negative numbers as expected', () => {
       const result = money.multiply(-2);
-      expect(result.toString()).toEqual('-200.00 EUR');
+      expect(result.toString()).toEqual('-200 EUR');
     });
 
     it('multiplies decimals', () => {
       const result = money.multiply(1.5);
-      expect(result.toString()).toEqual('150.00 EUR');
+      expect(result.toString()).toEqual('150 EUR');
     });
 
     it('multiplies negative decimals', () => {
       money = new Money(-122.86, 'EUR');
       const result = money.multiply(8.14);
-      expect(result.toString()).toEqual('-1000.09 EUR');
+      expect(result.toString()).toEqual('-1000.08 EUR');
     });
 
     it('multiplies long decimals', () => {
       money = new Money(122.8501, 'EUR');
       const result = money.multiply(8.140001514040282);
-      expect(result.toString()).toEqual('1000.00 EUR');
+      expect(result.toString()).toEqual('1000 EUR');
     });
 
     it('multiplies long negative decimals', () => {
       money = new Money(-122.8501, 'EUR');
       const result = money.multiply(8.140001514040282);
-      expect(result.toString()).toEqual('-1000.00 EUR');
+      expect(result.toString()).toEqual('-1000 EUR');
     });
   });
 
@@ -161,34 +166,34 @@ describe('Money', () => {
 
   describe('convert', () => {
     it('converts with different currency', () => {
-      money = new Money(100, 'USD'); // This represents 1 USD
-      expect(money.convert('EUR', 0.94).toString()).toEqual('94.00 EUR');
+      money = new Money(100, 'USD');
+      expect(money.convert('EUR', 0.94).toString()).toEqual('94 EUR');
     });
 
     it('converts with different currency long number', () => {
-      money = new Money(18546718, 'USD'); // This represents 185467.18 USD
+      money = new Money(18546718, 'USD');
       expect(money.convert('EUR', 0.94).toString()).toEqual('17433914.92 EUR');
     });
 
     it('converts with multiple decimals', () => {
-      money = new Money(11816, 'USD'); // This represents 185467.18 USD
-      expect(money.convert('EUR', 0.8499).toString()).toEqual('10042.41 EUR');
+      money = new Money(11816, 'USD');
+      expect(money.convert('EUR', 0.8499).toString()).toEqual('10042.42 EUR');
     });
 
     it('converts with same currency', () => {
-      expect(money.convert('EUR', 0.94).toString()).toEqual('94.00 EUR');
+      expect(money.convert('EUR', 0.94).toString()).toEqual('94 EUR');
     });
   });
 
   describe('abs', () => {
     it('returns abs for positive', () => {
       money = new Money(100, 'EUR');
-      expect(money.abs().toString()).toEqual('100.00 EUR');
+      expect(money.abs().toString()).toEqual('100 EUR');
     });
 
     it('returns abs for negative', () => {
       money = new Money(-100, 'EUR');
-      expect(money.abs().toString()).toEqual('100.00 EUR');
+      expect(money.abs().toString()).toEqual('100 EUR');
     });
   });
 });
@@ -237,7 +242,7 @@ describe('convert', () => {
       prices,
     );
 
-    expect(money.toString()).toEqual('1000.00 EUR');
+    expect(money.toString()).toEqual('1000 EUR');
   });
 
   it('converts as expected when investment with different currency', () => {
@@ -262,6 +267,6 @@ describe('convert', () => {
       prices,
     );
 
-    expect(money.toString()).toEqual('987.00 EUR');
+    expect(money.toString()).toEqual('987 EUR');
   });
 });

--- a/src/book/__tests__/models/InvestmentAccount.test.ts
+++ b/src/book/__tests__/models/InvestmentAccount.test.ts
@@ -96,17 +96,17 @@ describe('InvestmentAccount', () => {
       expect(investment.mainCurrency).toEqual('EUR');
       expect(investment.currency).toEqual('EUR');
 
-      expect(investment.quantity.toString()).toEqual('0.00 TICKER');
-      expect(investment.cost.toString()).toEqual('0.00 EUR');
-      expect(investment.costInCurrency.toString()).toEqual('0.00 EUR');
-      expect(investment.value.toString()).toEqual('0.00 EUR');
-      expect(investment.valueInCurrency.toString()).toEqual('0.00 EUR');
+      expect(investment.quantity.toString()).toEqual('0 TICKER');
+      expect(investment.cost.toString()).toEqual('0 EUR');
+      expect(investment.costInCurrency.toString()).toEqual('0 EUR');
+      expect(investment.value.toString()).toEqual('0 EUR');
+      expect(investment.valueInCurrency.toString()).toEqual('0 EUR');
       expect(investment.avgPrice).toEqual(0);
 
-      expect(investment.realizedProfit.toString()).toEqual('0.00 EUR');
-      expect(investment.realizedProfitInCurrency.toString()).toEqual('0.00 EUR');
-      expect(investment.realizedDividends.toString()).toEqual('0.00 EUR');
-      expect(investment.realizedDividendsInCurrency.toString()).toEqual('0.00 EUR');
+      expect(investment.realizedProfit.toString()).toEqual('0 EUR');
+      expect(investment.realizedProfitInCurrency.toString()).toEqual('0 EUR');
+      expect(investment.realizedDividends.toString()).toEqual('0 EUR');
+      expect(investment.realizedDividendsInCurrency.toString()).toEqual('0 EUR');
       expect(investment.isClosed).toBe(true);
 
       expect(investment.dividends).toHaveLength(0);
@@ -151,17 +151,17 @@ describe('InvestmentAccount', () => {
       expect(investment.mainCurrency).toEqual('EUR');
       expect(investment.currency).toEqual('USD');
 
-      expect(investment.quantity.toString()).toEqual('0.00 TICKER');
-      expect(investment.cost.toString()).toEqual('0.00 USD');
-      expect(investment.costInCurrency.toString()).toEqual('0.00 EUR');
-      expect(investment.value.toString()).toEqual('0.00 USD');
-      expect(investment.valueInCurrency.toString()).toEqual('0.00 EUR');
+      expect(investment.quantity.toString()).toEqual('0 TICKER');
+      expect(investment.cost.toString()).toEqual('0 USD');
+      expect(investment.costInCurrency.toString()).toEqual('0 EUR');
+      expect(investment.value.toString()).toEqual('0 USD');
+      expect(investment.valueInCurrency.toString()).toEqual('0 EUR');
       expect(investment.avgPrice).toEqual(0);
 
-      expect(investment.realizedProfit.toString()).toEqual('0.00 USD');
-      expect(investment.realizedProfitInCurrency.toString()).toEqual('0.00 EUR');
-      expect(investment.realizedDividends.toString()).toEqual('0.00 USD');
-      expect(investment.realizedDividendsInCurrency.toString()).toEqual('0.00 EUR');
+      expect(investment.realizedProfit.toString()).toEqual('0 USD');
+      expect(investment.realizedProfitInCurrency.toString()).toEqual('0 EUR');
+      expect(investment.realizedDividends.toString()).toEqual('0 USD');
+      expect(investment.realizedDividendsInCurrency.toString()).toEqual('0 EUR');
 
       expect(investment.dividends).toHaveLength(0);
 
@@ -389,11 +389,11 @@ describe('InvestmentAccount', () => {
         );
 
         expect(instance.quantity.toString()).toEqual('122.85 TICKER');
-        expect(instance.cost.toString()).toEqual(`1000.00 ${currency}`);
+        expect(instance.cost.toString()).toEqual(`1000 ${currency}`);
         expect(instance.costInCurrency.toString()).toEqual(`${instance.cost.convert(mainCurrency, currencyPrice.value)}`);
         expect(instance.avgPrice).toEqual(8.14);
 
-        expect(instance.value.toString()).toEqual(`1228.50 ${currency}`);
+        expect(instance.value.toString()).toEqual(`1228.5 ${currency}`);
         expect(instance.valueInCurrency.toString()).toEqual(`${instance.value.convert(mainCurrency, todayCurrencyPrice.value)}`);
       });
 
@@ -455,13 +455,13 @@ describe('InvestmentAccount', () => {
         );
 
         expect(instance.quantity.toString()).toEqual('368.55 TICKER');
-        expect(instance.cost.toString()).toEqual(`2700.00 ${currency}`);
+        expect(instance.cost.toString()).toEqual(`2700 ${currency}`);
         const expectedCostInCurrency = new Money(
           1000 * currencyPrice.value + 1700 * currencyPrice2.value,
           mainCurrency,
         );
         expect(instance.costInCurrency.toString()).toEqual(expectedCostInCurrency.toString());
-        expect(instance.value.toString()).toEqual(`3685.50 ${currency}`);
+        expect(instance.value.toString()).toEqual(`3685.5 ${currency}`);
         expect(instance.valueInCurrency.toString()).toEqual(
           `${instance.value.convert(mainCurrency, todayCurrencyPrice.value)}`,
         );
@@ -518,13 +518,13 @@ describe('InvestmentAccount', () => {
           new PriceDBMap([stockPrice, currencyPrice]),
         );
 
-        expect(instance.quantity.toString()).toEqual('0.00 TICKER');
-        expect(instance.realizedProfit.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.realizedProfitInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
-        expect(instance.cost.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.costInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
-        expect(instance.value.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.valueInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
+        expect(instance.quantity.toString()).toEqual('0 TICKER');
+        expect(instance.realizedProfit.toString()).toEqual(`0 ${currency}`);
+        expect(instance.realizedProfitInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
+        expect(instance.cost.toString()).toEqual(`0 ${currency}`);
+        expect(instance.costInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
+        expect(instance.value.toString()).toEqual(`0 ${currency}`);
+        expect(instance.valueInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
       });
 
       it('sells with gains', async () => {
@@ -576,8 +576,8 @@ describe('InvestmentAccount', () => {
           new PriceDBMap([stockPrice, currencyPrice]),
         );
 
-        expect(instance.quantity.toString()).toEqual('0.00 TICKER');
-        expect(instance.realizedProfit.toString()).toEqual(`1000.00 ${currency}`);
+        expect(instance.quantity.toString()).toEqual('0 TICKER');
+        expect(instance.realizedProfit.toString()).toEqual(`1000 ${currency}`);
         const expectedRealizedProfitInCurrency = new Money(
           1000 * currencyPrice.value,
           mainCurrency,
@@ -585,10 +585,10 @@ describe('InvestmentAccount', () => {
         expect(instance.realizedProfitInCurrency.toString()).toEqual(
           expectedRealizedProfitInCurrency.toString(),
         );
-        expect(instance.cost.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.costInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
-        expect(instance.value.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.valueInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
+        expect(instance.cost.toString()).toEqual(`0 ${currency}`);
+        expect(instance.costInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
+        expect(instance.value.toString()).toEqual(`0 ${currency}`);
+        expect(instance.valueInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
       });
 
       it('sells with losses', async () => {
@@ -639,8 +639,8 @@ describe('InvestmentAccount', () => {
           new PriceDBMap([stockPrice, currencyPrice]),
         );
 
-        expect(instance.quantity.toString()).toEqual('0.00 TICKER');
-        expect(instance.realizedProfit.toString()).toEqual(`-500.00 ${currency}`);
+        expect(instance.quantity.toString()).toEqual('0 TICKER');
+        expect(instance.realizedProfit.toString()).toEqual(`-500 ${currency}`);
         const expectedRealizedProfitInCurrency = new Money(
           -500 * currencyPrice.value,
           mainCurrency,
@@ -648,10 +648,10 @@ describe('InvestmentAccount', () => {
         expect(instance.realizedProfitInCurrency.toString()).toEqual(
           expectedRealizedProfitInCurrency.toString(),
         );
-        expect(instance.cost.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.costInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
-        expect(instance.value.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.valueInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
+        expect(instance.cost.toString()).toEqual(`0 ${currency}`);
+        expect(instance.costInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
+        expect(instance.value.toString()).toEqual(`0 ${currency}`);
+        expect(instance.valueInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
       });
 
       it('sells partially with gains', async () => {
@@ -703,12 +703,12 @@ describe('InvestmentAccount', () => {
         );
 
         expect(instance.quantity.toString()).toEqual('61.42 TICKER');
-        expect(instance.realizedProfit.toString()).toEqual(`500.00 ${currency}`);
+        expect(instance.realizedProfit.toString()).toEqual(`500 ${currency}`);
         const expectedRealizedProfitInCurrency = new Money(500 * currencyPrice.value, mainCurrency);
         expect(instance.realizedProfitInCurrency.toString()).toEqual(
           expectedRealizedProfitInCurrency.toString(),
         );
-        expect(instance.cost.toString()).toEqual(`500.00 ${currency}`);
+        expect(instance.cost.toString()).toEqual(`500 ${currency}`);
         const expectedCostInCurrency = new Money(500 * currencyPrice.value, mainCurrency);
         expect(instance.costInCurrency.toString()).toEqual(expectedCostInCurrency.toString());
         expect(instance.value.toString()).toEqual(`614.25 ${currency}`);
@@ -765,7 +765,7 @@ describe('InvestmentAccount', () => {
         );
 
         expect(instance.quantity.toString()).toEqual('61.42 TICKER');
-        expect(instance.realizedProfit.toString()).toEqual(`-250.00 ${currency}`);
+        expect(instance.realizedProfit.toString()).toEqual(`-250 ${currency}`);
         const expectedRealizedProfitInCurrency = new Money(
           -250 * currencyPrice.value,
           mainCurrency,
@@ -773,7 +773,7 @@ describe('InvestmentAccount', () => {
         expect(instance.realizedProfitInCurrency.toString()).toEqual(
           expectedRealizedProfitInCurrency.toString(),
         );
-        expect(instance.cost.toString()).toEqual(`500.00 ${currency}`);
+        expect(instance.cost.toString()).toEqual(`500 ${currency}`);
         const expectedCostInCurrency = new Money(500 * currencyPrice.value, mainCurrency);
         expect(instance.costInCurrency.toString()).toEqual(expectedCostInCurrency.toString());
         expect(instance.value.toString()).toEqual(`614.25 ${currency}`);
@@ -825,12 +825,12 @@ describe('InvestmentAccount', () => {
         );
 
         expect(instance.quantity.toString()).toEqual('143.85 TICKER');
-        expect(instance.cost.toString()).toEqual(`1000.00 ${currency}`); // cost stays the same
+        expect(instance.cost.toString()).toEqual(`1000 ${currency}`); // cost stays the same
         const expectedCostInCurrency = new Money(1000 * currencyPrice.value, mainCurrency);
         expect(instance.costInCurrency.toString()).toEqual(expectedCostInCurrency.toString());
         expect(instance.avgPrice).toEqual(6.9517); // avgPrice is recomputed
-        expect(instance.value.toString()).toEqual(`1438.50 ${currency}`); // value increases
-        const expectedValueInCurrency = new Money(1438.50 * todayCurrencyPrice.value, mainCurrency);
+        expect(instance.value.toString()).toEqual(`1438.5 ${currency}`); // value increases
+        const expectedValueInCurrency = new Money(1438.5 * todayCurrencyPrice.value, mainCurrency);
         expect(instance.valueInCurrency.toString()).toEqual(expectedValueInCurrency.toString());
       });
     });
@@ -885,12 +885,12 @@ describe('InvestmentAccount', () => {
         );
 
         expect(instance.quantity.toString()).toEqual('143.85 TICKER');
-        expect(instance.cost.toString()).toEqual(`1000.00 ${currency}`); // cost stays the same
+        expect(instance.cost.toString()).toEqual(`1000 ${currency}`); // cost stays the same
         const expectedCostInCurrency = new Money(1000 * currencyPrice.value, mainCurrency);
         expect(instance.costInCurrency.toString()).toEqual(expectedCostInCurrency.toString());
         expect(instance.avgPrice).toEqual(6.9517); // avgPrice is recomputed
-        expect(instance.value.toString()).toEqual(`1438.50 ${currency}`); // value increases
-        const expectedValueInCurrency = new Money(1438.50 * todayCurrencyPrice.value, mainCurrency);
+        expect(instance.value.toString()).toEqual(`1438.5 ${currency}`); // value increases
+        const expectedValueInCurrency = new Money(1438.5 * todayCurrencyPrice.value, mainCurrency);
         expect(instance.valueInCurrency.toString()).toEqual(expectedValueInCurrency.toString());
       });
     });
@@ -967,8 +967,8 @@ describe('InvestmentAccount', () => {
           new PriceDBMap([stockPrice, currencyPrice]),
         );
 
-        expect(instance.realizedProfit.toString()).toEqual(`0.00 ${currency}`);
-        expect(instance.realizedProfitInCurrency.toString()).toEqual(`0.00 ${mainCurrency}`);
+        expect(instance.realizedProfit.toString()).toEqual(`0 ${currency}`);
+        expect(instance.realizedProfitInCurrency.toString()).toEqual(`0 ${mainCurrency}`);
         expect(instance.realizedDividends.toString()).toEqual(`89.67 ${currency}`);
         const expected = new Money(89.67, mainCurrency);
         expect(instance.realizedDividendsInCurrency.toString()).toEqual(expected.toString());
@@ -1064,7 +1064,7 @@ describe('InvestmentAccount', () => {
         );
 
         expect(instance.realizedDividends.toString()).toEqual('176.12 SGD');
-        expect(instance.realizedDividendsInCurrency.toString()).toEqual('170.00 EUR');
+        expect(instance.realizedDividendsInCurrency.toString()).toEqual('170 EUR');
       });
 
       it('works when transaction is not in main currency using income split', async () => {
@@ -1149,7 +1149,7 @@ describe('InvestmentAccount', () => {
         expect(instance.realizedDividends.toString()).toEqual(`89.67 ${stockCurrency.mnemonic}`);
         expect(instance.realizedDividendsInCurrency.toString()).toEqual(
           stockCurrency.mnemonic === 'USD'
-            ? '88.37 EUR'
+            ? '88.38 EUR'
             : '89.67 EUR',
         );
       });

--- a/src/components/pages/account/InvestmentInfo.tsx
+++ b/src/components/pages/account/InvestmentInfo.tsx
@@ -82,7 +82,7 @@ export default function InvestmentInfo({
                   )
                 }
               >
-                {investment.totalBought.format()}
+                {investment.cost.format()}
               </span>
             </div>
           )


### PR DESCRIPTION
Using total bought is wrong as it counts sold titles too thus showing wrong number.

Also, increased the resolution of `format` call so it uses 4 decimals and then rounds instead of using 2 decimals. This reduces decimal error.