### PR TITLE
Rollback hidden behavior

### DIFF
--- a/src/__tests__/components/pages/account/IEInfo.test.tsx
+++ b/src/__tests__/components/pages/account/IEInfo.test.tsx
@@ -54,7 +54,6 @@ describe('IEInfo', () => {
     expect(MonthlyTotalHistogram).toHaveBeenCalledWith(
       {
         guids: [account.guid],
-        includeHiddenGuids: [account.guid],
         title: '',
       },
       undefined,
@@ -91,7 +90,6 @@ describe('IEInfo', () => {
     expect(MonthlyTotalHistogram).toHaveBeenCalledWith(
       {
         guids: ['1', '2'],
-        includeHiddenGuids: [],
         title: '',
       },
       undefined,

--- a/src/__tests__/helpers/accountsTotalAggregations.test.ts
+++ b/src/__tests__/helpers/accountsTotalAggregations.test.ts
@@ -391,7 +391,7 @@ describe('accountsTotalAggregations', () => {
       expect(totals.a5.toString()).toEqual('0 EUR');
     });
 
-    it('excludes hidden children from parent and type totals', () => {
+    it('includes hidden children in parent and type totals', () => {
       accounts[3].childrenIds = ['a5', 'a6'];
       accounts = [
         ...accounts,
@@ -424,12 +424,12 @@ describe('accountsTotalAggregations', () => {
         },
       );
 
-      expect(aggregatedTotals.type_income.toString()).toEqual('300 EUR');
-      expect(aggregatedTotals.a3.toString()).toEqual('300 EUR');
+      expect(aggregatedTotals.type_income.toString()).toEqual('500 EUR');
+      expect(aggregatedTotals.a3.toString()).toEqual('500 EUR');
       expect(aggregatedTotals.a6.toString()).toEqual('200 EUR');
     });
 
-    it('excludes hidden expense children from type totals', () => {
+    it('includes hidden expense children in type totals', () => {
       accounts[4].childrenIds = ['a5', 'a6'];
       accounts = [
         ...accounts,
@@ -461,7 +461,7 @@ describe('accountsTotalAggregations', () => {
         },
       );
 
-      expect(aggregatedTotals.type_expense.toString()).toEqual('100 EUR');
+      expect(aggregatedTotals.type_expense.toString()).toEqual('150 EUR');
     });
 
     it('excludes non-report children from parent totals when using reportChildIds', () => {
@@ -510,7 +510,7 @@ describe('accountsTotalAggregations', () => {
   });
 
   describe('aggregateMonthlyWorth with hidden accounts', () => {
-    it('excludes hidden children from parent but keeps direct totals', () => {
+    it('accumulates monthly totals for hidden accounts', () => {
       accounts[1].childrenIds = ['a5', 'a6'];
       accounts = [
         ...accounts,

--- a/src/__tests__/helpers/visibleAccountGuids.test.ts
+++ b/src/__tests__/helpers/visibleAccountGuids.test.ts
@@ -1,18 +1,17 @@
-import visibleAccountGuids, {
-  visibleChildIds,
+import {
   reportChildIds,
   isReportAccount,
 } from '@/helpers/visibleAccountGuids';
 import type { Account } from '@/book/entities';
 import mapAccounts from '@/helpers/mapAccounts';
 
-describe('visibleAccountGuids', () => {
+describe('report account helpers', () => {
   const accounts = [
     {
       guid: 'root',
       name: 'Root',
       type: 'ROOT',
-      childrenIds: ['visible', 'hidden'],
+      childrenIds: ['visible', 'hidden', 'no-report'],
     } as Account,
     {
       guid: 'visible',
@@ -29,47 +28,18 @@ describe('visibleAccountGuids', () => {
       childrenIds: [],
       hidden: true,
     } as Account,
+    {
+      guid: 'no-report',
+      name: 'No report',
+      type: 'INCOME',
+      parentId: 'root',
+      childrenIds: [],
+      report: false,
+    } as Account,
   ];
 
-  it('returns guids unchanged when accounts are undefined', () => {
-    expect(visibleAccountGuids(['visible', 'hidden'], undefined)).toEqual(['visible', 'hidden']);
-  });
-
-  it('filters hidden account guids', () => {
-    expect(visibleAccountGuids(['visible', 'hidden'], accounts)).toEqual(['visible']);
-  });
-
-  it('includes explicitly requested hidden account guids', () => {
-    expect(visibleAccountGuids(['visible', 'hidden'], accounts, ['hidden'])).toEqual(['visible', 'hidden']);
-    expect(visibleAccountGuids(['hidden'], accounts, ['hidden'])).toEqual(['hidden']);
-  });
-
-  it('returns visible child ids', () => {
-    const accountsMap = mapAccounts(accounts);
-
-    expect(visibleChildIds(accountsMap, accountsMap.root)).toEqual(['visible']);
-  });
-
   it('returns reportable child ids', () => {
-    const withReport = [
-      {
-        guid: 'root',
-        name: 'Root',
-        type: 'ROOT',
-        childrenIds: ['visible', 'hidden', 'no-report'],
-      } as Account,
-      accounts[1],
-      accounts[2],
-      {
-        guid: 'no-report',
-        name: 'No report',
-        type: 'INCOME',
-        parentId: 'root',
-        childrenIds: [],
-        report: false,
-      } as Account,
-    ];
-    const accountsMap = mapAccounts(withReport);
+    const accountsMap = mapAccounts(accounts);
 
     expect(reportChildIds(accountsMap, accountsMap.root)).toEqual(['visible', 'hidden']);
   });

--- a/src/components/charts/MonthlyTotalHistogram.tsx
+++ b/src/components/charts/MonthlyTotalHistogram.tsx
@@ -5,20 +5,17 @@ import Bar from '@/components/charts/Bar';
 import type { Account } from '@/book/entities';
 import { useAccounts, useMonthlyTotals, useMainCurrency } from '@/hooks/api';
 import { moneyToString } from '@/helpers/number';
-import visibleAccountGuids from '@/helpers/visibleAccountGuids';
 import { useInterval } from '@/hooks/state';
 import { intervalToDates } from '@/helpers/dates';
 
 export type MonthlyTotalHistogramProps = {
   title?: string,
   guids: string[],
-  includeHiddenGuids?: string[],
 };
 
 export default function MonthlyTotalHistogram({
   title,
   guids = [],
-  includeHiddenGuids = [],
 }: MonthlyTotalHistogramProps): React.JSX.Element {
   const { data: interval } = useInterval();
   const { data: monthlyTotals } = useMonthlyTotals(interval);
@@ -27,15 +24,10 @@ export default function MonthlyTotalHistogram({
   const { data: currency } = useMainCurrency();
   const unit = currency?.mnemonic || '';
 
-  const visibleGuids = React.useMemo(
-    () => visibleAccountGuids(guids, accounts, includeHiddenGuids),
-    [guids, accounts, includeHiddenGuids],
-  );
-
   const datasets: ChartDataset<'bar'>[] = [];
 
   if (accounts && monthlyTotals) {
-    visibleGuids.forEach(guid => {
+    guids.forEach(guid => {
       const data = monthlyTotals.map(m => m[guid]?.toNumber() || 0);
       if (!data.every(v => v === 0)) {
         datasets.push({

--- a/src/components/charts/TotalsPie.tsx
+++ b/src/components/charts/TotalsPie.tsx
@@ -9,7 +9,6 @@ import {
   useMainCurrency,
   usePrices,
 } from '@/hooks/api';
-import visibleAccountGuids from '@/helpers/visibleAccountGuids';
 import { useInterval } from '@/hooks/state';
 import { moneyToString, toFixed } from '@/helpers/number';
 
@@ -36,17 +35,12 @@ export default function TotalsPie({
   const { data: prices } = usePrices({});
   const unit = currency?.mnemonic || '';
 
-  const visibleGuids = React.useMemo(
-    () => visibleAccountGuids(guids, accounts),
-    [guids, accounts],
-  );
-
   const data = React.useMemo(() => {
     if (!accounts || !prices || !currency || !totals) {
       return [];
     }
 
-    return visibleGuids.map(guid => {
+    return guids.map(guid => {
       let total = totals?.[guid] || new Money(0, unit);
       const account = accounts?.find(a => a.guid === guid);
       if (account && currency && account.commodity.guid !== currency?.guid) {
@@ -54,13 +48,13 @@ export default function TotalsPie({
       }
       return total;
     });
-  }, [visibleGuids, currency, totals, unit, accounts, prices, interval.end]);
+  }, [guids, currency, totals, unit, accounts, prices, interval.end]);
 
   const total = data.reduce(
     (t, d) => t.add(d),
     new Money(0, unit),
   );
-  const labels = visibleGuids.map(guid => accounts?.find(a => a.guid === guid)?.name || '');
+  const labels = guids.map(guid => accounts?.find(a => a.guid === guid)?.name || '');
 
   return (
     <>

--- a/src/components/pages/account/IEInfo.tsx
+++ b/src/components/pages/account/IEInfo.tsx
@@ -57,7 +57,6 @@ export default function IEInfo({
           <MonthlyTotalHistogram
             title=""
             guids={account.placeholder ? account.childrenIds : [account.guid]}
-            includeHiddenGuids={account.placeholder ? [] : [account.guid]}
           />
         </div>
         <div className="col-span-12" />

--- a/src/helpers/accountsTotalAggregations.ts
+++ b/src/helpers/accountsTotalAggregations.ts
@@ -5,18 +5,24 @@ import { Account } from '@/book/entities';
 import type { AccountsTotals, AccountsMap } from '@/types/book';
 import type { PriceDBMap } from '@/book/prices';
 import mapAccounts from './mapAccounts';
-import { visibleChildIds } from './visibleAccountGuids';
 
 export type ChildIdsFn = (accounts: AccountsMap, parent: Account) => string[];
 
 export type AggregateChildrenOptions = {
+  /**
+   * Which children to roll into the parent total.
+   * Defaults to all children. Reports pass reportChildIds to skip
+   * accounts with report=false.
+   */
   getChildIds?: ChildIdsFn,
   /**
    * When true, children excluded from the rollup still get their own totals
-   * computed (used for hidden accounts on the dashboard detail pages).
+   * computed. Reports set this to false.
    */
   keepExcludedTotals?: boolean,
 };
+
+const allChildIds: ChildIdsFn = (_accounts, parent) => parent.childrenIds;
 
 /**
  * For some account types like Asset and Liabilities, we want to accumulate monthly
@@ -58,14 +64,8 @@ function aggregateWorth(
     aggregatedTotals[i][guid] = currentMonth.add(previousMonth);
   });
 
-  visibleChildIds(accounts, current).forEach((childId: string) => {
-    aggregateWorth(childId, accounts, monthlyTotals, aggregatedTotals);
-  });
-
   current.childrenIds.forEach((childId: string) => {
-    if (accounts[childId]?.hidden) {
-      aggregateWorth(childId, accounts, monthlyTotals, aggregatedTotals);
-    }
+    aggregateWorth(childId, accounts, monthlyTotals, aggregatedTotals);
   });
 }
 
@@ -85,8 +85,8 @@ export function aggregateChildrenTotals(
   options: AggregateChildrenOptions = {},
 ): AccountsTotals {
   const {
-    getChildIds = visibleChildIds,
-    keepExcludedTotals = true,
+    getChildIds = allChildIds,
+    keepExcludedTotals = false,
   } = options;
   const accountsMap = mapAccounts(accounts);
   const aggregatedTotals: AccountsTotals = {};

--- a/src/helpers/visibleAccountGuids.ts
+++ b/src/helpers/visibleAccountGuids.ts
@@ -1,26 +1,5 @@
 import type { Account } from '@/book/entities';
 import type { AccountsMap } from '@/types/book';
-import mapAccounts from '@/helpers/mapAccounts';
-
-export default function visibleAccountGuids(
-  guids: string[],
-  accounts: Account[] | undefined,
-  includeGuids: string[] = [],
-): string[] {
-  if (!accounts) {
-    return guids;
-  }
-
-  const includeSet = new Set(includeGuids);
-  const accountsMap = mapAccounts(accounts);
-  return guids.filter(
-    guid => includeSet.has(guid) || !accountsMap[guid]?.hidden,
-  );
-}
-
-export function visibleChildIds(accounts: AccountsMap, parent: Account): string[] {
-  return parent.childrenIds.filter(childId => !accounts[childId]?.hidden);
-}
 
 export function reportChildIds(accounts: AccountsMap, parent: Account): string[] {
   return parent.childrenIds.filter(childId => accounts[childId]?.report !== false);


### PR DESCRIPTION
Show hidden accounts in totals aggregations again given their numbers are still relevant. Hidden is meant for accounts that are not used/closed so their values should usually be 0. 

It's confusing to have hidden accounts with totals being non 0 because it doesn't show values accurately