### PR TITLE
Improve yahoo price sync

### DIFF
--- a/src/__tests__/components/tables/PricesTable.test.tsx
+++ b/src/__tests__/components/tables/PricesTable.test.tsx
@@ -80,6 +80,23 @@ describe('PricesTable', () => {
     ).toEqual('$100.50');
   });
 
+  it('shows up to 6 decimals', async () => {
+    render(<PricesTable prices={[]} />);
+
+    await screen.findByTestId('Table');
+    expect(
+      (Table as jest.Mock).mock.calls[0][0].columns[0].accessorFn({ date: DateTime.fromISO('2023-01-01') }),
+    ).toEqual(1672531200000);
+    expect(
+      (Table as jest.Mock).mock.calls[0][0].columns[1].accessorFn({
+        value: 0.0000581,
+        fk_currency: {
+          mnemonic: 'USD',
+        },
+      }),
+    ).toEqual('$0.000058');
+  });
+
   it('forwards prices as data', async () => {
     const prices = [
       {

--- a/src/book/Money.ts
+++ b/src/book/Money.ts
@@ -66,10 +66,10 @@ export default class Money {
    *
    * The result is a localized string with the currency as a symbol
    */
-  format(scale = 4): string {
+  format(scale = 4, decimals = 2): string {
     return djs.toDecimal(
       djs.transformScale(this._raw, scale),
-      ({ value, currency }) => moneyToString(toFixed(Number(value)), currency.code),
+      ({ value, currency }) => moneyToString(toFixed(Number(value), decimals), currency.code),
     );
   }
 

--- a/src/book/__tests__/Money.test.ts
+++ b/src/book/__tests__/Money.test.ts
@@ -42,6 +42,11 @@ describe('Money', () => {
       money = new Money(100.9999, 'GOOGL');
       expect(money.format()).toEqual('101 GOOGL');
     });
+
+    it('extra decimals', () => {
+      money = new Money(100.1234, 'USD');
+      expect(money.format(4, 6)).toEqual('$100.1234');
+    });
   });
 
   describe('toNumber', () => {

--- a/src/components/tables/PricesTable.tsx
+++ b/src/components/tables/PricesTable.tsx
@@ -14,7 +14,7 @@ export type PricesTableProps = {
   prices: Price[],
 };
 
-export default function TransactionsTable({
+export default function PricesTable({
   prices,
 }: PricesTableProps): JSX.Element {
   return (
@@ -59,7 +59,7 @@ const columns: ColumnDef<Price>[] = [
     accessorFn: (row: Price) => new Money(
       row.value,
       (row.fk_currency as Commodity).mnemonic,
-    ).format(),
+    ).format(6, 6),
   },
   {
     header: 'Actions',

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -41,6 +41,7 @@ export function moneyToString(n: number, currency: string): string {
     return n.toLocaleString(navigator.language, {
       style: 'currency',
       currency: currency || 'EUR',
+      maximumFractionDigits: 6,
     });
   } catch {
     return `${n.toLocaleString(navigator.language)} ${currency}`;


### PR DESCRIPTION
So apparently, for some currency rates, yahoo returns very bad resolution. Take https://finance.yahoo.com/quote/IDREUR=X?.tsrc=fin-srch for example which always returns 0.0001 which is definitely wrong.

The change I've introduced is see if there is some reliable currency in the ticker ('SGD', 'USD' and 'EUR') for now and if there is, use that one as a base

I.E IDREUR=X returns crap but EURIDR=X works as expected. So we apply this behavior too.

This is why in #831 IDR is always 10000. After this change, it shows correct prices:

<img width="1586" alt="Screenshot 2024-04-08 at 4 51 18 PM" src="https://github.com/maffin-io/maffin-app/assets/3578154/062994b3-560d-4d36-8d86-e46846f2fc80">

Also, as an improvement for this, increased the amount of decimals that can be shown in the prices chart and prices table

Fixes #831 