### PR TITLE
Ignore hidden accounts when calculating totals

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -17,9 +17,10 @@ jobs:
         node-version: [20.18.1]
         
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -31,17 +32,4 @@ jobs:
         run: yarn maffin:build
 
       - name: Test
-        run: yarn maffin:test --coverage
-
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        with:
-          args: >
-            -Dsonar.organization=maffin-io
-            -Dsonar.projectKey=maffin-io_maffin-app
-            -Dsonar.sources=./src/
-            -Dsonar.tests=./src/
-            -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
-            -Dsonar.test.inclusions=**/__tests__/**
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: yarn maffin:test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 ---
 
 [![Build](https://img.shields.io/github/actions/workflow/status/maffin-io/maffin-app/frontend-ci.yml?label=Build&logo=github)](https://github.com/maffin-io/maffin-app/actions/workflows/frontend-ci.yml)
-[![Sonar Coverage](https://img.shields.io/sonar/coverage/maffin-io_maffin-app?logo=sonarcloud&server=https://sonarcloud.io&label=Coverage)](https://sonarcloud.io/summary/new_code?id=maffin-io_maffin-app)
 [![Chat](https://img.shields.io/discord/1222940742335463566?logo=discord&label=Chat)](https://discord.gg/xeT2z4c35V)
 
 

--- a/src/__tests__/components/charts/MonthlyTotalHistogram.test.tsx
+++ b/src/__tests__/components/charts/MonthlyTotalHistogram.test.tsx
@@ -140,6 +140,11 @@ describe('MonthlyTotalHistogram', () => {
       {
         data: [
           {
+            guid: 'root',
+            name: 'Root',
+            type: 'ROOT',
+          } as Account,
+          {
             guid: 'salary',
             name: 'Salary',
             type: 'INCOME',
@@ -219,6 +224,11 @@ describe('MonthlyTotalHistogram', () => {
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
         data: [
+          {
+            guid: 'root',
+            name: 'Root',
+            type: 'ROOT',
+          } as Account,
           {
             guid: 'salary',
             name: 'Salary',

--- a/src/__tests__/components/charts/TotalsPie.test.tsx
+++ b/src/__tests__/components/charts/TotalsPie.test.tsx
@@ -27,6 +27,12 @@ jest.mock('@/hooks/state', () => ({
 }));
 
 describe('TotalsPie', () => {
+  const ROOT_ACCOUNT = {
+    guid: 'root',
+    name: 'Root',
+    type: 'ROOT',
+  } as Account;
+
   beforeEach(() => {
     jest.spyOn(apiHook, 'useMainCurrency').mockReturnValue({ data: { guid: 'eur', mnemonic: 'EUR' } } as UseQueryResult<Commodity>);
     jest.spyOn(apiHook, 'useAccountsTotals').mockReturnValue({ data: {} });
@@ -117,6 +123,7 @@ describe('TotalsPie', () => {
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
         data: [
+          ROOT_ACCOUNT,
           { guid: 'type_asset', name: 'Assets', commodity: { guid: 'eur' } },
           { guid: 'type_liability', name: 'Liabilities', commodity: { guid: 'eur' } },
         ],
@@ -173,6 +180,7 @@ describe('TotalsPie', () => {
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
         data: [
+          ROOT_ACCOUNT,
           { guid: '1', name: 'Groceries', commodity: { guid: 'eur' } },
           { guid: '2', name: 'Rent', commodity: { guid: 'eur' } },
           { guid: '3', name: 'Electricity', commodity: { guid: 'eur' } },
@@ -224,6 +232,7 @@ describe('TotalsPie', () => {
     jest.spyOn(apiHook, 'useAccounts').mockReturnValue(
       {
         data: [
+          ROOT_ACCOUNT,
           { guid: '1', name: 'ticker1', commodity: { guid: 'ticker1' } },
           { guid: '2', name: 'ticker2', commodity: { guid: 'ticker2' } },
         ],

--- a/src/__tests__/helpers/accountsTotalAggregations.test.ts
+++ b/src/__tests__/helpers/accountsTotalAggregations.test.ts
@@ -389,5 +389,114 @@ describe('accountsTotalAggregations', () => {
       expect(totals.type_asset.toString()).toEqual('0 EUR');
       expect(totals.a5.toString()).toEqual('0 EUR');
     });
+
+    it('excludes hidden children from parent and type totals', () => {
+      accounts[3].childrenIds = ['a5', 'a6'];
+      accounts = [
+        ...accounts,
+        {
+          guid: 'a5',
+          type: 'INCOME',
+          commodity: eur,
+          parentId: 'a3',
+          childrenIds: [] as string[],
+          hidden: false,
+        } as Account,
+        {
+          guid: 'a6',
+          type: 'INCOME',
+          commodity: eur,
+          parentId: 'a3',
+          childrenIds: [] as string[],
+          hidden: true,
+        } as Account,
+      ];
+
+      const aggregatedTotals = aggregateChildrenTotals(
+        ['type_income'],
+        accounts,
+        {} as PriceDBMap,
+        DateTime.now(),
+        {
+          a5: new Money(300, 'EUR'),
+          a6: new Money(200, 'EUR'),
+        },
+      );
+
+      expect(aggregatedTotals.type_income.toString()).toEqual('300 EUR');
+      expect(aggregatedTotals.a3.toString()).toEqual('300 EUR');
+      expect(aggregatedTotals.a6).toBeUndefined();
+    });
+
+    it('excludes hidden expense children from type totals', () => {
+      accounts[4].childrenIds = ['a5', 'a6'];
+      accounts = [
+        ...accounts,
+        {
+          guid: 'a5',
+          type: 'EXPENSE',
+          commodity: eur,
+          parentId: 'a4',
+          childrenIds: [] as string[],
+        } as Account,
+        {
+          guid: 'a6',
+          type: 'EXPENSE',
+          commodity: eur,
+          parentId: 'a4',
+          childrenIds: [] as string[],
+          hidden: true,
+        } as Account,
+      ];
+
+      const aggregatedTotals = aggregateChildrenTotals(
+        ['type_expense'],
+        accounts,
+        {} as PriceDBMap,
+        DateTime.now(),
+        {
+          a5: new Money(100, 'EUR'),
+          a6: new Money(50, 'EUR'),
+        },
+      );
+
+      expect(aggregatedTotals.type_expense.toString()).toEqual('100 EUR');
+    });
+  });
+
+  describe('aggregateMonthlyWorth with hidden accounts', () => {
+    it('does not accumulate totals for hidden accounts', () => {
+      accounts[1].childrenIds = ['a5', 'a6'];
+      accounts = [
+        ...accounts,
+        {
+          guid: 'a5',
+          type: 'ASSET',
+          commodity: eur,
+          parentId: 'a1',
+          childrenIds: [] as string[],
+        } as Account,
+        {
+          guid: 'a6',
+          type: 'ASSET',
+          commodity: eur,
+          parentId: 'a1',
+          childrenIds: [] as string[],
+          hidden: true,
+        } as Account,
+      ];
+
+      const monthlyTotals = [
+        { a5: new Money(100, 'EUR'), a6: new Money(50, 'EUR') },
+        { a5: new Money(200, 'EUR'), a6: new Money(50, 'EUR') },
+      ];
+
+      const aggregated = aggregateMonthlyWorth(['a1'], accounts, monthlyTotals);
+
+      expect(aggregated[0].a5.toString()).toEqual('100 EUR');
+      expect(aggregated[1].a5.toString()).toEqual('300 EUR');
+      expect(aggregated[0].a6).toBeUndefined();
+      expect(aggregated[1].a6).toBeUndefined();
+    });
   });
 });

--- a/src/__tests__/helpers/visibleAccountGuids.test.ts
+++ b/src/__tests__/helpers/visibleAccountGuids.test.ts
@@ -1,0 +1,43 @@
+import visibleAccountGuids, { visibleChildIds } from '@/helpers/visibleAccountGuids';
+import type { Account } from '@/book/entities';
+import mapAccounts from '@/helpers/mapAccounts';
+
+describe('visibleAccountGuids', () => {
+  const accounts = [
+    {
+      guid: 'root',
+      name: 'Root',
+      type: 'ROOT',
+      childrenIds: ['visible', 'hidden'],
+    } as Account,
+    {
+      guid: 'visible',
+      name: 'Visible',
+      type: 'INCOME',
+      parentId: 'root',
+      childrenIds: [],
+    } as Account,
+    {
+      guid: 'hidden',
+      name: 'Hidden',
+      type: 'INCOME',
+      parentId: 'root',
+      childrenIds: [],
+      hidden: true,
+    } as Account,
+  ];
+
+  it('returns guids unchanged when accounts are undefined', () => {
+    expect(visibleAccountGuids(['visible', 'hidden'], undefined)).toEqual(['visible', 'hidden']);
+  });
+
+  it('filters hidden account guids', () => {
+    expect(visibleAccountGuids(['visible', 'hidden'], accounts)).toEqual(['visible']);
+  });
+
+  it('returns visible child ids', () => {
+    const accountsMap = mapAccounts(accounts);
+
+    expect(visibleChildIds(accountsMap, accountsMap.root)).toEqual(['visible']);
+  });
+});

--- a/src/__tests__/layout/Footer.test.tsx
+++ b/src/__tests__/layout/Footer.test.tsx
@@ -4,6 +4,15 @@ import { render } from '@testing-library/react';
 import Footer from '@/layout/Footer';
 
 describe('Footer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('renders as expected', () => {
     const { container } = render(<Footer />);
 

--- a/src/components/charts/MonthlyTotalHistogram.tsx
+++ b/src/components/charts/MonthlyTotalHistogram.tsx
@@ -4,6 +4,7 @@ import type { ChartDataset } from 'chart.js';
 import Bar from '@/components/charts/Bar';
 import type { Account } from '@/book/entities';
 import { useAccounts, useMonthlyTotals, useMainCurrency } from '@/hooks/api';
+import mapAccounts from '@/helpers/mapAccounts';
 import { moneyToString } from '@/helpers/number';
 import { useInterval } from '@/hooks/state';
 import { intervalToDates } from '@/helpers/dates';
@@ -24,10 +25,18 @@ export default function MonthlyTotalHistogram({
   const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
+  const visibleGuids = React.useMemo(() => {
+    if (!accounts) {
+      return guids;
+    }
+    const accountsMap = mapAccounts(accounts);
+    return guids.filter(guid => !accountsMap[guid]?.hidden);
+  }, [guids, accounts]);
+
   const datasets: ChartDataset<'bar'>[] = [];
 
   if (accounts && monthlyTotals) {
-    guids.forEach(guid => {
+    visibleGuids.forEach(guid => {
       const data = monthlyTotals.map(m => m[guid]?.toNumber() || 0);
       if (!data.every(v => v === 0)) {
         datasets.push({

--- a/src/components/charts/MonthlyTotalHistogram.tsx
+++ b/src/components/charts/MonthlyTotalHistogram.tsx
@@ -4,8 +4,8 @@ import type { ChartDataset } from 'chart.js';
 import Bar from '@/components/charts/Bar';
 import type { Account } from '@/book/entities';
 import { useAccounts, useMonthlyTotals, useMainCurrency } from '@/hooks/api';
-import mapAccounts from '@/helpers/mapAccounts';
 import { moneyToString } from '@/helpers/number';
+import visibleAccountGuids from '@/helpers/visibleAccountGuids';
 import { useInterval } from '@/hooks/state';
 import { intervalToDates } from '@/helpers/dates';
 
@@ -25,13 +25,10 @@ export default function MonthlyTotalHistogram({
   const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
-  const visibleGuids = React.useMemo(() => {
-    if (!accounts) {
-      return guids;
-    }
-    const accountsMap = mapAccounts(accounts);
-    return guids.filter(guid => !accountsMap[guid]?.hidden);
-  }, [guids, accounts]);
+  const visibleGuids = React.useMemo(
+    () => visibleAccountGuids(guids, accounts),
+    [guids, accounts],
+  );
 
   const datasets: ChartDataset<'bar'>[] = [];
 

--- a/src/components/charts/TotalsPie.tsx
+++ b/src/components/charts/TotalsPie.tsx
@@ -9,6 +9,7 @@ import {
   useMainCurrency,
   usePrices,
 } from '@/hooks/api';
+import mapAccounts from '@/helpers/mapAccounts';
 import { useInterval } from '@/hooks/state';
 import { moneyToString, toFixed } from '@/helpers/number';
 
@@ -35,12 +36,20 @@ export default function TotalsPie({
   const { data: prices } = usePrices({});
   const unit = currency?.mnemonic || '';
 
+  const visibleGuids = React.useMemo(() => {
+    if (!accounts) {
+      return guids;
+    }
+    const accountsMap = mapAccounts(accounts);
+    return guids.filter(guid => !accountsMap[guid]?.hidden);
+  }, [guids, accounts]);
+
   const data = React.useMemo(() => {
     if (!accounts || !prices || !currency || !totals) {
       return [];
     }
 
-    return guids.map(guid => {
+    return visibleGuids.map(guid => {
       let total = totals?.[guid] || new Money(0, unit);
       const account = accounts?.find(a => a.guid === guid);
       if (account && currency && account.commodity.guid !== currency?.guid) {
@@ -48,13 +57,13 @@ export default function TotalsPie({
       }
       return total;
     });
-  }, [guids, currency, totals, unit, accounts, prices, interval.end]);
+  }, [visibleGuids, currency, totals, unit, accounts, prices, interval.end]);
 
   const total = data.reduce(
     (t, d) => t.add(d),
     new Money(0, unit),
   );
-  const labels = guids.map(guid => accounts?.find(a => a.guid === guid)?.name || '');
+  const labels = visibleGuids.map(guid => accounts?.find(a => a.guid === guid)?.name || '');
 
   return (
     <>

--- a/src/components/charts/TotalsPie.tsx
+++ b/src/components/charts/TotalsPie.tsx
@@ -9,7 +9,7 @@ import {
   useMainCurrency,
   usePrices,
 } from '@/hooks/api';
-import mapAccounts from '@/helpers/mapAccounts';
+import visibleAccountGuids from '@/helpers/visibleAccountGuids';
 import { useInterval } from '@/hooks/state';
 import { moneyToString, toFixed } from '@/helpers/number';
 
@@ -36,13 +36,10 @@ export default function TotalsPie({
   const { data: prices } = usePrices({});
   const unit = currency?.mnemonic || '';
 
-  const visibleGuids = React.useMemo(() => {
-    if (!accounts) {
-      return guids;
-    }
-    const accountsMap = mapAccounts(accounts);
-    return guids.filter(guid => !accountsMap[guid]?.hidden);
-  }, [guids, accounts]);
+  const visibleGuids = React.useMemo(
+    () => visibleAccountGuids(guids, accounts),
+    [guids, accounts],
+  );
 
   const data = React.useMemo(() => {
     if (!accounts || !prices || !currency || !totals) {

--- a/src/helpers/accountsTotalAggregations.ts
+++ b/src/helpers/accountsTotalAggregations.ts
@@ -5,6 +5,7 @@ import { Account } from '@/book/entities';
 import type { AccountsTotals, AccountsMap } from '@/types/book';
 import type { PriceDBMap } from '@/book/prices';
 import mapAccounts from './mapAccounts';
+import { visibleChildIds } from './visibleAccountGuids';
 
 /**
  * For some account types like Asset and Liabilities, we want to accumulate monthly
@@ -46,10 +47,7 @@ function aggregateWorth(
     aggregatedTotals[i][guid] = currentMonth.add(previousMonth);
   });
 
-  current.childrenIds.forEach(childId => {
-    if (accounts[childId]?.hidden) {
-      return;
-    }
+  visibleChildIds(accounts, current).forEach(childId => {
     aggregateWorth(childId, accounts, monthlyTotals, aggregatedTotals);
   });
 }
@@ -97,10 +95,7 @@ function aggregateTotals(
   const current = accounts[guid];
   aggregatedTotals[current.guid] = totals[current.guid] || new Money(0, current.commodity.mnemonic);
 
-  current.childrenIds.forEach((childId: string) => {
-    if (accounts[childId]?.hidden) {
-      return;
-    }
+  visibleChildIds(accounts, current).forEach((childId: string) => {
     aggregatedTotals[current.guid] = aggregatedTotals[current.guid].add(
       convert(
         aggregateTotals(childId, accounts, prices, selectedDate, totals, aggregatedTotals),

--- a/src/helpers/accountsTotalAggregations.ts
+++ b/src/helpers/accountsTotalAggregations.ts
@@ -47,6 +47,9 @@ function aggregateWorth(
   });
 
   current.childrenIds.forEach(childId => {
+    if (accounts[childId]?.hidden) {
+      return;
+    }
     aggregateWorth(childId, accounts, monthlyTotals, aggregatedTotals);
   });
 }
@@ -95,6 +98,9 @@ function aggregateTotals(
   aggregatedTotals[current.guid] = totals[current.guid] || new Money(0, current.commodity.mnemonic);
 
   current.childrenIds.forEach((childId: string) => {
+    if (accounts[childId]?.hidden) {
+      return;
+    }
     aggregatedTotals[current.guid] = aggregatedTotals[current.guid].add(
       convert(
         aggregateTotals(childId, accounts, prices, selectedDate, totals, aggregatedTotals),

--- a/src/helpers/visibleAccountGuids.ts
+++ b/src/helpers/visibleAccountGuids.ts
@@ -1,0 +1,19 @@
+import type { Account } from '@/book/entities';
+import type { AccountsMap } from '@/types/book';
+import mapAccounts from '@/helpers/mapAccounts';
+
+export default function visibleAccountGuids(
+  guids: string[],
+  accounts: Account[] | undefined,
+): string[] {
+  if (!accounts) {
+    return guids;
+  }
+
+  const accountsMap = mapAccounts(accounts);
+  return guids.filter(guid => !accountsMap[guid]?.hidden);
+}
+
+export function visibleChildIds(accounts: AccountsMap, parent: Account): string[] {
+  return parent.childrenIds.filter(childId => !accounts[childId]?.hidden);
+}


### PR DESCRIPTION
Currently even though the net worth widget and others hide accounts that are marked as hidden, the parent still shows aggregated quantity taking into account the hidden account. For example:

- Income: 100
  - salary: 0
  
Current situation makes this possible because there is a hidden account (that contributes the 100). With this change Income account will show 0 too. Also the reporting takes this into account.

Note that asset accounts still reflect the quantities coming from hidden accounts