### PR TITLE
Fix negative asset values

### DIFF
--- a/src/__tests__/components/charts/TotalsPie.test.tsx
+++ b/src/__tests__/components/charts/TotalsPie.test.tsx
@@ -142,7 +142,7 @@ describe('TotalsPie', () => {
           datasets: [
             {
               backgroundColor: ['#111', '#222'],
-              data: [1500, 150],
+              data: [1500, -150],
             },
           ],
           labels: ['Assets', 'Liabilities'],

--- a/src/__tests__/components/pages/account/TotalWidget.test.tsx
+++ b/src/__tests__/components/pages/account/TotalWidget.test.tsx
@@ -66,8 +66,7 @@ describe('TotalWidgetTest', () => {
     );
   });
 
-  it('keeps negative for liability', () => {
-    account.type = 'CREDIT';
+  it('keeps negative values', () => {
     jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({
       data: { guid: new Money(-100, 'EUR') } as AccountsTotals,
     });

--- a/src/__tests__/components/tables/AccountsTable.test.tsx
+++ b/src/__tests__/components/tables/AccountsTable.test.tsx
@@ -324,7 +324,10 @@ describe('AccountsTable', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('renders Total column as expected', async () => {
+  it.each([
+    ['ASSET', new Money(10, 'EUR'), '€10.00'],
+    ['ASSET', new Money(-10, 'EUR'), '-€10.00'],
+  ])('renders Total column for %s with correct symbol', async (type, money, expected) => {
     render(<AccountsTable guids={['a1']} />);
 
     await screen.findByTestId('Table');
@@ -333,29 +336,28 @@ describe('AccountsTable', () => {
 
     expect(
       // @ts-ignore
-      totalCol.accessorFn({ total: new Money(10, 'EUR') }),
-    ).toEqual(10);
+      totalCol.accessorFn({ total: money }),
+    ).toEqual(money.toNumber());
 
     expect(totalCol.cell).not.toBeUndefined();
-    const { container } = render(
+    render(
       // @ts-ignore
       totalCol.cell({
         row: {
           original: {
             account: {
-              guid: 'assets',
-              name: 'Assets',
-              type: 'ASSET',
+              guid: 'account',
+              name: 'Account',
+              type,
               childrenIds: ['a1'],
             } as Account,
-            total: new Money(10, 'EUR'),
+            total: money,
             children: [],
           },
         },
       }),
     );
 
-    await screen.findByText('€10.00');
-    expect(container).toMatchSnapshot();
+    await screen.findByText(expected);
   });
 });

--- a/src/__tests__/components/tables/__snapshots__/AccountsTable.test.tsx.snap
+++ b/src/__tests__/components/tables/__snapshots__/AccountsTable.test.tsx.snap
@@ -75,11 +75,3 @@ exports[`AccountsTable renders Name column as expected when expandable and not e
   </div>
 </div>
 `;
-
-exports[`AccountsTable renders Total column as expected 1`] = `
-<div>
-  <span>
-    €10.00
-  </span>
-</div>
-`;

--- a/src/components/charts/TotalsPie.tsx
+++ b/src/components/charts/TotalsPie.tsx
@@ -64,7 +64,7 @@ export default function TotalsPie({
           datasets: [
             {
               backgroundColor,
-              data: data.map(d => Math.abs(d.toNumber())),
+              data: data.map(d => d.toNumber()),
             },
           ],
         }}
@@ -100,7 +100,7 @@ export default function TotalsPie({
       <div className="-mt-12">
         <p className="flex justify-center">{title}</p>
         <p className="flex justify-center text-xl">
-          {total.abs().format()}
+          {total.format()}
         </p>
       </div>
     </>

--- a/src/components/pages/account/TotalWidget.tsx
+++ b/src/components/pages/account/TotalWidget.tsx
@@ -5,7 +5,6 @@ import Money from '@/book/Money';
 import type { Account } from '@/book/entities';
 import StatisticsWidget from '@/components/StatisticsWidget';
 import TotalChange from '@/components/widgets/TotalChange';
-import { isLiability } from '@/book/helpers';
 
 export type TotalWidgetProps = {
   account: Account,
@@ -21,7 +20,7 @@ export default function TotalWidget({
     <StatisticsWidget
       className="mr-2"
       title="Total"
-      stats={isLiability(account) ? total0.format() : total0.abs().format()}
+      stats={total0.format()}
       description={<TotalChange account={account} />}
     />
   );

--- a/src/components/tables/AccountsTable.tsx
+++ b/src/components/tables/AccountsTable.tsx
@@ -129,12 +129,12 @@ const columns: ColumnDef<AccountsTableRow>[] = [
     ),
   },
   {
-    accessorFn: (row: AccountsTableRow) => row.total.abs().toNumber(),
+    accessorFn: (row: AccountsTableRow) => row.total.toNumber(),
     id: 'total',
     header: '',
     cell: ({ row }) => (
       <span>
-        {row.original.total.abs().format()}
+        {row.original.total.format()}
       </span>
     ),
   },

--- a/src/lib/queries/getAccountsTotals.ts
+++ b/src/lib/queries/getAccountsTotals.ts
@@ -33,7 +33,10 @@ export default async function getAccountsTotals(
   const totals: { [guid: string]: Money } = {};
 
   rows.forEach(row => {
-    totals[row.accountId] = new Money(row.total, accountsMap[row.accountId].commodity.mnemonic);
+    totals[row.accountId] = new Money(
+      accountsMap[row.accountId].type === 'INCOME' ? Math.abs(row.total) : row.total,
+      accountsMap[row.accountId].commodity.mnemonic,
+    );
   });
 
   return totals;


### PR DESCRIPTION
Fixes #858 

For the Pie chart, it may be a bit confusing to users as we are displaying positive and negative values in the same dataset. Didn't find a better way to do this for now though so keeping as is:

<img width="397" alt="Screenshot 2024-05-20 at 10 52 27 AM" src="https://github.com/maffin-io/maffin-app/assets/3578154/58fa3e8b-57ed-4ad9-80c6-d8d1ad92db07">
