### PR TITLE
Minor improvements to liability page

### DIFF
--- a/src/__tests__/app/dashboard/accounts/page.test.tsx
+++ b/src/__tests__/app/dashboard/accounts/page.test.tsx
@@ -146,7 +146,13 @@ describe('AccountsPage', () => {
     expect(NetWorthHistogram).toHaveBeenLastCalledWith(
       {
         assetsGuid: 'type_asset',
+        assetsConfig: {
+          label: 'Assets',
+        },
         liabilitiesGuid: 'type_liability',
+        liabilitiesConfig: {
+          label: 'Liabilities',
+        },
       },
       {},
     );
@@ -277,7 +283,13 @@ describe('AccountsPage', () => {
     expect(NetWorthHistogram).toHaveBeenLastCalledWith(
       {
         assetsGuid: 'type_asset',
+        assetsConfig: {
+          label: 'Assets',
+        },
         liabilitiesGuid: 'type_liability',
+        liabilitiesConfig: {
+          label: 'Liabilities',
+        },
       },
       {},
     );

--- a/src/__tests__/components/charts/AssetSankey.test.tsx
+++ b/src/__tests__/components/charts/AssetSankey.test.tsx
@@ -81,6 +81,7 @@ describe('AssetSankey', () => {
       {
         height: 250,
         options: {
+          maintainAspectRatio: false,
           plugins: {
             title: {
               display: true,

--- a/src/__tests__/components/charts/NetWorthHistogram.test.tsx
+++ b/src/__tests__/components/charts/NetWorthHistogram.test.tsx
@@ -49,34 +49,7 @@ describe('NetWorthHistogram', () => {
       {
         height: 400,
         data: {
-          datasets: [
-            {
-              backgroundColor: '#06B6D4',
-              data: [],
-              label: 'Assets',
-              order: 1,
-              barPercentage: 0.6,
-            },
-            {
-              backgroundColor: '#0E7490',
-              borderColor: '#0E7490',
-              data: [],
-              label: 'Net worth',
-              order: 0,
-              pointHoverRadius: 10,
-              pointRadius: 5,
-              pointStyle: 'rectRounded',
-              type: 'line',
-              datalabels: {
-                align: 'end',
-                backgroundColor: '#0E7490FF',
-                borderRadius: 5,
-                color: '#FFF',
-                display: expect.any(Function),
-                formatter: expect.any(Function),
-              },
-            },
-          ],
+          datasets: [],
           labels: [
             TEST_INTERVAL.start,
             expect.any(DateTime),
@@ -100,7 +73,7 @@ describe('NetWorthHistogram', () => {
             title: {
               align: 'start',
               display: true,
-              text: 'Net Worth',
+              text: 'Net worth',
               font: {
                 size: 18,
               },
@@ -182,8 +155,14 @@ describe('NetWorthHistogram', () => {
 
     render(
       <NetWorthHistogram
-        assetsGuid=""
-        liabilitiesGuid=""
+        assetsGuid="type_asset"
+        assetsConfig={{
+          label: 'Assets',
+        }}
+        liabilitiesGuid="type_liability"
+        liabilitiesConfig={{
+          label: 'Liabilities',
+        }}
       />,
     );
 
@@ -197,6 +176,13 @@ describe('NetWorthHistogram', () => {
               data: [0, 0],
               label: 'Assets',
               order: 1,
+              barPercentage: 0.6,
+            },
+            {
+              backgroundColor: '#FF6600',
+              data: [0, 0],
+              label: 'Liabilities',
+              order: 2,
               barPercentage: 0.6,
             },
             {
@@ -242,7 +228,7 @@ describe('NetWorthHistogram', () => {
             title: {
               align: 'start',
               display: true,
-              text: 'Net Worth',
+              text: 'Net worth',
               font: {
                 size: 18,
               },
@@ -307,13 +293,15 @@ describe('NetWorthHistogram', () => {
     );
   });
 
-  it('hides assets and liabilities', () => {
+  it('displays assets only', () => {
+    jest.spyOn(apiHook, 'useMonthlyWorth').mockReturnValue({ data: [{}, {}] } as UseQueryResult<AccountsTotals[]>);
+
     render(
       <NetWorthHistogram
-        assetsGuid=""
-        hideAssets
-        liabilitiesGuid=""
-        hideLiabilities
+        assetsGuid="type_asset"
+        assetsConfig={{
+          label: 'Assets',
+        }}
       />,
     );
 
@@ -322,7 +310,33 @@ describe('NetWorthHistogram', () => {
         data: expect.objectContaining({
           datasets: [
             expect.objectContaining({
-              label: 'Net worth',
+              label: 'Assets',
+            }),
+          ],
+        }),
+      }),
+      {},
+    );
+  });
+
+  it('displays liabilities only', () => {
+    jest.spyOn(apiHook, 'useMonthlyWorth').mockReturnValue({ data: [{}, {}] } as UseQueryResult<AccountsTotals[]>);
+
+    render(
+      <NetWorthHistogram
+        assetsGuid="type_liability"
+        assetsConfig={{
+          label: 'Liabilities',
+        }}
+      />,
+    );
+
+    expect(Bar).toBeCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          datasets: [
+            expect.objectContaining({
+              label: 'Liabilities',
             }),
           ],
         }),
@@ -366,7 +380,13 @@ describe('NetWorthHistogram', () => {
     render(
       <NetWorthHistogram
         assetsGuid="type_asset"
+        assetsConfig={{
+          label: 'Assets',
+        }}
         liabilitiesGuid="type_liability"
+        liabilitiesConfig={{
+          label: 'Liabilities',
+        }}
       />,
     );
 

--- a/src/__tests__/components/pages/account/AssetInfo.test.tsx
+++ b/src/__tests__/components/pages/account/AssetInfo.test.tsx
@@ -69,23 +69,26 @@ describe('AssetInfo', () => {
     jest.clearAllMocks();
   });
 
-  it('renders as expected when not placeholder', () => {
+  it('renders as expected when not placeholder Asset', () => {
     const { container } = render(
       <AssetInfo account={account} />,
     );
 
     expect(NetWorthHistogram).toBeCalledWith(
       {
+        height: 428,
+        title: 'Net worth',
         assetsGuid: 'guid',
-        assetsLabel: 'Assets',
-        hideAssets: true,
-        hideLiabilities: true,
-        liabilitiesGuid: '',
+        assetsConfig: {
+          label: 'Assets',
+          borderColor: '#06B6D455',
+          type: 'line',
+        },
         showLegend: false,
       },
       {},
     );
-    expect(AssetSankey).toBeCalledWith({ height: 270, account }, {});
+    expect(AssetSankey).toBeCalledWith({ height: 428, account }, {});
     expect(TotalWidget).toBeCalledWith(
       { account },
       {},
@@ -101,6 +104,30 @@ describe('AssetInfo', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('renders as expected when not placeholder Liability', () => {
+    account.type = 'CREDIT';
+    account.name = 'Liabilities';
+
+    render(
+      <AssetInfo account={account} />,
+    );
+
+    expect(NetWorthHistogram).toBeCalledWith(
+      {
+        height: 428,
+        title: 'Debt',
+        liabilitiesGuid: 'guid',
+        liabilitiesConfig: {
+          label: 'Liabilities',
+          borderColor: '#FF660055',
+          type: 'line',
+        },
+        showLegend: false,
+      },
+      {},
+    );
+  });
+
   it('renders as expected when placeholder', () => {
     account.placeholder = true;
     account.childrenIds = ['1', '2'];
@@ -111,11 +138,14 @@ describe('AssetInfo', () => {
 
     expect(NetWorthHistogram).toBeCalledWith(
       {
+        height: 428,
+        title: 'Net worth',
         assetsGuid: 'guid',
-        assetsLabel: 'Assets',
-        hideAssets: true,
-        hideLiabilities: true,
-        liabilitiesGuid: '',
+        assetsConfig: {
+          label: 'Assets',
+          borderColor: '#06B6D455',
+          type: 'line',
+        },
         showLegend: false,
       },
       {},

--- a/src/__tests__/components/pages/account/TotalWidget.test.tsx
+++ b/src/__tests__/components/pages/account/TotalWidget.test.tsx
@@ -65,4 +65,23 @@ describe('TotalWidgetTest', () => {
       {},
     );
   });
+
+  it('keeps negative for liability', () => {
+    account.type = 'CREDIT';
+    jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({
+      data: { guid: new Money(-100, 'EUR') } as AccountsTotals,
+    });
+
+    render(<TotalWidget account={account} />);
+
+    expect(StatisticsWidget).toBeCalledWith(
+      {
+        className: 'mr-2',
+        description: expect.anything(),
+        stats: '-€100.00',
+        title: 'Total',
+      },
+      {},
+    );
+  });
 });

--- a/src/__tests__/components/pages/account/__snapshots__/AssetInfo.test.tsx.snap
+++ b/src/__tests__/components/pages/account/__snapshots__/AssetInfo.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssetInfo renders as expected when not placeholder 1`] = `
+exports[`AssetInfo renders as expected when not placeholder Asset 1`] = `
 <div>
   <div
-    class="grid grid-cols-12"
+    class="grid grid-cols-12 items-start"
   >
     <div
       class="col-span-6"
@@ -54,7 +54,7 @@ exports[`AssetInfo renders as expected when not placeholder 1`] = `
 exports[`AssetInfo renders as expected when placeholder 1`] = `
 <div>
   <div
-    class="grid grid-cols-12"
+    class="grid grid-cols-12 items-start"
   >
     <div
       class="col-span-6"

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -96,7 +96,13 @@ export default function AccountsPage(): JSX.Element {
           <div className="card col-span-8">
             <NetWorthHistogram
               assetsGuid="type_asset"
+              assetsConfig={{
+                label: 'Assets',
+              }}
               liabilitiesGuid="type_liability"
+              liabilitiesConfig={{
+                label: 'Liabilities',
+              }}
             />
           </div>
           <div className="card col-span-4">

--- a/src/components/charts/AssetSankey.tsx
+++ b/src/components/charts/AssetSankey.tsx
@@ -90,6 +90,7 @@ export default function AssetSankey({
         datasets,
       }}
       options={{
+        maintainAspectRatio: false,
         plugins: {
           title: {
             display: true,

--- a/src/components/charts/NetWorthHistogram.tsx
+++ b/src/components/charts/NetWorthHistogram.tsx
@@ -20,24 +20,41 @@ C.register(
   LineController,
 );
 
-export type NetWorthHistogramProps = {
+export type NetWorthHistogramProps =
+| {
+  title?: string,
   assetsGuid: string,
-  assetsLabel?: string,
-  hideAssets?: boolean,
+  assetsConfig?: Partial<ChartDataset>,
+  liabilitiesGuid?: never,
+  liabilitiesConfig?: never,
+  showLegend?: boolean,
+  height?: number,
+}
+| {
+  title?: string,
+  assetsGuid?: never,
+  assetsConfig?: never,
   liabilitiesGuid: string,
-  liabilitiesLabel?: string,
-  hideLiabilities?: boolean,
+  liabilitiesConfig?: Partial<ChartDataset>,
+  showLegend?: boolean,
+  height?: number,
+}
+| {
+  title?: string,
+  assetsGuid: string,
+  assetsConfig?: Partial<ChartDataset>,
+  liabilitiesGuid: string,
+  liabilitiesConfig?: Partial<ChartDataset>,
   showLegend?: boolean,
   height?: number,
 };
 
 export default function NetWorthHistogram({
-  assetsGuid,
-  assetsLabel = 'Assets',
-  hideAssets = false,
-  liabilitiesGuid,
-  liabilitiesLabel = 'Liabilities',
-  hideLiabilities = false,
+  title = 'Net worth',
+  assetsGuid = '',
+  assetsConfig = {},
+  liabilitiesGuid = '',
+  liabilitiesConfig = {},
   showLegend = true,
   height = 400,
 }: NetWorthHistogramProps): JSX.Element {
@@ -50,52 +67,54 @@ export default function NetWorthHistogram({
 
   const datasets: ChartDataset<'bar'>[] = [];
 
-  if (!hideAssets) {
+  if (assetsGuid) {
     datasets.push({
-      label: assetsLabel,
-      data: assetSeries || [],
       backgroundColor: '#06B6D4',
       order: 1,
       barPercentage: 0.6,
-    });
+      ...assetsConfig,
+      data: assetSeries || [],
+    } as ChartDataset<'bar'>);
   }
 
-  if (liabilitySeries?.some(n => n !== 0) && !hideLiabilities) {
+  if (liabilitiesGuid) {
     datasets.push({
-      label: liabilitiesLabel,
-      data: liabilitySeries || [],
       backgroundColor: '#FF6600',
       order: 2,
       barPercentage: 0.6,
-    });
+      ...liabilitiesConfig,
+      data: liabilitySeries || [],
+    } as ChartDataset<'bar'>);
   }
 
-  datasets.push({
-    label: 'Net worth',
-    // @ts-ignore
-    type: 'line',
-    data: assetSeries?.map((n, i) => n + (liabilitySeries?.[i] || 0)) || [],
-    backgroundColor: '#0E7490',
-    borderColor: '#0E7490',
-    pointStyle: 'rectRounded',
-    pointRadius: 5,
-    pointHoverRadius: 10,
-    order: 0,
-    datalabels: {
-      display: (ctx) => {
-        if (ctx.dataIndex % 2) {
-          return true;
-        }
+  if (assetsGuid && liabilitiesGuid) {
+    datasets.push({
+      label: 'Net worth',
+      // @ts-ignore
+      type: 'line',
+      data: assetSeries?.map((n, i) => n + (liabilitySeries?.[i] || 0)) || [],
+      backgroundColor: '#0E7490',
+      borderColor: '#0E7490',
+      pointStyle: 'rectRounded',
+      pointRadius: 5,
+      pointHoverRadius: 10,
+      order: 0,
+      datalabels: {
+        display: (ctx) => {
+          if (ctx.dataIndex % 2) {
+            return true;
+          }
 
-        return false;
+          return false;
+        },
+        formatter: (value) => moneyToString(value, unit),
+        align: 'end',
+        backgroundColor: '#0E7490FF',
+        borderRadius: 5,
+        color: '#FFF',
       },
-      formatter: (value) => moneyToString(value, unit),
-      align: 'end',
-      backgroundColor: '#0E7490FF',
-      borderRadius: 5,
-      color: '#FFF',
-    },
-  });
+    });
+  }
 
   const labels = intervalToDates(interval);
   return (
@@ -150,7 +169,7 @@ export default function NetWorthHistogram({
             plugins: {
               title: {
                 display: true,
-                text: 'Net Worth',
+                text: title,
                 align: 'start',
                 padding: {
                   top: 0,

--- a/src/components/pages/account/AssetInfo.tsx
+++ b/src/components/pages/account/AssetInfo.tsx
@@ -5,6 +5,7 @@ import type { Account } from '@/book/entities';
 import { AssetSankey, NetWorthHistogram, TotalsPie } from '@/components/charts';
 import { AccountsTable } from '@/components/tables';
 import TotalChange from '@/components/widgets/TotalChange';
+import { isAsset } from '@/book/helpers';
 import TotalWidget from './TotalWidget';
 import SpendWidget from './SpendWidget';
 import EarnWidget from './EarnWidget';
@@ -17,7 +18,7 @@ export default function AssetInfo({
   account,
 }: AssetInfoProps): JSX.Element {
   return (
-    <div className="grid grid-cols-12">
+    <div className="grid grid-cols-12 items-start">
       <div className="col-span-6">
         <div className="grid grid-cols-12 items-start">
           <div
@@ -67,7 +68,7 @@ export default function AssetInfo({
               !account.placeholder
               && (
                 <AssetSankey
-                  height={270}
+                  height={428}
                   account={account}
                 />
               )
@@ -77,14 +78,36 @@ export default function AssetInfo({
       </div>
       <div className="grid grid-cols-12 col-span-6">
         <div className="card col-span-12">
-          <NetWorthHistogram
-            assetsGuid={account.guid}
-            assetsLabel={account.name}
-            hideAssets
-            liabilitiesGuid=""
-            hideLiabilities
-            showLegend={false}
-          />
+          {
+            (
+              isAsset(account)
+              && (
+                <NetWorthHistogram
+                  height={428}
+                  title="Net worth"
+                  assetsGuid={account.guid}
+                  assetsConfig={{
+                    label: account.name,
+                    type: 'line',
+                    borderColor: '#06B6D455',
+                  }}
+                  showLegend={false}
+                />
+              )
+            ) || (
+              <NetWorthHistogram
+                height={428}
+                title="Debt"
+                liabilitiesGuid={account.guid}
+                liabilitiesConfig={{
+                  label: account.name,
+                  type: 'line',
+                  borderColor: '#FF660055',
+                }}
+                showLegend={false}
+              />
+            )
+          }
         </div>
         <div className="col-span-12" />
       </div>

--- a/src/components/pages/account/TotalWidget.tsx
+++ b/src/components/pages/account/TotalWidget.tsx
@@ -5,6 +5,7 @@ import Money from '@/book/Money';
 import type { Account } from '@/book/entities';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import TotalChange from '@/components/widgets/TotalChange';
+import { isLiability } from '@/book/helpers';
 
 export type TotalWidgetProps = {
   account: Account,
@@ -20,7 +21,7 @@ export default function TotalWidget({
     <StatisticsWidget
       className="mr-2"
       title="Total"
-      stats={total0.abs().format()}
+      stats={isLiability(account) ? total0.format() : total0.abs().format()}
       description={<TotalChange account={account} />}
     />
   );


### PR DESCRIPTION
I've changed the networth histogram to be a bit more configurable so now it can:

- Show assets, liabilities and net worth
- Show only asset account with its own configuration
- Show only liability account with its own configuration

<img width="1581" alt="Screenshot 2024-04-08 at 12 14 56 PM" src="https://github.com/maffin-io/maffin-app/assets/3578154/f49caf1d-210b-46a3-bc4a-101c98d8246d">

I've decided to not make the values for liabilities absolute as we are talking about debt. Saying that at some point in time the amount is -934 is correct. Would be confusing to say its 934 as the users may think they are in positive.

Fixes #834 

