### PR TITLE
Use roles for premium/standard ui

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_AUTH0_DOMAIN=maffin-dev.eu.auth0.com
 NEXT_PUBLIC_AUTH0_CLIENT_ID=mMmnR4NbQOnim9B8QZfe9wfFuaKb8rwW
-NEXT_PUBLIC_AUTH0_SCOPES=profile email
+NEXT_PUBLIC_AUTH0_SCOPES=profile email https://www.googleapis.com/auth/drive.file

--- a/.env.staging
+++ b/.env.staging
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_AUTH0_DOMAIN=maffin-dev.eu.auth0.com
 NEXT_PUBLIC_AUTH0_CLIENT_ID=mMmnR4NbQOnim9B8QZfe9wfFuaKb8rwW
-NEXT_PUBLIC_AUTH0_SCOPES=profile email
+NEXT_PUBLIC_AUTH0_SCOPES=profile email https://www.googleapis.com/auth/drive.file

--- a/src/__tests__/components/CommodityCard.test.tsx
+++ b/src/__tests__/components/CommodityCard.test.tsx
@@ -6,6 +6,7 @@ import * as apiHooks from '@/hooks/api';
 import { PriceDBMap } from '@/book/prices';
 import type { Commodity, Price } from '@/book/entities';
 import CommodityCard from '@/components/CommodityCard';
+import * as sessionHook from '@/hooks/useSession';
 
 jest.mock('@/hooks/api');
 
@@ -13,16 +14,15 @@ jest.mock('@/components/Loading', () => jest.fn(
   () => <div data-testid="Loading" />,
 ));
 
-jest.mock('@/helpers/env', () => ({
+jest.mock('@/hooks/useSession', () => ({
   __esModule: true,
-  get IS_PAID_PLAN() {
-    return true;
-  },
+  ...jest.requireActual('@/hooks/useSession'),
 }));
 
 describe('CommodityCard', () => {
   let eur: Commodity;
   beforeEach(() => {
+    jest.spyOn(sessionHook, 'default').mockReturnValue({ isPremium: true } as sessionHook.SessionReturn);
     jest.spyOn(apiHooks, 'useCommodity').mockReturnValue({ data: undefined } as UseQueryResult<Commodity>);
     jest.spyOn(apiHooks, 'usePrices').mockReturnValue({ data: undefined } as UseQueryResult<PriceDBMap>);
 

--- a/src/__tests__/components/buttons/SaveButton.test.tsx
+++ b/src/__tests__/components/buttons/SaveButton.test.tsx
@@ -10,17 +10,15 @@ import * as query from '@tanstack/react-query';
 import SaveButton from '@/components/buttons/SaveButton';
 import { DataSourceContext } from '@/hooks';
 import type { DataSourceContextType } from '@/hooks';
-import * as helpers_env from '@/helpers/env';
 import * as stateHooks from '@/hooks/state';
+import * as sessionHook from '@/hooks/useSession';
 
 jest.mock('@tanstack/react-query');
 jest.mock('@/lib/prices');
 
-jest.mock('@/helpers/env', () => ({
+jest.mock('@/hooks/useSession', () => ({
   __esModule: true,
-  get IS_PAID_PLAN() {
-    return true;
-  },
+  ...jest.requireActual('@/hooks/useSession'),
 }));
 
 jest.mock('@/hooks/state', () => ({
@@ -32,6 +30,7 @@ describe('SaveButton', () => {
   beforeEach(() => {
     jest.spyOn(query, 'useQuery').mockReturnValue({ data: false } as query.UseQueryResult<boolean>);
     jest.spyOn(stateHooks, 'useOnline').mockReturnValue({ isOnline: true });
+    jest.spyOn(sessionHook, 'default').mockReturnValue({ isPremium: true } as sessionHook.SessionReturn);
   });
 
   it('loads while unavailable datasource', async () => {
@@ -103,7 +102,7 @@ describe('SaveButton', () => {
   });
 
   it('is disabled when not PAID_PLAN', async () => {
-    jest.spyOn(helpers_env, 'IS_PAID_PLAN', 'get').mockReturnValue(false);
+    jest.spyOn(sessionHook, 'default').mockReturnValue({ isPremium: false } as sessionHook.SessionReturn);
     render(
       <DataSourceContext.Provider value={{ isLoaded: true } as DataSourceContextType}>
         <SaveButton />

--- a/src/__tests__/hooks/useBookStorage.test.ts
+++ b/src/__tests__/hooks/useBookStorage.test.ts
@@ -4,7 +4,7 @@ import useBookStorage from '@/hooks/useBookStorage';
 import * as gapiHooks from '@/hooks/useGapiClient';
 import BookStorage from '@/lib/storage/GDriveBookStorage';
 import DemoBookStorage from '@/lib/storage/DemoBookStorage';
-import * as helpers_env from '@/helpers/env';
+import * as sessionHook from '@/hooks/useSession';
 
 jest.mock('@/hooks/useGapiClient', () => ({
   __esModule: true,
@@ -13,20 +13,15 @@ jest.mock('@/hooks/useGapiClient', () => ({
 
 jest.mock('@/lib/storage/GDriveBookStorage');
 
-jest.mock('@/helpers/env', () => ({
+jest.mock('@/hooks/useSession', () => ({
   __esModule: true,
-  get IS_DEMO_PLAN() {
-    return false;
-  },
-  get IS_PAID_PLAN() {
-    return false;
-  },
+  ...jest.requireActual('@/hooks/useSession'),
 }));
 
 describe('useBookStorage', () => {
   beforeEach(() => {
     jest.spyOn(gapiHooks, 'default').mockReturnValue([false]);
-    jest.spyOn(helpers_env, 'IS_PAID_PLAN', 'get').mockReturnValue(true);
+    jest.spyOn(sessionHook, 'default').mockReturnValue({ isPremium: true } as sessionHook.SessionReturn);
   });
 
   afterEach(() => {
@@ -53,9 +48,8 @@ describe('useBookStorage', () => {
     });
   });
 
-  it('returns DemoStorage when IS_DEMO_PLAN', async () => {
-    jest.spyOn(helpers_env, 'IS_PAID_PLAN', 'get').mockReturnValue(false);
-    jest.spyOn(helpers_env, 'IS_DEMO_PLAN', 'get').mockReturnValue(true);
+  it('returns DemoStorage when not premium', async () => {
+    jest.spyOn(sessionHook, 'default').mockReturnValue({ isPremium: false } as sessionHook.SessionReturn);
     window.gapi = {
       client: {} as typeof gapi.client,
     } as typeof gapi;

--- a/src/__tests__/hooks/useGapiClient.test.ts
+++ b/src/__tests__/hooks/useGapiClient.test.ts
@@ -2,18 +2,10 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 
 import useGapiClient from '@/hooks/useGapiClient';
 import * as sessionHook from '@/hooks/useSession';
-import * as helpers_env from '@/helpers/env';
 
 jest.mock('@/hooks/useSession', () => ({
   __esModule: true,
   ...jest.requireActual('@/hooks/useSession'),
-}));
-
-jest.mock('@/helpers/env', () => ({
-  __esModule: true,
-  get IS_PAID_PLAN() {
-    return true;
-  },
 }));
 
 describe('useGapiClient', () => {
@@ -21,7 +13,6 @@ describe('useGapiClient', () => {
     // @ts-ignore
     window.gapi = null;
 
-    jest.spyOn(helpers_env, 'IS_PAID_PLAN', 'get').mockReturnValue(true);
     jest.spyOn(sessionHook, 'default').mockReturnValue({
       accessToken: '',
     } as sessionHook.SessionReturn);
@@ -63,13 +54,6 @@ describe('useGapiClient', () => {
 
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.body.getElementsByTagName('script').length).toEqual(1);
-  });
-
-  it('returns true when not PAID_PLAN', () => {
-    jest.spyOn(helpers_env, 'IS_PAID_PLAN', 'get').mockReturnValue(false);
-    const { result } = renderHook(() => useGapiClient());
-
-    expect(result.current).toEqual([true]);
   });
 
   it('returns false when script onload not finished', () => {

--- a/src/__tests__/lib/jwt.test.ts
+++ b/src/__tests__/lib/jwt.test.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 
-import { verify } from '@/lib/jwt';
+import { isPremium, verify } from '@/lib/jwt';
 
 describe('verify', () => {
   beforeEach(() => {
@@ -26,5 +26,23 @@ describe('verify', () => {
     );
 
     await expect(verify('token')).rejects.toThrow('fail');
+  });
+});
+
+describe('isPremium', () => {
+  it('returns true when premium', async () => {
+    jest.spyOn(jwt, 'decode').mockReturnValue({
+      'https://maffin/roles': ['premium'],
+    });
+
+    expect(await isPremium('token')).toBe(true);
+  });
+
+  it('returns false when not premium', async () => {
+    jest.spyOn(jwt, 'decode').mockReturnValue({
+      'https://maffin/roles': [],
+    });
+
+    expect(await isPremium('token')).toBe(false);
   });
 });

--- a/src/__tests__/lib/storage/DemoBookStorage.test.ts
+++ b/src/__tests__/lib/storage/DemoBookStorage.test.ts
@@ -33,6 +33,13 @@ describe('DemoBookStorage', () => {
           arrayBuffer: () => Promise.resolve(rawBook.buffer),
         })) as jest.Mock,
       );
+      Object.defineProperty(window, 'location', {
+        value: {
+          host: 'demo.maffin.io',
+        },
+        writable: true,
+      });
+
       await instance.initStorage();
     });
 
@@ -52,10 +59,10 @@ describe('DemoBookStorage', () => {
       expect(content).toEqual(pako.ungzip(rawBook));
     });
 
-    it('returns empty data when in free.maffin.io', async () => {
+    it('returns empty data when domain not demo.maffin.io', async () => {
       Object.defineProperty(window, 'location', {
         value: {
-          host: 'free.maffin.io',
+          host: 'app.maffin.io',
         },
         writable: true,
       });

--- a/src/app/actions/getTodayPrices.ts
+++ b/src/app/actions/getTodayPrices.ts
@@ -2,7 +2,7 @@
 
 import getPrices from '@/lib/external/yahoo';
 import type { Price } from '@/lib/external/yahoo';
-import { verify } from '@/lib/jwt';
+import { isPremium, verify } from '@/lib/jwt';
 
 /**
  * Action to retrieve prices from an external API.
@@ -17,8 +17,8 @@ export default async function getTodayPrices({
   tickers: string[],
   accessToken: string,
 }): Promise<{ [ticker: string]: Price }> {
-  const token = await verify(accessToken);
-  if (!token['https://maffin/roles'].includes('premium')) {
+  await verify(accessToken);
+  if (!await isPremium(accessToken)) {
     return {};
   }
 

--- a/src/components/CommodityCard.tsx
+++ b/src/components/CommodityCard.tsx
@@ -9,7 +9,7 @@ import {
 import { Tooltip, UpgradeTooltip } from '@/components/tooltips';
 import { useCommodity, useMainCurrency, usePrices } from '@/hooks/api';
 import Loading from '@/components/Loading';
-import { IS_PAID_PLAN } from '@/helpers/env';
+import useSession from '@/hooks/useSession';
 
 export type CommodityCardProps = {
   guid: string;
@@ -21,6 +21,7 @@ export default function CommodityCard({
   const { data: commodity } = useCommodity(guid);
   const { data: mainCurrency } = useMainCurrency();
   const { data: prices } = usePrices({ from: commodity });
+  const { isPremium } = useSession();
 
   if (!commodity || !prices) {
     return <Loading />;
@@ -132,7 +133,7 @@ export default function CommodityCard({
       {
         !priceAvailable
         && (
-          IS_PAID_PLAN
+          isPremium
             ? (
               <Tooltip
                 id={`missing-price-${guid}`}

--- a/src/components/buttons/SaveButton.tsx
+++ b/src/components/buttons/SaveButton.tsx
@@ -4,9 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 
 import { DataSourceContext } from '@/hooks';
-import { IS_PAID_PLAN } from '@/helpers/env';
 import { useOnline } from '@/hooks/state';
 import { UpgradeTooltip } from '@/components/tooltips';
+import useSession from '@/hooks/useSession';
 
 export default function SaveButton(): JSX.Element {
   const { data: isSaving } = useQuery({
@@ -16,6 +16,7 @@ export default function SaveButton(): JSX.Element {
   });
   const { isLoaded, save } = React.useContext(DataSourceContext);
   const { isOnline } = useOnline();
+  const { isPremium } = useSession();
 
   if (!isLoaded) {
     return (
@@ -39,7 +40,7 @@ export default function SaveButton(): JSX.Element {
             'btn-danger': !isOnline,
           },
         )}
-        disabled={isSaving || !IS_PAID_PLAN || !isOnline}
+        disabled={isSaving || !isPremium || !isOnline}
         data-tooltip-id="storage-upgrade-tooltip"
         onClick={async () => {
           await save();
@@ -72,7 +73,7 @@ export default function SaveButton(): JSX.Element {
         }
       </button>
       {
-        !IS_PAID_PLAN
+        !isPremium
         && (
           <UpgradeTooltip
             id="storage-upgrade-tooltip"

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,2 +1,0 @@
-export const IS_PAID_PLAN: boolean = process.env.NEXT_PUBLIC_ENV === 'master';
-export const IS_DEMO_PLAN = !IS_PAID_PLAN;

--- a/src/hooks/useBookStorage.ts
+++ b/src/hooks/useBookStorage.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import useGapiClient from '@/hooks/useGapiClient';
-import { IS_PAID_PLAN } from '@/helpers/env';
 import type BookStorage from '@/lib/storage/BookStorage';
 import {
   GDriveBookStorage,
   DemoBookStorage,
 } from '@/lib/storage';
+import useSession from './useSession';
 
 type UseBookStorageReturn = {
   storage: BookStorage | null,
@@ -15,6 +15,7 @@ type UseBookStorageReturn = {
 export default function useBookStorage(): UseBookStorageReturn {
   const [isGapiLoaded] = useGapiClient();
   const [storage, setStorage] = React.useState<BookStorage | null>(null);
+  const { isPremium } = useSession();
 
   const [error, setError] = React.useState<Error | null>(null);
   if (error) {
@@ -25,7 +26,7 @@ export default function useBookStorage(): UseBookStorageReturn {
     async function load() {
       let instance: BookStorage = new DemoBookStorage();
 
-      if (IS_PAID_PLAN) {
+      if (isPremium) {
         instance = new GDriveBookStorage(window.gapi.client);
       }
 
@@ -40,7 +41,7 @@ export default function useBookStorage(): UseBookStorageReturn {
     if (isGapiLoaded) {
       load();
     }
-  }, [isGapiLoaded]);
+  }, [isGapiLoaded, isPremium]);
 
   return { storage };
 }

--- a/src/hooks/useDataSource.tsx
+++ b/src/hooks/useDataSource.tsx
@@ -16,7 +16,6 @@ import {
   Transaction,
 } from '@/book/entities';
 import { MIGRATIONS } from '@/book/migrations';
-import { IS_DEMO_PLAN } from '@/helpers/env';
 import { useQueryClient } from '@tanstack/react-query';
 import type BookStorage from '@/lib/storage/BookStorage';
 import { MaffinError, StorageError } from '@/helpers/errors';
@@ -121,7 +120,7 @@ async function save(storage: BookStorage) {
 }
 
 async function importBook(storage: BookStorage, rawData: Uint8Array) {
-  if (IS_DEMO_PLAN) {
+  if (process.env.NEXT_PUBLIC_ENV !== 'master') {
     Settings.now = () => Date.now();
   }
   let parsedData;

--- a/src/hooks/useGapiClient.ts
+++ b/src/hooks/useGapiClient.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { IS_PAID_PLAN } from '@/helpers/env';
 import useSession from './useSession';
 
 const isBrowser = typeof window !== 'undefined';
@@ -48,10 +47,6 @@ export default function useGapiClient() {
       window.gapi.client.setToken({ access_token: accessToken });
     }
   }, [isLoaded, accessToken]);
-
-  if (!IS_PAID_PLAN) {
-    return [true];
-  }
 
   return [!!(isLoaded && accessToken)];
 }

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -9,14 +9,9 @@ import { Toaster } from 'react-hot-toast';
 
 import '@/css/globals.css';
 import Auth0Provider from '@/lib/auth0-provider';
-import { IS_DEMO_PLAN } from '@/helpers/env';
 
 if (process.env.NODE_ENV === 'development') {
   Settings.throwOnInvalid = true;
-}
-
-if (IS_DEMO_PLAN) {
-  Settings.now = () => 1703980800000; // 2023-12-31
 }
 
 const queryClient = new QueryClient({

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -26,3 +26,8 @@ export async function verify(token: string): Promise<JwtPayload> {
 
   return verified;
 }
+
+export async function isPremium(token: string): Promise<boolean> {
+  const decoded = jwt.decode(token) as JwtPayload;
+  return decoded['https://maffin/roles'].includes('premium');
+}

--- a/src/lib/storage/DemoBookStorage.ts
+++ b/src/lib/storage/DemoBookStorage.ts
@@ -1,4 +1,5 @@
 import pako from 'pako';
+import { Settings } from 'luxon';
 
 import BookStorage from '@/lib/storage/BookStorage';
 
@@ -10,10 +11,13 @@ export default class DemoBookStorage implements BookStorage {
   }
 
   async get(): Promise<Uint8Array> {
-    if (window.location.host === 'free.maffin.io') {
+    if (!(window.location.host === 'demo.maffin.io')) {
       return new Uint8Array([]);
     }
 
+    // When we show demo data, we set modify DateTime.now
+    // so it shows the stored data
+    Settings.now = () => 1703980800000; // 2023-12-31
     const response = await fetch(
       `/books/${this.fileName}.sqlite.gz`,
       {


### PR DESCRIPTION
Use `isPremium` flag coming from auth0 jwt token instead of IS_DEMO_PLAN and IS_PLAID_PLAN which depended on the environment being used. This means that we can now have both premium and non premium users in both environments.

This defeats the purpose of having `free.maffin.io` so I'll be deleting the domain and remove the `check_subscription` from app.maffin.io so anyone can login (new users will always be non premium as the role is assigned manually for now).

This behavior is nice because it allows to add extra roles for trying new features. I.e. could have a role called `beta` and then use an `isBeta` flag to enable those features for only those users.