### PR TITLE
Add bank config entity

### DIFF
--- a/src/__tests__/components/forms/account/AccountForm.test.tsx
+++ b/src/__tests__/components/forms/account/AccountForm.test.tsx
@@ -14,6 +14,7 @@ import { UseQueryResult } from '@tanstack/react-query';
 import { getAllowedSubAccounts } from '@/book/helpers/accountType';
 import {
   Account,
+  BankConfig,
   Commodity,
   Price,
   Split,
@@ -40,7 +41,7 @@ describe('AccountForm', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Price, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Price, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/components/forms/transaction/SplitsField.test.tsx
+++ b/src/__tests__/components/forms/transaction/SplitsField.test.tsx
@@ -11,6 +11,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 
 import {
   Account,
+  BankConfig,
   Commodity,
   Price,
   Split,
@@ -42,7 +43,7 @@ describe('SplitsField', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction, Price],
+      entities: [Account, BankConfig, Commodity, Split, Transaction, Price],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
+++ b/src/__tests__/components/forms/transaction/TransactionForm.test.tsx
@@ -11,6 +11,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 
 import {
   Account,
+  BankConfig,
   Commodity,
   Price,
   Split,
@@ -44,7 +45,7 @@ describe('TransactionForm', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Price, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Price, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/components/onboarding/Onboarding.test.tsx
+++ b/src/__tests__/components/onboarding/Onboarding.test.tsx
@@ -14,6 +14,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import Onboarding from '@/components/onboarding/Onboarding';
 import {
   Account,
+  BankConfig,
   Commodity,
   Price,
   Split,
@@ -37,7 +38,7 @@ describe('Onboarding', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Price, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Price, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/hooks/api/useCashFlow.test.tsx
+++ b/src/__tests__/hooks/api/useCashFlow.test.tsx
@@ -10,6 +10,7 @@ import {
 import { useCashFlow } from '@/hooks/api';
 import {
   Account,
+  BankConfig,
   Commodity,
   Split,
   Transaction,
@@ -36,7 +37,7 @@ describe('useCashFlow', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Split, Transaction, Account, Commodity],
+      entities: [Split, Transaction, Account, BankConfig, Commodity],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/hooks/api/useSplits.test.tsx
+++ b/src/__tests__/hooks/api/useSplits.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/hooks/api';
 import {
   Account,
+  BankConfig,
   Commodity,
   Split,
   Transaction,
@@ -37,7 +38,7 @@ describe('useSplits', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Split, Transaction, Account, Commodity],
+      entities: [Split, Transaction, Account, BankConfig, Commodity],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/lib/createEquityAccount.test.ts
+++ b/src/__tests__/lib/createEquityAccount.test.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import createEquityAccount from '@/lib/createEquityAccount';
 import {
   Account,
+  BankConfig,
   Commodity,
   Split,
   Transaction,
@@ -19,7 +20,7 @@ describe('createEquityAccount', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/lib/gnucash/migrate.test.ts
+++ b/src/__tests__/lib/gnucash/migrate.test.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import { migrate } from '@/lib/gnucash';
 import {
   Account,
+  BankConfig,
   Commodity,
   Split,
   Transaction,
@@ -17,7 +18,7 @@ describe('importBook', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/lib/queries/getAccountsTotals.test.ts
+++ b/src/__tests__/lib/queries/getAccountsTotals.test.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 
 import {
   Account,
+  BankConfig,
   Commodity,
   Price,
   Split,
@@ -22,7 +23,7 @@ describe('getAccountsTotals', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Price, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Price, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/lib/queries/getInvestments.test.ts
+++ b/src/__tests__/lib/queries/getInvestments.test.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 
 import {
   Account,
+  BankConfig,
   Commodity,
   Price,
   Split,
@@ -44,7 +45,7 @@ describe('getInvestments', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Price, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Price, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/lib/queries/getMainCurrency.test.ts
+++ b/src/__tests__/lib/queries/getMainCurrency.test.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm';
 
 import {
   Account,
+  BankConfig,
   Commodity,
   Split,
   Transaction,
@@ -18,7 +19,7 @@ describe('getMainCurrency', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/__tests__/lib/queries/getMonthlyTotals.test.ts
+++ b/src/__tests__/lib/queries/getMonthlyTotals.test.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 
 import {
   Account,
+  BankConfig,
   Commodity,
   Price,
   Split,
@@ -21,7 +22,7 @@ describe('getMonthlyTotals', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Price, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Price, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/book/__tests__/entities/Account.test.ts
+++ b/src/book/__tests__/entities/Account.test.ts
@@ -5,6 +5,7 @@ import {
   Commodity,
   Split,
   Transaction,
+  BankConfig,
   BaseEntity,
 } from '../../entities';
 
@@ -19,7 +20,7 @@ describe('Account', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
     });
@@ -219,7 +220,7 @@ describe('caching', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
       extra: {

--- a/src/book/__tests__/entities/Book.test.ts
+++ b/src/book/__tests__/entities/Book.test.ts
@@ -6,6 +6,7 @@ import {
   Transaction,
   Split,
   Account,
+  BankConfig,
 } from '../../entities';
 
 describe('Book', () => {
@@ -16,7 +17,7 @@ describe('Book', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Book, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Book, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/book/__tests__/entities/Split.test.ts
+++ b/src/book/__tests__/entities/Split.test.ts
@@ -7,6 +7,7 @@ import {
   Transaction,
   Split,
   Account,
+  BankConfig,
 } from '../../entities';
 
 describe('Split', () => {
@@ -19,7 +20,7 @@ describe('Split', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/book/__tests__/entities/Transaction.test.ts
+++ b/src/book/__tests__/entities/Transaction.test.ts
@@ -7,6 +7,7 @@ import {
   Transaction,
   Split,
   Account,
+  BankConfig,
 } from '../../entities';
 
 describe('Transaction', () => {
@@ -20,7 +21,7 @@ describe('Transaction', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
     });
@@ -269,7 +270,7 @@ describe('caching', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Split, Transaction],
       synchronize: true,
       logging: false,
       extra: {

--- a/src/book/__tests__/models/InvestmentAccount.test.ts
+++ b/src/book/__tests__/models/InvestmentAccount.test.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm';
 import { InvestmentAccount } from '@/book/models';
 import {
   Account,
+  BankConfig,
   Commodity,
   Transaction,
   Split,
@@ -24,7 +25,7 @@ describe('InvestmentAccount', () => {
     datasource = new DataSource({
       type: 'sqljs',
       dropSchema: true,
-      entities: [Account, Commodity, Price, Split, Transaction],
+      entities: [Account, BankConfig, Commodity, Price, Split, Transaction],
       synchronize: true,
       logging: false,
     });

--- a/src/book/entities/Account.ts
+++ b/src/book/entities/Account.ts
@@ -29,6 +29,7 @@ import {
 import type Commodity from './Commodity';
 import Split from './Split';
 import BaseEntity from './BaseEntity';
+import BankConfig from './BankConfig';
 
 /**
  * CREATE TABLE accounts (
@@ -109,6 +110,10 @@ export default class Account extends BaseEntity {
 
   @OneToMany('Split', (split: Split) => split.fk_account)
     splits!: Split[];
+
+  @ManyToOne('BankConfig', (config: BankConfig) => config.accounts)
+  @JoinColumn({ name: 'config_guid' })
+    config!: BankConfig;
 
   @Column({
     type: 'text',

--- a/src/book/entities/BankConfig.ts
+++ b/src/book/entities/BankConfig.ts
@@ -1,0 +1,27 @@
+import {
+  Column,
+  Entity,
+  OneToMany,
+} from 'typeorm';
+import {
+  IsString,
+} from 'class-validator';
+
+import BaseEntity from './BaseEntity';
+import type Account from './Account';
+
+@Entity('bank_config')
+export default class BankConfig extends BaseEntity {
+  @Column({
+    type: 'text',
+    length: 2048,
+  })
+  @IsString()
+    token!: string;
+
+  @OneToMany(
+    'Account',
+    (account: Account) => account.config,
+  )
+    accounts!: Account[];
+}

--- a/src/book/entities/index.ts
+++ b/src/book/entities/index.ts
@@ -1,4 +1,5 @@
 export { default as Account } from './Account';
+export { default as BankConfig } from './BankConfig';
 export { default as Commodity } from './Commodity';
 export { default as Price } from './Price';
 export { default as Split } from './Split';

--- a/src/book/migrations/1717405195056-AddBankConfig.ts
+++ b/src/book/migrations/1717405195056-AddBankConfig.ts
@@ -1,0 +1,36 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableForeignKey,
+} from 'typeorm';
+
+/**
+ * The migration adds a new BankConfig table and the relation with the Account
+ */
+export class AddBankConfig1717405195056 implements MigrationInterface {
+  // eslint-disable-next-line class-methods-use-this
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const columnExists = await queryRunner.hasTable('bank_config');
+    if (!columnExists) {
+      await queryRunner.query(
+        'ALTER TABLE "accounts" ADD COLUMN "config_guid" VARCHAR(32)',
+      );
+
+      await queryRunner.createForeignKey(
+        'accounts',
+        new TableForeignKey({
+          columnNames: ['config_guid'],
+          referencedColumnNames: ['guid'],
+          referencedTableName: 'bank_config',
+        }),
+      );
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public async down(): Promise<void> {
+    'unimplemented';
+  }
+}
+
+Object.defineProperty(AddBankConfig1717405195056, 'name', { value: 'AddBankConfig1717405195056' });

--- a/src/book/migrations/index.ts
+++ b/src/book/migrations/index.ts
@@ -1,3 +1,4 @@
 import { AddCommodityName1697688851711 } from './1697688851711-AddCommodityName';
+import { AddBankConfig1717405195056 } from './1717405195056-AddBankConfig';
 
-export const MIGRATIONS = [AddCommodityName1697688851711];
+export const MIGRATIONS = [AddBankConfig1717405195056, AddCommodityName1697688851711];

--- a/src/hooks/useDataSource.tsx
+++ b/src/hooks/useDataSource.tsx
@@ -9,6 +9,7 @@ import useBookStorage from '@/hooks/useBookStorage';
 import { migrate as migrateFromGnucash } from '@/lib/gnucash';
 import {
   Account,
+  BankConfig,
   Book,
   Commodity,
   Price,
@@ -31,7 +32,7 @@ const DATASOURCE: DataSource = new DataSource({
   type: 'sqljs',
   synchronize: true,
   logging: false,
-  entities: [Account, Book, Commodity, Price, Split, Transaction],
+  entities: [Account, BankConfig, Book, Commodity, Price, Split, Transaction],
   migrations: MIGRATIONS,
 });
 
@@ -63,7 +64,7 @@ export default function useDataSource(): DataSourceContextType {
             type: 'sqljs',
             synchronize: true,
             logging: false,
-            entities: [Account, Book, Commodity, Price, Split, Transaction],
+            entities: [Account, BankConfig, Book, Commodity, Price, Split, Transaction],
             migrations: MIGRATIONS,
             extra: {
               queryClient,


### PR DESCRIPTION
Add new entity for holding online bank configuration. Probably will need to modify in the future as right now the online use case we have is for holding Plaid integration information