### PR TITLE
Improve commodities sync

### DIFF
--- a/amplify/backend/function/stockerlambda/ts/app.ts
+++ b/amplify/backend/function/stockerlambda/ts/app.ts
@@ -43,7 +43,11 @@ app.get('/api/prices', async (req, res) => {
   const result: { [ticker: string]: Price } = {};
 
   async function callAndSave(ticker: string) {
-    result[ticker] = await yahoo.getPrice(ticker);
+    try {
+      result[ticker] = await yahoo.getPrice(ticker);
+    } catch (e) {
+      console.warn(`A price retrieval failed: ${e}`);
+    }
   }
 
   const promises: Promise<void>[] = [];

--- a/src/__tests__/app/dashboard/commodities/__snapshots__/page.test.tsx.snap
+++ b/src/__tests__/app/dashboard/commodities/__snapshots__/page.test.tsx.snap
@@ -34,33 +34,9 @@ exports[`CommoditiesPage renders as expected 1`] = `
   <div
     class="grid grid-cols-12"
   >
-    <a
-      class="card col-span-1 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
-      href="/dashboard/commodities/eur"
-    >
-      <div
-        class="flex items-center"
-      >
-        <svg
-          class="mr-1"
-          fill="currentColor"
-          height="1em"
-          stroke="currentColor"
-          stroke-width="0"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 4H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1zm-1 11a3 3 0 0 0-3 3H7a3 3 0 0 0-3-3V9a3 3 0 0 0 3-3h10a3 3 0 0 0 3 3v6z"
-          />
-          <path
-            d="M12 8c-2.206 0-4 1.794-4 4s1.794 4 4 4 4-1.794 4-4-1.794-4-4-4zm0 6c-1.103 0-2-.897-2-2s.897-2 2-2 2 .897 2 2-.897 2-2 2z"
-          />
-        </svg>
-        EUR
-      </div>
-    </a>
+    <div
+      data-testid="CommodityCard"
+    />
   </div>
   <div
     class="header"
@@ -74,33 +50,9 @@ exports[`CommoditiesPage renders as expected 1`] = `
   <div
     class="grid grid-cols-12"
   >
-    <a
-      class="card col-span-2 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
-      href="/dashboard/commodities/googl"
-    >
-      <div
-        class="flex items-center"
-      >
-        <svg
-          class="mr-1"
-          fill="currentColor"
-          height="1em"
-          stroke="currentColor"
-          stroke-width="0"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 3v17a1 1 0 0 0 1 1h17v-2H5V3H3z"
-          />
-          <path
-            d="M15.293 14.707a.999.999 0 0 0 1.414 0l5-5-1.414-1.414L16 12.586l-2.293-2.293a.999.999 0 0 0-1.414 0l-5 5 1.414 1.414L13 12.414l2.293 2.293z"
-          />
-        </svg>
-        GOOGL
-      </div>
-    </a>
+    <div
+      data-testid="CommodityCard"
+    />
   </div>
   <div
     class="header"
@@ -114,30 +66,9 @@ exports[`CommoditiesPage renders as expected 1`] = `
   <div
     class="grid grid-cols-12"
   >
-    <a
-      class="card col-span-2 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
-      href="/dashboard/commodities/loy"
-    >
-      <div
-        class="flex items-center"
-      >
-        <svg
-          class="mr-1"
-          fill="currentColor"
-          height="1em"
-          stroke="currentColor"
-          stroke-width="0"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 11v8h.051c.245 1.692 1.69 3 3.449 3 1.174 0 2.074-.417 2.672-1.174a3.99 3.99 0 0 0 5.668-.014c.601.762 1.504 1.188 2.66 1.188 1.93 0 3.5-1.57 3.5-3.5V11c0-4.962-4.037-9-9-9s-9 4.038-9 9zm6 1c-1.103 0-2-.897-2-2s.897-2 2-2 2 .897 2 2-.897 2-2 2zm6-4c1.103 0 2 .897 2 2s-.897 2-2 2-2-.897-2-2 .897-2 2-2z"
-          />
-        </svg>
-        EX_LOYALTY
-      </div>
-    </a>
+    <div
+      data-testid="CommodityCard"
+    />
   </div>
 </div>
 `;

--- a/src/__tests__/app/dashboard/commodities/page.test.tsx
+++ b/src/__tests__/app/dashboard/commodities/page.test.tsx
@@ -20,6 +20,10 @@ jest.mock('@/components/Loading', () => jest.fn(
   () => <div data-testid="Loading" />,
 ));
 
+jest.mock('@/components/CommodityCard', () => jest.fn(
+  () => <div data-testid="CommodityCard" />,
+));
+
 jest.mock('@/components/buttons/FormButton', () => jest.fn(
   (props: React.PropsWithChildren) => (
     <div data-testid="FormButton">
@@ -84,7 +88,9 @@ describe('CommoditiesPage', () => {
       {},
     );
     expect(CommodityForm).toBeCalledWith(
-      {},
+      {
+        onSave: expect.any(Function),
+      },
       {},
     );
     expect(container).toMatchSnapshot();

--- a/src/__tests__/components/CommodityCard.test.tsx
+++ b/src/__tests__/components/CommodityCard.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import * as apiHooks from '@/hooks/api';
+import { PriceDBMap } from '@/book/prices';
+import type { Commodity, Price } from '@/book/entities';
+import CommodityCard from '@/components/CommodityCard';
+
+jest.mock('@/hooks/api');
+
+jest.mock('@/components/Loading', () => jest.fn(
+  () => <div data-testid="Loading" />,
+));
+
+jest.mock('@/helpers/env', () => ({
+  __esModule: true,
+  get IS_PAID_PLAN() {
+    return true;
+  },
+}));
+
+describe('CommodityCard', () => {
+  let eur: Commodity;
+  beforeEach(() => {
+    jest.spyOn(apiHooks, 'useCommodity').mockReturnValue({ data: undefined } as UseQueryResult<Commodity>);
+    jest.spyOn(apiHooks, 'usePrices').mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
+
+    eur = {
+      mnemonic: 'EUR',
+      namespace: 'CURRENCY',
+    } as Commodity;
+    jest.spyOn(apiHooks, 'useMainCurrency').mockReturnValue({
+      data: eur,
+    } as UseQueryResult<Commodity>);
+  });
+
+  it('returns loading when no commodity', () => {
+    jest.spyOn(apiHooks, 'usePrices').mockReturnValue({ data: {} } as UseQueryResult<PriceDBMap>);
+
+    render(<CommodityCard guid="guid" />);
+
+    screen.getByTestId('Loading');
+  });
+
+  it('returns loading when no prices', () => {
+    jest.spyOn(apiHooks, 'useCommodity').mockReturnValue({ data: {} } as UseQueryResult<Commodity>);
+
+    render(<CommodityCard guid="guid" />);
+
+    screen.getByTestId('Loading');
+  });
+
+  it('renders as expected without warning when prices for CURRENCY', () => {
+    jest.spyOn(apiHooks, 'useCommodity').mockReturnValue({
+      data: {
+        mnemonic: 'EUR',
+        namespace: 'CURRENCY',
+      },
+    } as UseQueryResult<Commodity>);
+
+    jest.spyOn(apiHooks, 'usePrices').mockReturnValue({
+      data: {
+        getPrice: (() => ({ guid: 'price' } as Price)) as PriceDBMap['getPrice'],
+        getInvestmentPrice: (() => ({ guid: 'price' } as Price)) as PriceDBMap['getInvestmentPrice'],
+      } as PriceDBMap,
+    } as UseQueryResult<PriceDBMap>);
+
+    const { container } = render(<CommodityCard guid="guid" />);
+
+    screen.getByText('EUR');
+    expect(container).toMatchSnapshot();
+  });
+
+  it.each([
+    'STOCK', 'MUTUAL', 'OTHER',
+  ])('renders as expected without warning when prices for non CURRENCY', (namespace) => {
+    jest.spyOn(apiHooks, 'useCommodity').mockReturnValue({
+      data: {
+        mnemonic: 'MNE',
+        namespace,
+      },
+    } as UseQueryResult<Commodity>);
+
+    jest.spyOn(apiHooks, 'usePrices').mockReturnValue({
+      data: {
+        getPrice: (() => ({ guid: 'price' } as Price)) as PriceDBMap['getPrice'],
+        getInvestmentPrice: (() => ({ guid: 'price' } as Price)) as PriceDBMap['getInvestmentPrice'],
+      } as PriceDBMap,
+    } as UseQueryResult<PriceDBMap>);
+
+    render(<CommodityCard guid="guid" />);
+
+    screen.getByText('MNE');
+    expect(screen.queryByText('!')).toBeNull();
+  });
+
+  it.each([
+    'CURRENCY', 'STOCK', 'MUTUAL', 'OTHER',
+  ])('renders as expected without warning when prices for %s', (namespace) => {
+    jest.spyOn(apiHooks, 'useCommodity').mockReturnValue({
+      data: {
+        mnemonic: 'MNE',
+        namespace,
+      },
+    } as UseQueryResult<Commodity>);
+
+    jest.spyOn(apiHooks, 'usePrices').mockReturnValue({
+      data: {
+        getPrice: (() => ({ guid: 'missing_price' } as Price)) as PriceDBMap['getPrice'],
+        getInvestmentPrice: (() => ({ guid: 'missing_price' } as Price)) as PriceDBMap['getInvestmentPrice'],
+      } as PriceDBMap,
+    } as UseQueryResult<PriceDBMap>);
+
+    render(<CommodityCard guid="guid" />);
+
+    screen.getByText('MNE');
+    screen.getByText('!');
+  });
+});

--- a/src/__tests__/components/__snapshots__/CommodityCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/CommodityCard.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CommodityCard renders as expected without warning when prices for CURRENCY 1`] = `
+<div>
+  <a
+    class="card col-span-2 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
+    href="/dashboard/commodities/undefined"
+  >
+    <div
+      class="flex items-center"
+    >
+      <svg
+        class="mr-1"
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21 4H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1zm-1 11a3 3 0 0 0-3 3H7a3 3 0 0 0-3-3V9a3 3 0 0 0 3-3h10a3 3 0 0 0 3 3v6z"
+        />
+        <path
+          d="M12 8c-2.206 0-4 1.794-4 4s1.794 4 4 4 4-1.794 4-4-1.794-4-4-4zm0 6c-1.103 0-2-.897-2-2s.897-2 2-2 2 .897 2 2-.897 2-2 2z"
+        />
+      </svg>
+      EUR
+    </div>
+  </a>
+</div>
+`;

--- a/src/__tests__/components/buttons/__snapshots__/SaveButton.test.tsx.snap
+++ b/src/__tests__/components/buttons/__snapshots__/SaveButton.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`SaveButton renders as expected when datasource ready and not saving 1`]
 <div>
   <button
     class="btn btn-primary"
-    data-tooltip-id="upgrade-tooltip"
+    data-tooltip-id="storage-upgrade-tooltip"
     id="save-button"
     type="button"
   >
@@ -47,7 +47,7 @@ exports[`SaveButton renders as expected when datasource ready and saving 1`] = `
 <div>
   <button
     class="btn btn-primary"
-    data-tooltip-id="upgrade-tooltip"
+    data-tooltip-id="storage-upgrade-tooltip"
     disabled=""
     id="save-button"
     type="button"
@@ -77,7 +77,7 @@ exports[`SaveButton renders as expected when offline 1`] = `
 <div>
   <button
     class="btn btn-primary btn-danger"
-    data-tooltip-id="upgrade-tooltip"
+    data-tooltip-id="storage-upgrade-tooltip"
     disabled=""
     id="save-button"
     type="button"

--- a/src/__tests__/components/forms/commodity/CommodityForm.test.tsx
+++ b/src/__tests__/components/forms/commodity/CommodityForm.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { DataSource } from 'typeorm';
 
 import CommodityForm from '@/components/forms/commodity/CommodityForm';
-import { Commodity } from '@/book/entities';
+import { Commodity, Price } from '@/book/entities';
 
 describe('CommodityForm', () => {
   let datasource: DataSource;
@@ -151,7 +151,9 @@ describe('CommodityForm', () => {
     });
   });
 
-  it('deletes commodity', async () => {
+  it('deletes commodity and related prices', async () => {
+    jest.spyOn(Price, 'delete').mockImplementation();
+
     const user = userEvent.setup();
     const mockSave = jest.fn();
     const eur = await Commodity.create({
@@ -175,5 +177,7 @@ describe('CommodityForm', () => {
     const commodities = await Commodity.find();
 
     expect(commodities).toHaveLength(0);
+    expect(Price.delete).toBeCalledWith({ fk_commodity: { guid: eur.guid } });
+    expect(Price.delete).toBeCalledWith({ fk_currency: { guid: eur.guid } });
   });
 });

--- a/src/__tests__/components/tooltips/UpgradeTooltip.test.tsx
+++ b/src/__tests__/components/tooltips/UpgradeTooltip.test.tsx
@@ -11,7 +11,7 @@ describe('UpgradeTooltip', () => {
         <span data-tooltip-id="upgrade-tooltip">
           upgrade
         </span>
-        <UpgradeTooltip />
+        <UpgradeTooltip id="upgrade-tooltip" message="message" />
       </>,
     );
 

--- a/src/__tests__/components/tooltips/__snapshots__/UpgradeTooltip.test.tsx.snap
+++ b/src/__tests__/components/tooltips/__snapshots__/UpgradeTooltip.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`UpgradeTooltip renders as expected 1`] = `
     <div
       class="text-center"
     >
-      Auto saving to persistent storage only available for premium users.
+      message
     </div>
     <a
       class="btn btn-cta hover:text-white hover:-translate-y-0 table mx-auto my-4"

--- a/src/app/dashboard/commodities/page.tsx
+++ b/src/app/dashboard/commodities/page.tsx
@@ -2,21 +2,18 @@
 
 import React from 'react';
 import {
-  BiLineChart,
-  BiMoney,
-  BiSolidGhost,
   BiPlusCircle,
 } from 'react-icons/bi';
 
 import { useCommodities } from '@/hooks/api';
-import Link from 'next/link';
 import Loading from '@/components/Loading';
 import FormButton from '@/components/buttons/FormButton';
 import CommodityForm from '@/components/forms/commodity/CommodityForm';
+import { insertTodayPrices } from '@/lib/Stocker';
+import CommodityCard from '@/components/CommodityCard';
 
 export default function CommoditiesPage(): JSX.Element {
-  let { data: commodities } = useCommodities();
-  const { isLoading } = useCommodities();
+  const { data: commodities = [], isLoading } = useCommodities();
 
   if (isLoading) {
     return (
@@ -27,8 +24,6 @@ export default function CommoditiesPage(): JSX.Element {
       </div>
     );
   }
-
-  commodities = commodities || [];
 
   const currencies = commodities.filter(c => c.namespace === 'CURRENCY');
   const financial = commodities.filter(c => ['STOCK', 'FUND'].includes(c.namespace));
@@ -51,7 +46,7 @@ export default function CommoditiesPage(): JSX.Element {
               </>
             )}
           >
-            <CommodityForm />
+            <CommodityForm onSave={() => insertTodayPrices()} />
           </FormButton>
         </div>
       </div>
@@ -61,18 +56,7 @@ export default function CommoditiesPage(): JSX.Element {
         </span>
       </div>
       <div className="grid grid-cols-12">
-        {currencies.map(commodity => (
-          <Link
-            key={commodity.guid}
-            href={`/dashboard/commodities/${commodity.guid}`}
-            className="card col-span-1 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
-          >
-            <div className="flex items-center">
-              <BiMoney className="mr-1" />
-              {commodity.mnemonic}
-            </div>
-          </Link>
-        ))}
+        {currencies.map(commodity => <CommodityCard key={commodity.guid} guid={commodity.guid} />)}
       </div>
       {
         financial.length > 0
@@ -84,18 +68,9 @@ export default function CommoditiesPage(): JSX.Element {
               </span>
             </div>
             <div className="grid grid-cols-12">
-              {financial.map(commodity => (
-                <Link
-                  key={commodity.guid}
-                  href={`/dashboard/commodities/${commodity.guid}`}
-                  className="card col-span-2 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
-                >
-                  <div className="flex items-center">
-                    <BiLineChart className="mr-1" />
-                    {commodity.mnemonic}
-                  </div>
-                </Link>
-              ))}
+              {financial.map(
+                commodity => <CommodityCard key={commodity.guid} guid={commodity.guid} />,
+              )}
             </div>
           </>
         )
@@ -110,18 +85,7 @@ export default function CommoditiesPage(): JSX.Element {
               </span>
             </div>
             <div className="grid grid-cols-12">
-              {other.map(commodity => (
-                <Link
-                  key={commodity.guid}
-                  href={`/dashboard/commodities/${commodity.guid}`}
-                  className="card col-span-2 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
-                >
-                  <div className="flex items-center">
-                    <BiSolidGhost className="mr-1" />
-                    {commodity.mnemonic}
-                  </div>
-                </Link>
-              ))}
+              {other.map(commodity => <CommodityCard key={commodity.guid} guid={commodity.guid} />)}
             </div>
           </>
         )

--- a/src/book/__tests__/prices/PriceDBMap.test.ts
+++ b/src/book/__tests__/prices/PriceDBMap.test.ts
@@ -127,8 +127,8 @@ describe('PriceDBMap', () => {
       expect(instance.getPrice('from', 'to').guid).toEqual('missing_price');
     });
 
-    it('returns missing_price when from === to', () => {
-      expect(instance.getPrice('from', 'to').guid).toEqual('missing_price');
+    it('returns same_symbol when from === to', () => {
+      expect(instance.getPrice('from', 'from').guid).toEqual('same_symbol');
     });
 
     it('returns price with matching date', () => {

--- a/src/book/prices/PriceDBMap.ts
+++ b/src/book/prices/PriceDBMap.ts
@@ -39,6 +39,7 @@ export default class PriceDBMap {
     });
 
     if (from === to) {
+      missingPrice.guid = 'same_symbol';
       return missingPrice;
     }
 

--- a/src/components/CommodityCard.tsx
+++ b/src/components/CommodityCard.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import Link from 'next/link';
+import {
+  BiLineChart,
+  BiMoney,
+  BiSolidGhost,
+} from 'react-icons/bi';
+
+import { Tooltip, UpgradeTooltip } from '@/components/tooltips';
+import { useCommodity, useMainCurrency, usePrices } from '@/hooks/api';
+import Loading from '@/components/Loading';
+import { IS_PAID_PLAN } from '@/helpers/env';
+
+export type CommodityCardProps = {
+  guid: string;
+};
+
+export default function CommodityCard({
+  guid,
+}: CommodityCardProps): JSX.Element {
+  const { data: commodity } = useCommodity(guid);
+  const { data: mainCurrency } = useMainCurrency();
+  const { data: prices } = usePrices({ from: commodity });
+
+  if (!commodity || !prices) {
+    return <Loading />;
+  }
+
+  let iconComponent = <BiLineChart className="mr-1" />;
+  let tooltipContent = (
+    <div>
+      <p>
+        No prices found for this commodity! This means that accounts
+        using this commodity don&apos;t have an exchange rate to convert
+        to your main currency and we will convert 1 to 1 for now.
+      </p>
+
+      <p className="mt-1">
+        To fix this, make sure the symbol can be found in
+
+        {' '}
+        <Link
+          href={`https://finance.yahoo.com/quote/${commodity.mnemonic}`}
+          target="blank"
+        >
+          Yahoo
+        </Link>
+        . If not, consider adding this commodity
+        as &quot;OTHER&quot; type instead and add prices manually.
+      </p>
+    </div>
+  );
+
+  if (commodity.namespace === 'CURRENCY') {
+    iconComponent = <BiMoney className="mr-1" />;
+    tooltipContent = (
+      <div>
+        <p>
+          No prices found for the
+          {' '}
+          {`${commodity.mnemonic}.${mainCurrency?.mnemonic}`}
+          {' '}
+          pair! This means that accounts using this currency don&apos;
+          have an exchange rate to convert to your main currency and we
+          will convert 1 to 1 for now.
+        </p>
+
+        <p className="mt-1">
+          To fix this, make sure the currency can be found in
+          {' '}
+          <Link
+            href={`https://finance.yahoo.com/quote/${commodity.mnemonic}${mainCurrency?.mnemonic}=X`}
+            target="blank"
+          >
+            Yahoo
+          </Link>
+          . If it does not exist, it means you will have to track prices for this currency
+          manually.
+        </p>
+      </div>
+    );
+  } else if (commodity.namespace === 'OTHER') {
+    tooltipContent = (
+      <div>
+        <p>
+          No prices found for this commodity! This means that accounts
+          using this commodity don&apos;t have an exchange rate to convert
+          to your main currency and we will convert 1 to 1 for now.
+        </p>
+
+        <p className="mt-1">
+          To fix this, make sure to add prices manually for this commodity
+        </p>
+      </div>
+    );
+    iconComponent = <BiSolidGhost className="mr-1" />;
+  }
+
+  let priceAvailable = false;
+  if (commodity.namespace === 'CURRENCY') {
+    const price = prices.getPrice(commodity.mnemonic, mainCurrency?.mnemonic || '');
+    priceAvailable = price?.guid !== 'missing_price';
+  } else {
+    const price = prices.getInvestmentPrice(commodity.mnemonic);
+    priceAvailable = price?.guid !== 'missing_price';
+  }
+
+  return (
+    <>
+      <Link
+        key={commodity.guid}
+        href={`/dashboard/commodities/${commodity.guid}`}
+        className="card col-span-2 cursor-pointer hover:shadow-lg text-slate-400 dark:hover:text-white"
+      >
+        <div className="flex items-center">
+          {iconComponent}
+          {commodity.mnemonic}
+          {
+            !priceAvailable
+            && (
+              <div
+                className="badge warning ml-auto"
+                data-tooltip-id={`missing-price-${guid}`}
+              >
+                !
+              </div>
+            )
+          }
+        </div>
+      </Link>
+
+      {
+        !priceAvailable
+        && (
+          IS_PAID_PLAN
+            ? (
+              <Tooltip
+                id={`missing-price-${guid}`}
+                className="!w-1/6 !text-xs"
+                clickable
+              >
+                {tooltipContent}
+              </Tooltip>
+            )
+            : (
+              <UpgradeTooltip
+                id={`missing-price-${guid}`}
+                message="Non paid users need to add prices manually. Consider upgrading for getting a bunch of commodities synced automatically for you!"
+              />
+            )
+        )
+      }
+    </>
+  );
+}

--- a/src/components/buttons/SaveButton.tsx
+++ b/src/components/buttons/SaveButton.tsx
@@ -40,7 +40,7 @@ export default function SaveButton(): JSX.Element {
           },
         )}
         disabled={isSaving || !IS_PAID_PLAN || !isOnline}
-        data-tooltip-id="upgrade-tooltip"
+        data-tooltip-id="storage-upgrade-tooltip"
         onClick={async () => {
           await save();
         }}
@@ -73,7 +73,12 @@ export default function SaveButton(): JSX.Element {
       </button>
       {
         !IS_PAID_PLAN
-        && <UpgradeTooltip />
+        && (
+          <UpgradeTooltip
+            id="storage-upgrade-tooltip"
+            message="Auto saving to persistent storage only available for premium users."
+          />
+        )
       }
     </>
   );

--- a/src/components/forms/commodity/CommodityForm.tsx
+++ b/src/components/forms/commodity/CommodityForm.tsx
@@ -3,7 +3,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';
 import classNames from 'classnames';
 
-import { Commodity } from '@/book/entities';
+import { Commodity, Price } from '@/book/entities';
 import { NamespaceSelector } from '@/components/selectors';
 
 const resolver = classValidatorResolver(Commodity, { validator: { stopAtFirstError: true } });
@@ -112,6 +112,10 @@ async function onSubmit(
   if (action === 'add' || action === 'update') {
     await commodity.save();
   } else if (action === 'delete') {
+    await Promise.all([
+      Price.delete({ fk_commodity: { guid: commodity.guid } }),
+      Price.delete({ fk_currency: { guid: commodity.guid } }),
+    ]);
     await commodity.remove();
   }
 

--- a/src/components/tooltips/UpgradeTooltip.tsx
+++ b/src/components/tooltips/UpgradeTooltip.tsx
@@ -4,10 +4,18 @@ import { BiCrown } from 'react-icons/bi';
 
 import Tooltip from './Tooltip';
 
-export default function UpgradeTooltip(): JSX.Element {
+export type UpgradeTooltipProps = {
+  id: string,
+  message: string;
+};
+
+export default function UpgradeTooltip({
+  id,
+  message,
+}: UpgradeTooltipProps): JSX.Element {
   return (
     <Tooltip
-      id="upgrade-tooltip"
+      id={id}
       className="max-w-80"
       clickable
     >
@@ -16,7 +24,7 @@ export default function UpgradeTooltip(): JSX.Element {
         Premium
       </h2>
       <div className="text-center">
-        Auto saving to persistent storage only available for premium users.
+        {message}
       </div>
       <Link
         href="https://maffin.io"

--- a/src/hooks/useDataSource.tsx
+++ b/src/hooks/useDataSource.tsx
@@ -16,7 +16,7 @@ import {
   Transaction,
 } from '@/book/entities';
 import { MIGRATIONS } from '@/book/migrations';
-import { IS_DEMO_PLAN, IS_PAID_PLAN } from '@/helpers/env';
+import { IS_DEMO_PLAN } from '@/helpers/env';
 import { useQueryClient } from '@tanstack/react-query';
 import type BookStorage from '@/lib/storage/BookStorage';
 import { MaffinError, StorageError } from '@/helpers/errors';
@@ -176,13 +176,11 @@ async function createEmptyBook() {
 }
 
 async function loadStockerPrices() {
-  if (IS_PAID_PLAN) {
-    try {
-      // We have to await because we use Price.upsert. Once we correct this,
-      // saving Price already updates the local cache so we don't need await
-      await insertTodayPrices();
-    } catch (e) {
-      console.warn(`Retrieving live prices failed ${e}`);
-    }
+  try {
+    // We have to await because we use Price.upsert. Once we correct this,
+    // saving Price already updates the local cache so we don't need await
+    await insertTodayPrices();
+  } catch (e) {
+    console.warn(`Retrieving live prices failed ${e}`);
   }
 }

--- a/src/lib/Stocker.ts
+++ b/src/lib/Stocker.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { Commodity, Price } from '@/book/entities';
 import { getMainCurrency } from '@/lib/queries';
 import { toAmountWithScale } from '@/helpers/number';
+import { IS_PAID_PLAN } from '@/helpers/env';
 
 import awsExports from '../aws-exports';
 
@@ -16,80 +17,84 @@ const API_NAME = 'stocker';
  * all currency pairs and commodities.
  */
 export async function insertTodayPrices(): Promise<void> {
-  const start = performance.now();
-  const mainCurrency = await getMainCurrency();
-  const [currencies, commodities] = await Promise.all([
-    Commodity.findBy({ namespace: 'CURRENCY' }),
-    Commodity.find({
-      where: [
-        { namespace: 'STOCK' },
-        { namespace: 'FUND' },
-      ],
-    }),
-  ]);
+  if (IS_PAID_PLAN) {
+    const start = performance.now();
+    const mainCurrency = await getMainCurrency();
+    const [currencies, commodities] = await Promise.all([
+      Commodity.findBy({ namespace: 'CURRENCY' }),
+      Commodity.find({
+        where: [
+          { namespace: 'STOCK' },
+          { namespace: 'FUND' },
+        ],
+      }),
+    ]);
 
-  const currencyTickers = currencies
-    .filter(c => c.guid !== mainCurrency.guid)
-    .map(c => `${c.mnemonic}${mainCurrency.mnemonic}=X`);
+    const currencyTickers = currencies
+      .filter(c => c.guid !== mainCurrency.guid)
+      .map(c => `${c.mnemonic}${mainCurrency.mnemonic}=X`);
 
-  const commodityTickers = commodities.map(c => c.cusip || c.mnemonic);
-  const tickers = [
-    ...currencyTickers,
-    ...commodityTickers,
-  ];
+    const commodityTickers = commodities.map(c => c.cusip || c.mnemonic);
+    const tickers = [
+      ...currencyTickers,
+      ...commodityTickers,
+    ];
 
-  const options = {
-    queryStringParameters: {
-      ids: Array.from(new Set(tickers)).toString(),
-    },
-  };
-  const resp = await API.get(API_NAME, '/api/prices', options) as { [key: string]:LiveSummary; };
+    const options = {
+      queryStringParameters: {
+        ids: Array.from(new Set(tickers)).toString(),
+      },
+    };
+    const resp = await API.get(API_NAME, '/api/prices', options) as { [key: string]:LiveSummary; };
 
-  const now = DateTime.now().startOf('day');
+    const now = DateTime.now().startOf('day');
 
-  const prices = Object.entries(resp).map(([key, summary]) => {
-    let commodityMnemonic = key.substring(0, 3);
-    let currencyMnemonic = key.substring(3, 6);
-    if (!key.endsWith('=X')) {
-      commodityMnemonic = key;
-      currencyMnemonic = summary.currency;
+    const prices = Object.entries(resp).map(([key, summary]) => {
+      let commodityMnemonic = key.substring(0, 3);
+      let currencyMnemonic = key.substring(3, 6);
+      if (!key.endsWith('=X')) {
+        commodityMnemonic = key;
+        currencyMnemonic = summary.currency;
+      }
+      const { amount, scale } = toAmountWithScale(summary.price);
+
+      const commodity: Commodity = (
+        currencies.find(c => c.mnemonic === commodityMnemonic)
+        || commodities.find(
+          c => (c.mnemonic === commodityMnemonic || c.cusip === commodityMnemonic),
+        )
+      ) as Commodity;
+
+      const currency: Commodity = currencies.find(
+        c => c.mnemonic === currencyMnemonic,
+      ) as Commodity;
+
+      return Price.create({
+        fk_commodity: commodity.guid,
+        fk_currency: currency.guid,
+        date: now,
+        source: `maffin::${JSON.stringify(summary)}`,
+        valueNum: amount,
+        valueDenom: parseInt('1'.padEnd(scale + 1, '0'), 10),
+      });
+    });
+
+    await Price.upsert(
+      prices,
+      {
+        conflictPaths: ['fk_commodity', 'fk_currency', 'date'],
+      },
+    );
+
+    if (prices.length) {
+      prices[0]?.queryClient?.invalidateQueries({
+        queryKey: ['api', 'prices'],
+      });
     }
-    const { amount, scale } = toAmountWithScale(summary.price);
 
-    const commodity: Commodity = (
-      currencies.find(c => c.mnemonic === commodityMnemonic)
-      || commodities.find(
-        c => (c.mnemonic === commodityMnemonic || c.cusip === commodityMnemonic),
-      )
-    ) as Commodity;
-
-    const currency: Commodity = currencies.find(c => c.mnemonic === currencyMnemonic) as Commodity;
-
-    return Price.create({
-      fk_commodity: commodity.guid,
-      fk_currency: currency.guid,
-      date: now,
-      source: `maffin::${JSON.stringify(summary)}`,
-      valueNum: amount,
-      valueDenom: parseInt('1'.padEnd(scale + 1, '0'), 10),
-    });
-  });
-
-  await Price.upsert(
-    prices,
-    {
-      conflictPaths: ['fk_commodity', 'fk_currency', 'date'],
-    },
-  );
-
-  if (prices.length) {
-    prices[0]?.queryClient?.invalidateQueries({
-      queryKey: ['api', 'prices'],
-    });
+    const end = performance.now();
+    console.log(`/stocker/api/prices: ${end - start}ms`);
   }
-
-  const end = performance.now();
-  console.log(`/stocker/api/prices: ${end - start}ms`);
 }
 
 export type LiveSummary = {


### PR DESCRIPTION
Improve some commodities behaviors:

- Stocker was failing the whole request when 1 of the tickers passed failed which made all commodities to be un-synced. Now, if one of them fails, we just ignore it.
- We display a warning for commodities that don't have any prices
<img width="373" alt="Screenshot 2024-04-05 at 12 15 32 PM" src="https://github.com/maffin-io/maffin-app/assets/3578154/8f4e0ab7-b584-4a67-8acb-452705a56b6e">

- Whenever a new currency or stock/mutual is added, we re-sync all prices.

There is a new behavior I found that is a bit weird and yet unsolved:

- If you add a new STOCK let's say TSLA which has a base currency of USD but you don't have that currency, it will show the warning. This is solved whenever the user adds USD (and both prices will be synced) but the error message shown to the user is not trivial.