### PR TITLE
Tx form account selection

### DIFF
--- a/src/__tests__/components/buttons/AddTxDropdown.test.tsx
+++ b/src/__tests__/components/buttons/AddTxDropdown.test.tsx
@@ -66,10 +66,7 @@ describe('AddTxDropdown', () => {
             expect.objectContaining({
               fk_account: account,
             }),
-            {
-              action: '',
-              guid: expect.any(String),
-            },
+            {},
           ],
         },
       },
@@ -119,10 +116,7 @@ describe('AddTxDropdown', () => {
             expect.objectContaining({
               fk_account: account,
             }),
-            {
-              action: '',
-              guid: expect.any(String),
-            },
+            {},
           ],
         },
       },

--- a/src/components/buttons/AddTxDropdown.tsx
+++ b/src/components/buttons/AddTxDropdown.tsx
@@ -48,7 +48,10 @@ export default function AddTxDropdown({
                 {
                   date: (latestDate || DateTime.now()).toISODate() as string,
                   description: '',
-                  splits: [Split.create({ fk_account: account }), new Split()],
+                  splits: [
+                    Split.create({ fk_account: account }),
+                    {} as Split,
+                  ],
                   fk_currency: account.commodity,
                 }
               }

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -69,6 +69,8 @@ export default function SplitField({
     form.trigger('splits');
   }, [value, exchangeRate, form, action, index]);
 
+  const defaultAccount = form.formState.defaultValues?.splits?.[index]?.fk_account as Account;
+
   return (
     <fieldset className="grid grid-cols-13" key={`splits.${index}`}>
       <div className={`col-span-${showValueField ? 7 : 9}`}>
@@ -81,9 +83,11 @@ export default function SplitField({
                 id={`splits.${index}.account`}
                 isClearable={false}
                 isDisabled={disabled}
-                placeholder={account?.type ? `<Choose a ${account.type} account>` : '<Choose an account>'}
+                placeholder={defaultAccount?.type ? `<Choose a ${defaultAccount.type} account>` : '<Choose an account>'}
                 ignorePlaceholders
-                onlyTypes={account?.type ? getAllowedSubAccounts(account.type) : undefined}
+                onlyTypes={
+                  defaultAccount?.type ? getAllowedSubAccounts(defaultAccount.type) : undefined
+                }
                 onChange={async (a: SingleValue<Account>) => {
                   field.onChange(a);
                   const mainCurrency = await getMainCurrency();

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -94,17 +94,22 @@ export default function SplitField({
                   const splits = form.getValues('splits');
 
                   if (a) {
-                    const nonCurrencySplit = splits.find(
-                      split => (split.fk_account as Account).commodity.namespace !== 'CURRENCY',
+                    const investmentSplit = splits.find(
+                      split => (split.fk_account as Account).type === 'INVESTMENT',
                     );
 
-                    if (nonCurrencySplit) {
-                      const price = await Price.findOneByOrFail({
-                        fk_commodity: {
-                          guid: (nonCurrencySplit.fk_account as Account).commodity.guid,
-                        },
-                      });
-                      form.setValue('fk_currency', price.currency);
+                    if (investmentSplit) {
+                      const investmentAccount = investmentSplit.fk_account as Account;
+                      let currency = investmentAccount.commodity;
+
+                      if (investmentAccount.commodity.namespace !== 'CURRENCY') {
+                        ({ currency } = await Price.findOneByOrFail({
+                          fk_commodity: {
+                            guid: investmentAccount.commodity.guid,
+                          },
+                        }));
+                      }
+                      form.setValue('fk_currency', currency);
                     } else if (txCurrency.guid !== mainCurrency.guid) {
                       if (a.commodity.guid === mainCurrency?.guid) {
                         form.setValue('fk_currency', mainCurrency);


### PR DESCRIPTION
When we added support for RoboAdvisors we made the change that investment accounts can be assigned a currency as commodity. This broke the `txCurrency` selection in the Transaction form as in there we assumed that investment accounts would always have a non currency.

This fixes this by checking in the account of the split is of INVESTMENT type instead of checking the commodity to decide the txCurrency

> We always want the transactions for an investment to be in the currency of the investment itself so the computations done in InvestmentAccount are correct. Otherwise we start mixing currencies and it will throw errors.

Fixes #833 