### PR TITLE
Refactor transaction form pt.1

### DIFF
--- a/src/book/entities/priceOps.ts
+++ b/src/book/entities/priceOps.ts
@@ -1,0 +1,31 @@
+import type { DateTime } from 'luxon';
+import type { PriceDBMap } from '../prices';
+import type Commodity from './Commodity';
+import Price from './Price';
+
+type GetExchangeRateOptions = {
+  date: DateTime;
+  from: Commodity;
+  to: Commodity;
+};
+
+const getExchangeRate = (prices: PriceDBMap, options: GetExchangeRateOptions): Price => {
+  const { from, to, date } = options;
+
+  const isSameCommodity = from.guid === to.guid;
+  if (isSameCommodity) {
+    return Price.create({ valueNum: 1, valueDenom: 1 });
+  }
+
+  if (to.namespace !== 'CURRENCY') {
+    return Price.create({ valueNum: 1, valueDenom: 1 });
+  }
+
+  return from.namespace !== 'CURRENCY'
+    ? prices.getInvestmentPrice(from.mnemonic, date)
+    : prices.getPrice(from.mnemonic, to.mnemonic, date);
+};
+
+export const priceOps = {
+  getExchangeRate,
+};

--- a/src/book/entities/splitOps.ts
+++ b/src/book/entities/splitOps.ts
@@ -1,0 +1,7 @@
+import Split from './Split';
+
+export const splitOps = {
+  isSameCommodity: (a: Split, b: Split) => (
+    a.account?.commodity?.guid === b.account?.commodity?.guid
+  ),
+};

--- a/src/components/forms/transaction/MainSplit.tsx
+++ b/src/components/forms/transaction/MainSplit.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 
 import { Tooltip } from '@/components/tooltips';
 import { Price } from '@/book/entities';
+import { priceOps } from '@/book/entities/priceOps';
 import { toFixed } from '@/helpers/number';
 import { currencyToSymbol } from '@/helpers/currency';
 import { usePrices } from '@/hooks/api';
@@ -34,23 +35,15 @@ export default function MainSplit({
   );
 
   React.useEffect(() => {
-    if (
-      form.formState.isDirty
-      && date
-      && prices
-    ) {
-      let rate = null;
-      const d = DateTime.fromISO(date);
-      if (account.commodity.guid !== txCurrency.guid && txCurrency.namespace === 'CURRENCY') {
-        rate = account.commodity.namespace !== 'CURRENCY'
-          ? prices.getInvestmentPrice(account.commodity.mnemonic, d)
-          : prices.getPrice(account.commodity.mnemonic, txCurrency.mnemonic, d);
-
-        setExchangeRate(rate);
-      } else {
-        setExchangeRate(Price.create({ valueNum: 1, valueDenom: 1 }));
-      }
+    if (!date || !prices || !form.formState.isDirty) {
+      return;
     }
+    const rate = priceOps.getExchangeRate(prices, {
+      date: DateTime.fromISO(date),
+      from: account.commodity,
+      to: txCurrency,
+    });
+    setExchangeRate(rate);
   }, [txCurrency, date, form.formState.isDirty, account, prices]);
 
   React.useEffect(() => {

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -13,7 +13,15 @@ import { usePrices } from '@/hooks/api';
 import { Account, Price } from '@/book/entities';
 import { priceOps } from '@/book/entities/priceOps';
 import { getAllowedSubAccounts } from '@/book/helpers/accountType';
+import { type TransactionFormContext } from './txFormOps';
 import type { FormValues } from './types';
+
+export const prepareSplitFieldProps = (
+  { action, form, disabled }: TransactionFormContext,
+  index: number,
+): SplitFieldProps => ({
+  action, index, form, disabled,
+});
 
 export type SplitFieldProps = {
   index: number;

--- a/src/components/forms/transaction/SplitField.tsx
+++ b/src/components/forms/transaction/SplitField.tsx
@@ -11,6 +11,7 @@ import { AccountSelector } from '@/components/selectors';
 import { currencyToSymbol } from '@/helpers/currency';
 import { usePrices } from '@/hooks/api';
 import { Account, Price } from '@/book/entities';
+import { priceOps } from '@/book/entities/priceOps';
 import { getAllowedSubAccounts } from '@/book/helpers/accountType';
 import type { FormValues } from './types';
 
@@ -39,25 +40,18 @@ export default function SplitField({
   const value = form.watch(`splits.${index}.value`);
 
   React.useEffect(() => {
-    if (
-      account
-      && date
-      && action === 'add'
-      && prices
-    ) {
-      let rate = null;
-      const d = DateTime.fromISO(date);
-      if (showValueField && txCurrency.namespace === 'CURRENCY') {
-        rate = account.commodity.namespace !== 'CURRENCY'
-          ? prices.getInvestmentPrice(account.commodity.mnemonic, d)
-          : prices.getPrice(account.commodity.mnemonic, txCurrency.mnemonic, d);
-
-        setExchangeRate(rate);
-      } else {
-        setExchangeRate(Price.create({ valueNum: 1, valueDenom: 1 }));
-      }
+    if (!account || !date || !prices) {
+      return;
     }
-  }, [account, showValueField, txCurrency, date, action, prices]);
+    if (action === 'add') {
+      const rate = priceOps.getExchangeRate(prices, {
+        date: DateTime.fromISO(date),
+        from: account.commodity,
+        to: txCurrency,
+      });
+      setExchangeRate(rate);
+    }
+  }, [account, txCurrency, date, action, prices]);
 
   React.useEffect(() => {
     if (value && action === 'add') {

--- a/src/components/forms/transaction/SplitRow.tsx
+++ b/src/components/forms/transaction/SplitRow.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import SplitField, { type SplitFieldProps, prepareSplitFieldProps } from './SplitField';
+import { TransactionFormContext, txFormOps } from './txFormOps';
+
+export type SplitRowProps = {
+  key: string;
+  splitFieldProps: SplitFieldProps;
+  deleteButtonProps?:
+  | { show: true; onClick: VoidFunction }
+  | { show: false };
+};
+
+export const prepareSplitRowProps = (
+  formContext: TransactionFormContext,
+  { index }: { index: number },
+): SplitRowProps | null => {
+  const showMainSplit = txFormOps.hasMainSplitField(formContext);
+  if (showMainSplit && index === 0) {
+    return null;
+  }
+
+  const { splitsFieldArray } = formContext;
+  const currentField = splitsFieldArray.fields[index];
+
+  const hasDeleteButton = index > 1;
+  const deleteButtonProps = hasDeleteButton
+    ? { show: true, onClick: () => splitsFieldArray.remove(index) }
+    : undefined;
+
+  return {
+    key: currentField.id,
+    deleteButtonProps,
+    splitFieldProps: prepareSplitFieldProps(formContext, index),
+  };
+};
+
+export function SplitRow(props: SplitRowProps) {
+  const { deleteButtonProps, splitFieldProps } = props;
+
+  return (
+    <fieldset className="grid grid-cols-12">
+      <div className="col-span-11">
+        <SplitField {...splitFieldProps} />
+      </div>
+      {(
+        deleteButtonProps?.show
+        && (
+          <div className="col-span-1">
+            <DeleteSplitButton {...deleteButtonProps} />
+          </div>
+        )
+      )}
+    </fieldset>
+  );
+}
+
+function DeleteSplitButton(props: {
+  onClick: () => void;
+}) {
+  return (
+    <div className="col-span-1">
+      <button
+        type="button"
+        className="btn btn-primary rounded-sm"
+        onClick={props.onClick}
+      >
+        X
+      </button>
+    </div>
+  );
+}

--- a/src/components/forms/transaction/SplitsField.tsx
+++ b/src/components/forms/transaction/SplitsField.tsx
@@ -3,10 +3,23 @@ import { useFieldArray } from 'react-hook-form';
 import type { UseFormReturn } from 'react-hook-form';
 
 import { Tooltip } from '@/components/tooltips';
-import { Split } from '@/book/entities';
+import { splitOps } from '@/book/entities/splitOps';
 import type { FormValues } from './types';
-import SplitField from './SplitField';
 import MainSplit from './MainSplit';
+import { TransactionFormContext, txFormOps } from './txFormOps';
+import { SplitRow, prepareSplitRowProps } from './SplitRow';
+import { txFormActions } from './txFormActions';
+
+function isTruthy<T = unknown>(value: T | null | undefined): value is T {
+  return !!value;
+}
+
+const prepareSplitRows = (formContext: TransactionFormContext) => {
+  const { splitsFieldArray } = formContext;
+  return splitsFieldArray.fields
+    .map((_, index) => prepareSplitRowProps(formContext, { index }))
+    .filter(isTruthy);
+};
 
 export type SplitsFieldProps = {
   action?: 'add' | 'update' | 'delete',
@@ -19,26 +32,31 @@ export default function SplitsField({
   form,
   disabled = false,
 }: SplitsFieldProps): JSX.Element {
-  const { fields, append, remove } = useFieldArray({
+  const splitsFieldArray = useFieldArray({
     control: form.control,
     name: 'splits',
   });
+  const formContext: TransactionFormContext = {
+    action, form, disabled, splitsFieldArray,
+  };
+  const splitRows = prepareSplitRows(formContext);
+  const showMainSplit = txFormOps.hasMainSplitField(formContext);
+  const errorMessage = txFormOps.getSplitsErrorMessage(formContext);
+
+  const handleAddSplit = () => txFormActions.onAddSplit(formContext);
 
   const splits = form.watch('splits');
-  const mainSplit = splits[0];
-  let firstSplitIndex = 1;
-  if (action === 'update') {
-    firstSplitIndex = 0;
-  }
+  const [mainSplit] = splits;
 
   React.useEffect(() => {
-    if (
-      splits.length === 2
-      && action === 'add'
-    ) {
-      if (
-        splits[0].account?.commodity?.guid === splits[1].account?.commodity?.guid
-      ) {
+    if (action !== 'add') {
+      return;
+    }
+
+    // If the user changes the main split value and we only have two splits,
+    // then we want to update the second split to be the opposite of the main split.
+    if (splits.length === 2) {
+      if (splitOps.isSameCommodity(splits[0], splits[1])) {
         form.setValue('splits.1.quantity', -mainSplit.quantity);
       }
 
@@ -51,7 +69,7 @@ export default function SplitsField({
   return (
     <>
       {
-        action !== 'update'
+        showMainSplit
         && (
           <div>
             <label className="inline-block mb-2">Amount</label>
@@ -60,80 +78,52 @@ export default function SplitsField({
         )
       }
       {
-        fields.slice(firstSplitIndex).length > 0
-        && (
-          <label className="inline-block mt-5 mb-2">Records</label>
-        )
-      }
-      {
-        fields.slice(firstSplitIndex).map((item, index) => {
-          index += firstSplitIndex;
-          return (
-            <fieldset className="grid grid-cols-12" key={item.id}>
-              <div className="col-span-11">
-                <SplitField
-                  action={action}
-                  index={index}
-                  form={form}
-                  disabled={disabled}
-                />
-              </div>
-              {(
-                index > 1
-                && (
-                  <div className="col-span-1">
-                    <button
-                      type="button"
-                      className="btn btn-primary rounded-sm"
-                      onClick={() => remove(index)}
-                    >
-                      X
-                    </button>
-                  </div>
-                )
-              )}
-            </fieldset>
-          );
-        })
-      }
-      <p className="invalid-feedback">{form.formState.errors.splits?.message}</p>
-      {
-        !disabled
+        splitRows.length > 0
         && (
           <>
-            <button
-              className="link m-3 mr-0"
-              type="button"
-              onClick={() => (
-                append(Split.create({
-                  value: 0,
-                  quantity: 0,
-                }))
-              )}
-            >
-              Add split
-            </button>
-            <span
-              className="badge default ml-0.5"
-              data-tooltip-id="add-split-help"
-            >
-              ?
-            </span>
-            <Tooltip
-              id="add-split-help"
-            >
-              <p className="mb-2">
-                Adding extra splits to a transaction is helpful when you want to split
-                a transaction between different categories.
-              </p>
-              <p>
-                An example would be a transaction where you deduct 100 euros from your
-                Asset account and send 70 to Groceries and 30 to Restaurant.
-              </p>
-            </Tooltip>
+            <label className="inline-block mt-5 mb-2">Records</label>
+            {splitRows.map((splitRowProps) => <SplitRow {...splitRowProps} />)}
           </>
         )
       }
+      <p className="invalid-feedback">{errorMessage}</p>
+      {!disabled && (<AddSplitButton onClick={handleAddSplit} />)}
+    </>
+  );
+}
+
+type AddSplitButtonProps = {
+  onClick: () => void,
+};
+
+function AddSplitButton(props: AddSplitButtonProps) {
+  return (
+    <>
+      <button
+        className="link m-3 mr-0"
+        type="button"
+        onClick={props.onClick}
+      >
+        Add split
+      </button>
+      <span
+        className="badge default ml-0.5"
+        data-tooltip-id="add-split-help"
+      >
+        ?
+      </span>
+      <Tooltip
+        id="add-split-help"
+      >
+        <p className="mb-2">
+          Adding extra splits to a transaction is helpful when you want to split
+          a transaction between different categories.
+        </p>
+        <p>
+          An example would be a transaction where you deduct 100 euros from your
+          Asset account and send 70 to Groceries and 30 to Restaurant.
+        </p>
+      </Tooltip>
     </>
   );
 }

--- a/src/components/forms/transaction/txFormActions.ts
+++ b/src/components/forms/transaction/txFormActions.ts
@@ -1,0 +1,11 @@
+import { Split } from '@/book/entities';
+import { TransactionFormContext } from './txFormOps';
+
+const onAddSplit = ({ splitsFieldArray }: TransactionFormContext) => {
+  const newSplit = Split.create({ value: 0, quantity: 0 });
+  return splitsFieldArray.append(newSplit);
+};
+
+export const txFormActions = {
+  onAddSplit,
+};

--- a/src/components/forms/transaction/txFormOps.ts
+++ b/src/components/forms/transaction/txFormOps.ts
@@ -1,0 +1,32 @@
+import { UseFieldArrayReturn, UseFormReturn } from 'react-hook-form';
+import { FormValues } from './types';
+
+export type TransactionFormContext = {
+  action?: 'add' | 'update' | 'delete',
+  splitsFieldArray: UseFieldArrayReturn<FormValues, 'splits', 'id'>,
+  form: UseFormReturn<FormValues>,
+  disabled?: boolean,
+};
+
+const hasMainSplitField = (formContext: TransactionFormContext) => (
+  formContext.action === 'add' || formContext.action === 'delete'
+);
+
+const hasSplitFieldsOtherThanMain = (formContext: TransactionFormContext) => (
+  hasMainSplitField(formContext)
+    ? formContext.splitsFieldArray.fields.length > 1
+    : formContext.splitsFieldArray.fields.length > 0
+);
+
+const getMainSplitValue = ({ form }: TransactionFormContext) => form.getValues('splits.0');
+
+const getSplitsErrorMessage = ({ form }: TransactionFormContext) => (
+  form.formState.errors.splits?.message
+);
+
+export const txFormOps = {
+  getMainSplitValue,
+  getSplitsErrorMessage,
+  hasMainSplitField,
+  hasSplitFieldsOtherThanMain,
+};


### PR DESCRIPTION
The end-goal with my contribution is to tame the TransactionForm which is quite difficult to work with, and my approach to do that is:
1. Centralize control of state in the 'root' of the form in order to have access to both all the events and state. By doing this I'm expecting to get rid of all `useEffects` because we can now update the entire state at once according to the event fired rather than relying on a downstream "sync" side effect based on the change in state.
2. Build a set of pure "operations" around the logic that is otherwise inlined in order to create a language around the intention of the expression. This will abstract business logic out of the components and into a layer independent of React, and forms the building blocks that we can use to compose bigger pieces of logic together. It is also very useful that logic is given a name so that it is easier to understand what's being done:
![Screenshot 2024-05-12 at 13 50 24](https://github.com/maffin-io/maffin-app/assets/4065840/b9c92920-b062-4fb6-8c70-a9e871713aac)

This PR doesn't go all the way to refactor the TransactionForm because that's a rather big job and I would like to get your feedback on this sooner rather than later because it is quite different from existing style/architecture.

In this PR I attack the `SplitsField` because it is very central to the form but was also confusing to understand. I reworked it to make the logic clearer by delegating it to named operations, but also to make the component focused on its role of just "displaying and passing props to the fields". A key to this is introducing the `TransactionFormContext` domain object which is an abstraction that contain all state of the form so that we can build a set of "transaction form operations" which have all the context they need to be pure. By never "looking behind and breaking the abstraction" but instead using dedicated operations like:
```ts
const showMainSplit = txFormOps.hasMainSplitField(formContext);
const errorMessage = txFormOps.getSplitsErrorMessage(formContext);
```
it removes the components' coupling on the form library and the internal state of the form to give us leverage to change it over time without refactoring the components. In a following PR I'll double down on this structure and lift it into the `TransactionForm` and use it to pre-calculate how the form should render at the top level, which will allow me to intercept `onChange` calls made by the `MainField` in order to update the other visible form field.

Please let me know what you think of this, and if I can make it any simpler to review. I know it is a bit of a change in direction, but I'm open to discuss a middle ground here. 

One question on my part is that it was not clear to me how I could extend your entities with my "operations". I think it's neat to keep them separate as the "entity" is connected with the db, whereas the operations are supposed to be pure functions that give us the predictability that they do not mutate existing structures.