### PR TITLE
Fix money to string decimals

### DIFF
--- a/src/__tests__/helpers/number.test.ts
+++ b/src/__tests__/helpers/number.test.ts
@@ -56,4 +56,12 @@ describe('moneyToString', () => {
   it('returns as expected when not a currency', () => {
     expect(moneyToString(1234567.89, 'NVDA')).toEqual('1,234,567.89 NVDA');
   });
+
+  it('rounds to specific decimals', () => {
+    expect(moneyToString(1.9876389, 'EUR', 5)).toEqual('€1.98764');
+  });
+
+  it('rounds to specific decimals when not a currency', () => {
+    expect(moneyToString(1.9876389, 'NVDA', 5)).toEqual('1.98764 NVDA');
+  });
 });

--- a/src/book/Money.ts
+++ b/src/book/Money.ts
@@ -64,12 +64,14 @@ export default class Money {
    * Represents the money object as a string with the currency standardizing
    * the scale to 2 as a default. If the scale is passed then it uses that.
    *
+   * By default it rounds the final number to 2 decimals but can pass a custom one.
+   *
    * The result is a localized string with the currency as a symbol
    */
   format(scale = 4, decimals = 2): string {
     return djs.toDecimal(
       djs.transformScale(this._raw, scale),
-      ({ value, currency }) => moneyToString(toFixed(Number(value), decimals), currency.code),
+      ({ value, currency }) => moneyToString(Number(value), currency.code, decimals),
     );
   }
 

--- a/src/book/__tests__/Money.test.ts
+++ b/src/book/__tests__/Money.test.ts
@@ -43,9 +43,14 @@ describe('Money', () => {
       expect(money.format()).toEqual('101 GOOGL');
     });
 
+    it('rounds with decimals', () => {
+      money = new Money(100.1254, 'USD');
+      expect(money.format(4, 2)).toEqual('$100.13');
+    });
+
     it('extra decimals', () => {
       money = new Money(100.1234, 'USD');
-      expect(money.format(4, 6)).toEqual('$100.1234');
+      expect(money.format(4, 4)).toEqual('$100.1234');
     });
   });
 

--- a/src/components/pages/commodity/PricesChart.tsx
+++ b/src/components/pages/commodity/PricesChart.tsx
@@ -42,7 +42,7 @@ export default function PricesChart({
           tooltip: {
             backgroundColor: '#323b44',
             callbacks: {
-              label: (ctx) => `${moneyToString(Number(ctx.parsed.y), currency)}`,
+              label: (ctx) => `${moneyToString(Number(ctx.parsed.y), currency, 6)}`,
             },
           },
         },

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -36,14 +36,16 @@ export function toFixed(n: number, decimals = 2): number {
   return parseFloat(n.toFixed(decimals));
 }
 
-export function moneyToString(n: number, currency: string): string {
+export function moneyToString(n: number, currency: string, decimals = 2): string {
   try {
     return n.toLocaleString(navigator.language, {
       style: 'currency',
       currency: currency || 'EUR',
-      maximumFractionDigits: 6,
+      maximumFractionDigits: decimals,
     });
   } catch {
-    return `${n.toLocaleString(navigator.language)} ${currency}`;
+    return `${n.toLocaleString(navigator.language, {
+      maximumFractionDigits: decimals,
+    })} ${currency}`;
   }
 }


### PR DESCRIPTION
Currently, some moneyToString calls are showing too many decimals. This PR fixes that by allowing the user to specify how many decimals they want. This is necessary because when showing exchange rates, we need more than two decimals but for any normal money representation, 2 decimals is fine.