### PR TITLE
Move transaction preloading for transaction form

### DIFF
--- a/src/__tests__/components/forms/transaction/__snapshots__/TransactionForm.test.tsx.snap
+++ b/src/__tests__/components/forms/transaction/__snapshots__/TransactionForm.test.tsx.snap
@@ -489,13 +489,12 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                     />
                   </svg>
                   <div
-                    class="selector__value-container css-1fdsijx-ValueContainer"
+                    class="selector__value-container selector__value-container--has-value css-1fdsijx-ValueContainer"
                   >
                     <div
-                      class="selector__placeholder css-1jqq78o-placeholder"
-                      id="react-select-5-placeholder"
+                      class="!text-inherit selector__single-value selector__single-value--is-disabled css-olqui2-singleValue"
                     >
-                      &lt;Choose an account&gt;
+                      Expenses:random
                     </div>
                     <div
                       class="!text-inherit selector__input-container css-1h01tm3-Input"
@@ -504,7 +503,6 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                       <input
                         aria-activedescendant=""
                         aria-autocomplete="list"
-                        aria-describedby="react-select-5-placeholder"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="splits.1.account"
@@ -551,9 +549,7 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
               </div>
               <p
                 class="invalid-feedback"
-              >
-                account is required
-              </p>
+              />
             </div>
             <div
               class="col-span-4"
@@ -571,7 +567,9 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
                 />
                 <span
                   class="pr-2"
-                />
+                >
+                  €
+                </span>
               </div>
             </div>
             <div
@@ -618,7 +616,6 @@ exports[`TransactionForm renders as expected with action delete 1`] = `
     >
       <button
         class="btn capitalize btn-danger"
-        disabled=""
         type="submit"
       >
         delete
@@ -884,13 +881,12 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                     />
                   </svg>
                   <div
-                    class="selector__value-container css-1fdsijx-ValueContainer"
+                    class="selector__value-container selector__value-container--has-value css-1fdsijx-ValueContainer"
                   >
                     <div
-                      class="selector__placeholder css-1jqq78o-placeholder"
-                      id="react-select-4-placeholder"
+                      class="!text-inherit selector__single-value css-1dimb5e-singleValue"
                     >
-                      &lt;Choose an account&gt;
+                      Expenses:random
                     </div>
                     <div
                       class="!text-inherit selector__input-container css-qbdosj-Input"
@@ -899,7 +895,6 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                       <input
                         aria-activedescendant=""
                         aria-autocomplete="list"
-                        aria-describedby="react-select-4-placeholder"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="splits.1.account"
@@ -945,14 +940,12 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                 <input
                   name="splits.1.account"
                   type="hidden"
-                  value=""
+                  value="Expenses:random"
                 />
               </div>
               <p
                 class="invalid-feedback"
-              >
-                account is required
-              </p>
+              />
             </div>
             <div
               class="col-span-4"
@@ -969,7 +962,9 @@ exports[`TransactionForm renders as expected with action update 1`] = `
                 />
                 <span
                   class="pr-2"
-                />
+                >
+                  €
+                </span>
               </div>
             </div>
             <div
@@ -1027,7 +1022,6 @@ exports[`TransactionForm renders as expected with action update 1`] = `
     >
       <button
         class="btn capitalize btn-warn"
-        disabled=""
         type="submit"
       >
         update

--- a/src/__tests__/components/selectors/AccountSelector.test.tsx
+++ b/src/__tests__/components/selectors/AccountSelector.test.tsx
@@ -68,10 +68,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 
@@ -107,10 +104,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 
@@ -150,10 +144,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 
@@ -189,10 +180,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 
@@ -229,10 +217,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 
@@ -271,10 +256,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 
@@ -313,10 +295,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 
@@ -354,10 +333,7 @@ describe('AccountSelector', () => {
     ];
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
-        data: [
-          options[0],
-          options[1],
-        ],
+        data: options,
       } as UseQueryResult<Account[]>,
     );
 

--- a/src/__tests__/components/tables/TransactionsTable.test.tsx
+++ b/src/__tests__/components/tables/TransactionsTable.test.tsx
@@ -4,7 +4,6 @@ import {
   render,
   screen,
 } from '@testing-library/react';
-import * as query from '@tanstack/react-query';
 import type { LinkProps } from 'next/link';
 import type { UseQueryResult } from '@tanstack/react-query';
 
@@ -199,12 +198,13 @@ describe('TransactionsTable', () => {
   });
 
   it('renders Description column as expected', async () => {
-    jest.spyOn(query, 'useQuery').mockReturnValue({
+    jest.spyOn(apiHook, 'useTransaction').mockReturnValue({
       data: {
         guid: 'tx_guid',
         description: 'Tx description',
       },
     } as UseQueryResult<Transaction>);
+
     render(<TransactionsTable account={account} />);
 
     await screen.findByTestId('Table');
@@ -220,9 +220,7 @@ describe('TransactionsTable', () => {
       }),
     );
 
-    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
-      queryKey: ['api', 'txs', 'tx_guid'],
-    }));
+    expect(apiHook.useTransaction).toBeCalledWith({ guid: 'tx_guid' });
     expect(container).toMatchSnapshot();
   });
 
@@ -241,7 +239,7 @@ describe('TransactionsTable', () => {
         },
       ],
     } as UseQueryResult<Account[]>);
-    jest.spyOn(query, 'useQuery').mockReturnValue({
+    jest.spyOn(apiHook, 'useTransaction').mockReturnValue({
       data: {
         guid: 'tx_guid',
         splits: [
@@ -251,6 +249,7 @@ describe('TransactionsTable', () => {
         ],
       },
     } as UseQueryResult<Transaction>);
+
     render(<TransactionsTable account={account} />);
 
     await screen.findByTestId('Table');
@@ -266,9 +265,6 @@ describe('TransactionsTable', () => {
       }),
     );
 
-    expect(query.useQuery).toBeCalledWith(expect.objectContaining({
-      queryKey: ['api', 'txs', 'tx_guid'],
-    }));
     expect(container).toMatchSnapshot();
   });
 
@@ -333,19 +329,11 @@ describe('TransactionsTable', () => {
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue({
       data: accounts,
     } as UseQueryResult<Account[]>);
+
     const tx = {
       guid: 'tx_guid',
-      date: DateTime.fromISO('2023-01-01'),
-      splits: [
-        split,
-        {
-          accountId: 'account_guid_2',
-          value: 100,
-          quantity: 100,
-        },
-      ],
     };
-    jest.spyOn(query, 'useQuery').mockReturnValue({
+    jest.spyOn(apiHook, 'useTransaction').mockReturnValue({
       data: tx,
     } as UseQueryResult<Transaction>);
 
@@ -382,16 +370,7 @@ describe('TransactionsTable', () => {
       1,
       {
         action: 'update',
-        defaultValues: {
-          ...tx,
-          date: '2023-01-01',
-          splits: tx.splits.map(s => ({
-            ...s,
-            value: s.value,
-            quantity: s.quantity,
-            fk_account: accounts.find(a => a.guid === s.accountId),
-          })),
-        },
+        guid: 'tx_guid',
         onSave: expect.any(Function),
       },
       {},
@@ -409,16 +388,7 @@ describe('TransactionsTable', () => {
       2,
       {
         action: 'delete',
-        defaultValues: {
-          ...tx,
-          date: '2023-01-01',
-          splits: tx.splits.map(s => ({
-            ...s,
-            value: s.value,
-            quantity: s.quantity,
-            fk_account: accounts.find(a => a.guid === s.accountId),
-          })),
-        },
+        guid: 'tx_guid',
       },
       {},
     );

--- a/src/__tests__/hooks/api/useTransactions.test.tsx
+++ b/src/__tests__/hooks/api/useTransactions.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+
+import { useTransaction } from '@/hooks/api';
+import { Transaction } from '@/book/entities';
+
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={QUERY_CLIENT}>{children}</QueryClientProvider>
+);
+
+describe('useTransaction', () => {
+  let tx: Transaction;
+
+  beforeEach(() => {
+    tx = {
+      guid: 'guid1',
+    } as Transaction;
+    jest.spyOn(Transaction, 'findOne').mockResolvedValue(tx);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    QUERY_CLIENT.removeQueries();
+  });
+
+  it('calls query as expected', async () => {
+    const { result } = renderHook(() => useTransaction({ guid: 'guid1' }), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toEqual('success'));
+    expect(Transaction.findOne).toBeCalledWith({
+      relations: {
+        splits: {
+          fk_account: true,
+        },
+      },
+      where: {
+        guid: 'guid1',
+      },
+    });
+    expect(result.current.data).toEqual(tx);
+
+    const queryCache = QUERY_CLIENT.getQueryCache().getAll();
+    expect(queryCache).toHaveLength(1);
+    expect(queryCache[0].queryKey).toEqual(['api', 'txs', 'guid1']);
+  });
+});

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -24,6 +24,7 @@ export { useMonthlyWorth } from '@/hooks/api/useMonthlyWorth';
 export { usePrices } from '@/hooks/api/usePrices';
 export { useCashFlow } from '@/hooks/api/useCashFlow';
 export { useMainCurrency } from '@/hooks/api/useMainCurrency';
+export { useTransaction } from '@/hooks/api/useTransactions';
 
 export function useStartDate(): UseQueryResult<DateTime> {
   return useQuery({

--- a/src/hooks/api/useTransactions.ts
+++ b/src/hooks/api/useTransactions.ts
@@ -1,0 +1,34 @@
+import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+
+import { Transaction } from '@/book/entities';
+import fetcher from '@/hooks/api/fetcher';
+
+export type UseTransactionProps<TData> = {
+  guid: string,
+  select?: (data: Transaction) => TData,
+} & Omit<Partial<UseQueryOptions<Transaction>>, 'select'>;
+
+export function useTransaction<TData = Transaction>({
+  guid,
+  select,
+  ...props
+}: UseTransactionProps<TData>): UseQueryResult<TData> {
+  const queryKey = [...Transaction.CACHE_KEY, guid];
+  return useQuery({
+    ...props,
+    queryKey,
+    queryFn: fetcher(
+      () => Transaction.findOne({
+        where: { guid },
+        relations: {
+          splits: {
+            fk_account: true,
+          },
+        },
+      }),
+      queryKey,
+    ),
+    select,
+    networkMode: 'always',
+  });
+}


### PR DESCRIPTION
In previous version the caller of TransactionForm had to know which Transaction entity fields were needed. This is ugly because it moves knowledge out of the component and makes re-usability hard as each time you use the form, you have to repeat the same logic.

Changed it so:

- When action is add, you can still pass default values as needed
- When action is update or delete, you MUST pass a `guid` and not defaultValues. With this guid, the transaction form loads the transaction values needed to show it properly in the form.