### PR TITLE
Add plaid duplicate detection

### DIFF
--- a/src/book/__tests__/entities/BankConfig.test.ts
+++ b/src/book/__tests__/entities/BankConfig.test.ts
@@ -1,0 +1,49 @@
+import { DataSource } from 'typeorm';
+
+import {
+  Account,
+  Commodity,
+  Split,
+  Transaction,
+  BankConfig,
+} from '../../entities';
+
+describe('BankConfig', () => {
+  let datasource: DataSource;
+  let account: Account;
+
+  beforeEach(async () => {
+    datasource = new DataSource({
+      type: 'sqljs',
+      dropSchema: true,
+      entities: [Account, Commodity, Split, Transaction, BankConfig],
+      synchronize: true,
+      logging: false,
+    });
+    await datasource.initialize();
+
+    const root = await Account.create({
+      name: 'Root',
+      type: 'ROOT',
+    }).save();
+
+    account = await Account.create({
+      name: 'Account',
+      type: 'ASSET',
+      parent: root,
+      fk_commodity: Commodity.create({
+        namespace: 'CURRENCY',
+        mnemonic: 'EUR',
+      }),
+    }).save();
+  });
+
+  // https://github.com/typeorm/typeorm/issues/10917
+  it.failing('saves config with account', async () => {
+    await BankConfig.create({
+      guid: 'inst_id',
+      token: 'token',
+      accounts: [account],
+    }).save();
+  });
+});

--- a/src/book/entities/Account.ts
+++ b/src/book/entities/Account.ts
@@ -29,7 +29,7 @@ import {
 import type Commodity from './Commodity';
 import Split from './Split';
 import BaseEntity from './BaseEntity';
-import BankConfig from './BankConfig';
+import type BankConfig from './BankConfig';
 
 /**
  * CREATE TABLE accounts (
@@ -113,7 +113,11 @@ export default class Account extends BaseEntity {
 
   @ManyToOne('BankConfig', (config: BankConfig) => config.accounts)
   @JoinColumn({ name: 'config_guid' })
-    config!: BankConfig;
+    fk_config!: BankConfig | string;
+
+  get config(): BankConfig {
+    return this.fk_config as BankConfig;
+  }
 
   @Column({
     type: 'text',

--- a/src/book/entities/BankConfig.ts
+++ b/src/book/entities/BankConfig.ts
@@ -6,9 +6,10 @@ import {
 import {
   IsString,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 
 import BaseEntity from './BaseEntity';
-import type Account from './Account';
+import Account from './Account';
 
 @Entity('bank_config')
 export default class BankConfig extends BaseEntity {
@@ -21,8 +22,9 @@ export default class BankConfig extends BaseEntity {
 
   @OneToMany(
     'Account',
-    (account: Account) => account.config,
+    (account: Account) => account.fk_config,
   )
+  @Type(() => Account)
     accounts!: Account[];
 }
 


### PR DESCRIPTION
Create bank config entity when the user is linking a new institution. If they try to link again we raise an error.

The bank config contains the accounts that have been linked and the access token