### PR TITLE
[WIP] Import plaid transactions

### DIFF
--- a/src/lib/external/plaid.ts
+++ b/src/lib/external/plaid.ts
@@ -1,7 +1,15 @@
+import { DateTime } from 'luxon';
 import { AccountType } from 'plaid';
 import type { TransactionsSyncResponse } from 'plaid';
 
-import { Account, Commodity } from '@/book/entities';
+import {
+  Account,
+  Commodity,
+  Split,
+  Transaction,
+} from '@/book/entities';
+import { toAmountWithScale } from '@/helpers/number';
+import { getMainCurrency } from '@/lib/queries';
 
 /**
  * Transform the response returned from transactionsSync to our entities.
@@ -11,22 +19,11 @@ import { Account, Commodity } from '@/book/entities';
  *    whenever is needed
  */
 export async function createEntitiesFromData(data: TransactionsSyncResponse) {
-  const { accounts } = data;
+  const { accounts: plaidAccounts, added } = data;
+  console.log(data);
 
   await Promise.all(
-    accounts.map(async (account) => {
-      let commodity = await Commodity.findOneBy({
-        namespace: 'CURRENCY',
-        mnemonic: account.balances.iso_currency_code as string,
-      });
-
-      if (!commodity) {
-        commodity = await Commodity.create({
-          namespace: 'CURRENCY',
-          mnemonic: account.balances.iso_currency_code as string,
-        }).save();
-      }
-
+    plaidAccounts.map(async (account) => {
       let type = 'BANK';
       let parent = await Account.findOneByOrFail({
         type: 'ASSET',
@@ -44,14 +41,139 @@ export async function createEntitiesFromData(data: TransactionsSyncResponse) {
         });
       }
 
-      await Account.create({
+      const currency = await getOrCreateCurrency(account.balances.iso_currency_code as string);
+      const a = await Account.create({
         guid: `plaid-${account.persistent_account_id}`,
         name: account.name,
-        fk_commodity: commodity,
+        fk_commodity: currency,
         type,
         description: 'Synced account',
         parent,
       }).save();
+
+      await createTransactions({
+        account: a,
+        txs: added,
+        currency,
+      });
     }),
   );
+}
+
+async function getOrCreateCurrency(mnemonic: string): Promise<Commodity> {
+  let currency = await Commodity.findOneBy({
+    namespace: 'CURRENCY',
+    mnemonic,
+  });
+
+  if (!currency) {
+    currency = await Commodity.create({
+      namespace: 'CURRENCY',
+      mnemonic,
+    }).save();
+  }
+
+  return currency;
+}
+
+async function createTransactions({
+  account,
+  txs,
+  currency,
+}: {
+  account: Account,
+  txs: TransactionsSyncResponse['added'],
+  currency: Commodity,
+}) {
+  const [income, expense] = await getOrCreateImportAccounts();
+  const transactions = txs
+    .filter(tx => tx.account_id === account.guid)
+    .map(tx => {
+      console.log(tx);
+      const { amount, scale } = toAmountWithScale(tx.amount);
+      return Transaction.create({
+        guid: tx.transaction_id,
+        description: tx.name,
+        date: DateTime.fromISO(tx.date),
+        fk_currency: currency,
+        splits: [
+          Split.create({
+            fk_account: account,
+            quantityNum: -1 * amount,
+            quantityDenom: parseInt('1'.padEnd(scale + 1, '0'), 10),
+            valueNum: -1 * amount,
+            valueDenom: parseInt('1'.padEnd(scale + 1, '0'), 10),
+          }),
+          Split.create({
+            fk_account: amount < 0 ? income : expense,
+            quantityNum: -1 * amount,
+            quantityDenom: parseInt('1'.padEnd(scale + 1, '0'), 10),
+            valueNum: -1 * amount,
+            valueDenom: parseInt('1'.padEnd(scale + 1, '0'), 10),
+          }),
+        ],
+      });
+    });
+
+  await Transaction.insert(transactions);
+  console.log(transactions);
+
+  currency.queryClient?.refetchQueries({
+    queryKey: ['api'],
+    type: 'all',
+  });
+}
+
+async function getOrCreateImportAccounts(): Promise<[Account, Account]> {
+  const mainCurrency = await getMainCurrency();
+  const parentExpense = await Account.findOneByOrFail({
+    type: 'EXPENSE',
+    parent: {
+      type: 'ROOT',
+    },
+  });
+
+  let expenseAccount = await Account.findOneBy({
+    type: 'EXPENSE',
+    name: 'Imported',
+    parent: {
+      guid: parentExpense.guid,
+    },
+  });
+
+  if (!expenseAccount) {
+    expenseAccount = await Account.create({
+      type: 'EXPENSE',
+      name: 'Imported',
+      description: 'Imported transactions that need to be reviewed',
+      fk_commodity: mainCurrency,
+      parent: parentExpense,
+    }).save();
+  }
+
+  const parentIncome = await Account.findOneByOrFail({
+    type: 'INCOME',
+    parent: {
+      type: 'ROOT',
+    },
+  });
+  let incomeAccount = await Account.findOneBy({
+    type: 'INCOME',
+    name: 'Imported',
+    parent: {
+      guid: parentIncome.guid,
+    },
+  });
+
+  if (!incomeAccount) {
+    incomeAccount = await Account.create({
+      type: 'INCOME',
+      name: 'Imported',
+      description: 'Imported transactions that need to be reviewed',
+      fk_commodity: mainCurrency,
+      parent: parentIncome,
+    }).save();
+  }
+
+  return [incomeAccount, expenseAccount];
 }


### PR DESCRIPTION
Import transactions from plaid.

For transactions coming from plaid, we have the original account which is the synced one and then we can decide if it's INCOME or EXPENSE depending on the amount being negative or not. The problem though is to know to which account we assign those.

For now taking a pragmatic approach of creating an INCOME and EXPENSE for imported transactions so the user needs to review each and assign to the category they want. The good thing is it's way less work than entering everything manually.

TODO: 

- Transactions from plaid have a currency too but haven't found a case where the currency is different than the one from the account and not sure which case this could happen?
- No proper support yet for accounts that are different than your main currency. This needs some extra work as when creating the splits we need to do the conversion (same as the TransactionForm does). For now I'll just work on importing everything as is and work from there.

PS: I'm pausing this to work on account import because I did some wrong assumptions when working on importing accounts. The account_id is going to change every time the user links an account and right now we don't have a way to avoid the user importing the same accounts twice. https://plaid.com/docs/link/duplicate-items/ 