### PR TITLE
Fix account selection in account form

### DIFF
--- a/src/__tests__/components/buttons/AddTxDropdown.test.tsx
+++ b/src/__tests__/components/buttons/AddTxDropdown.test.tsx
@@ -66,10 +66,7 @@ describe('AddTxDropdown', () => {
             expect.objectContaining({
               fk_account: account,
             }),
-            {
-              action: '',
-              guid: expect.any(String),
-            },
+            {},
           ],
         },
       },
@@ -119,10 +116,7 @@ describe('AddTxDropdown', () => {
             expect.objectContaining({
               fk_account: account,
             }),
-            {
-              action: '',
-              guid: expect.any(String),
-            },
+            {},
           ],
         },
       },

--- a/src/components/buttons/AddTxDropdown.tsx
+++ b/src/components/buttons/AddTxDropdown.tsx
@@ -48,7 +48,10 @@ export default function AddTxDropdown({
                 {
                   date: (latestDate || DateTime.now()).toISODate() as string,
                   description: '',
-                  splits: [Split.create({ fk_account: account }), new Split()],
+                  splits: [
+                    Split.create({ fk_account: account }),
+                    {} as Split,
+                  ],
                   fk_currency: account.commodity,
                 }
               }

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -69,6 +69,8 @@ export default function SplitField({
     form.trigger('splits');
   }, [value, exchangeRate, form, action, index]);
 
+  const defaultAccount = form.formState.defaultValues?.splits?.[index]?.fk_account as Account;
+
   return (
     <fieldset className="grid grid-cols-13" key={`splits.${index}`}>
       <div className={`col-span-${showValueField ? 7 : 9}`}>
@@ -81,9 +83,11 @@ export default function SplitField({
                 id={`splits.${index}.account`}
                 isClearable={false}
                 isDisabled={disabled}
-                placeholder={account?.type ? `<Choose a ${account.type} account>` : '<Choose an account>'}
+                placeholder={defaultAccount?.type ? `<Choose a ${defaultAccount.type} account>` : '<Choose an account>'}
                 ignorePlaceholders
-                onlyTypes={account?.type ? getAllowedSubAccounts(account.type) : undefined}
+                onlyTypes={
+                  defaultAccount?.type ? getAllowedSubAccounts(defaultAccount.type) : undefined
+                }
                 onChange={async (a: SingleValue<Account>) => {
                   field.onChange(a);
                   const mainCurrency = await getMainCurrency();


### PR DESCRIPTION
An old bug... passing an instance of a Split object makes the defaultValue reference to be updated when changing the value. Passing now a {} instead of a split instance in the add transaction second split to avoid this and then using `formState.defaultValues` to see if we have set a default for the account type.

Fixes #832 